### PR TITLE
feat: add SP metadata url and test link on SAML provider config form

### DIFF
--- a/src/components/SamlProviderConfiguration/index.jsx
+++ b/src/components/SamlProviderConfiguration/index.jsx
@@ -159,7 +159,7 @@ export class SamlProviderConfigurationCore extends React.Component {
 
     const { id, slug, metadata_source } = providerConfig || { id: '', slug: '', metadata_source: '' };
 
-    const learnerPortalUrl = configuration.ENTERPRISE_LEARNER_PORTAL_URL;
+    const learnerPortalUrl = `${configuration.ENTERPRISE_LEARNER_PORTAL_URL}/${this.props.enterpriseSlug}`;
     const testLink = this.props.learnerPortalEnabled === true ? learnerPortalUrl : `${configuration.LMS_BASE_URL}/dashboard?tpa_hint=saml-${slug}`;
     const spMetadataLink = `${configuration.LMS_BASE_URL}/auth/saml/metadata.xml?tpa_hint=saml-${slug}`;
 

--- a/src/components/SamlProviderConfiguration/index.jsx
+++ b/src/components/SamlProviderConfiguration/index.jsx
@@ -159,7 +159,7 @@ export class SamlProviderConfigurationCore extends React.Component {
 
     const { id, slug, metadata_source } = providerConfig || { id: '', slug: '', metadata_source: '' };
 
-    const learnerPortalUrl = `${configuration.ENTERPRISE_LEARNER_PORTAL_URL}/?tpa_hint=saml-${slug}`;
+    const learnerPortalUrl = configuration.ENTERPRISE_LEARNER_PORTAL_URL;
     const testLink = this.props.learnerPortalEnabled === true ? learnerPortalUrl : `${configuration.LMS_BASE_URL}/dashboard?tpa_hint=saml-${slug}`;
     const spMetadataLink = `${configuration.LMS_BASE_URL}/auth/saml/metadata.xml?tpa_hint=saml-${slug}`;
 

--- a/src/components/SamlProviderConfiguration/index.jsx
+++ b/src/components/SamlProviderConfiguration/index.jsx
@@ -15,7 +15,7 @@ import LoadingMessage from '../LoadingMessage';
 import ErrorPage from '../ErrorPage';
 import { configuration } from '../../config';
 
-class SamlProviderConfiguration extends React.Component {
+export class SamlProviderConfigurationCore extends React.Component {
   state = {
     providerConfig: undefined,
     providerData: undefined,
@@ -285,12 +285,12 @@ class SamlProviderConfiguration extends React.Component {
   }
 }
 
-SamlProviderConfiguration.defaultProps = {
+SamlProviderConfigurationCore.defaultProps = {
   enterpriseSlug: null,
   enterpriseName: null,
 };
 
-SamlProviderConfiguration.propTypes = {
+SamlProviderConfigurationCore.propTypes = {
   enterpriseName: PropTypes.string,
   enterpriseSlug: PropTypes.string,
   enterpriseId: PropTypes.string.isRequired,
@@ -301,4 +301,4 @@ const mapStateToProps = state => ({
   learnerPortalEnabled: state.portalConfiguration.enableLearnerPortal,
 });
 
-export default connect(mapStateToProps)(SamlProviderConfiguration);
+export default connect(mapStateToProps)(SamlProviderConfigurationCore);

--- a/src/components/SamlProviderConfiguration/index.jsx
+++ b/src/components/SamlProviderConfiguration/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
@@ -5,12 +6,14 @@ import { Collapsible, Icon } from '@edx/paragon';
 import classNames from 'classnames';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 import { logError } from '@edx/frontend-platform/logging';
+import { connect } from 'react-redux';
 import SamlProviderConfigForm from './SamlProviderConfigForm';
 import SamlProviderDataForm from './SamlProviderDataForm';
 import { snakeCaseFormData } from '../../utils';
 import LmsApiService from '../../data/services/LmsApiService';
 import LoadingMessage from '../LoadingMessage';
 import ErrorPage from '../ErrorPage';
+import { configuration } from '../../config';
 
 class SamlProviderConfiguration extends React.Component {
   state = {
@@ -153,13 +156,20 @@ class SamlProviderConfiguration extends React.Component {
         />
       );
     }
+
+    const { id, slug, metadata_source } = providerConfig || { id: '', slug: '', metadata_source: '' };
+
+    const learnerPortalUrl = `${configuration.ENTERPRISE_LEARNER_PORTAL_URL}/?tpa_hint=saml-${slug}`;
+    const testLink = this.props.learnerPortalEnabled === true ? learnerPortalUrl : `${configuration.LMS_BASE_URL}/dashboard?tpa_hint=saml-${slug}`;
+    const spMetadataLink = `${configuration.LMS_BASE_URL}/auth/saml/metadata.xml?tpa_hint=saml-${slug}`;
+
     return (
       <main role="main">
         <div>
           <>
             {providerConfig && (
               <div
-                key={providerConfig.id}
+                key={id}
                 className="mb-3"
               >
                 <Collapsible
@@ -182,7 +192,15 @@ class SamlProviderConfiguration extends React.Component {
                       </div>
                       <div className="col">
                         <h3 className="h6">Metadata Source:</h3>
-                        <p>{providerConfig.metadata_source}</p>
+                        <p>{metadata_source}</p>
+                      </div>
+                      <div className="col">
+                        <h3 className="h6">SP Metadata</h3>
+                        <p><a target="_blank" rel="noopener noreferrer" href={spMetadataLink}>{spMetadataLink}</a></p>
+                      </div>
+                      <div className="col">
+                        <h3 className="h6">Test link</h3>
+                        <p><a target="_blank" rel="noopener noreferrer" href={testLink}>{testLink}</a></p>
                       </div>
                     </div>
                   )}
@@ -276,6 +294,11 @@ SamlProviderConfiguration.propTypes = {
   enterpriseName: PropTypes.string,
   enterpriseSlug: PropTypes.string,
   enterpriseId: PropTypes.string.isRequired,
+  learnerPortalEnabled: PropTypes.bool.isRequired,
 };
 
-export default SamlProviderConfiguration;
+const mapStateToProps = state => ({
+  learnerPortalEnabled: state.portalConfiguration.enableLearnerPortal,
+});
+
+export default connect(mapStateToProps)(SamlProviderConfiguration);

--- a/src/components/SamlProviderConfiguration/index.test.jsx
+++ b/src/components/SamlProviderConfiguration/index.test.jsx
@@ -1,10 +1,9 @@
+import { mount, shallow } from 'enzyme';
 import React from 'react';
-import { shallow, mount } from 'enzyme';
-
-import SamlProviderConfiguration from './index';
 import LmsApiService from '../../data/services/LmsApiService';
-import { REQUIRED_DATA_FIELDS } from './SamlProviderDataForm';
+import { SamlProviderConfigurationCore } from './index';
 import { REQUIRED_CONFIG_FIELDS } from './SamlProviderConfigForm';
+import { REQUIRED_DATA_FIELDS } from './SamlProviderDataForm';
 
 jest.mock('./../../data/services/LmsApiService');
 
@@ -33,7 +32,7 @@ describe('<SamlProviderConfiguration /> ', () => {
   it('get provider config (with no data)', () => {
     LmsApiService.getProviderConfig.mockResolvedValue(configResponse);
     LmsApiService.getProviderData.mockResolvedValue(invalidDataResponse);
-    const wrapper = mount(<SamlProviderConfiguration enterpriseId="testEnterpriseId" />);
+    const wrapper = mount(<SamlProviderConfigurationCore enterpriseId="testEnterpriseId" learnerPortalEnabled />);
     setImmediate(() => {
       expect(wrapper.state().providerConfig).toEqual(configResponse.data.results[0]);
     });
@@ -42,7 +41,7 @@ describe('<SamlProviderConfiguration /> ', () => {
   it('get provider config and data', () => {
     LmsApiService.getProviderConfig.mockResolvedValue(configResponse);
     LmsApiService.getProviderData.mockResolvedValue(validDataResponse);
-    const wrapper = mount(<SamlProviderConfiguration enterpriseId="testEnterpriseId" />);
+    const wrapper = mount(<SamlProviderConfigurationCore enterpriseId="testEnterpriseId" learnerPortalEnabled />);
     setImmediate(() => {
       expect(wrapper.state().providerConfig).toEqual(configResponse.data.results[0]);
       expect(wrapper.state().providerData).toEqual(validDataResponse.data.results[0]);
@@ -50,7 +49,7 @@ describe('<SamlProviderConfiguration /> ', () => {
   });
 
   it('creating provider config states', () => {
-    const wrapper = shallow(<SamlProviderConfiguration enterpriseId="testEnterpriseId" />);
+    const wrapper = mount(<SamlProviderConfigurationCore enterpriseId="testEnterpriseId" learnerPortalEnabled />);
 
     LmsApiService.postNewProviderConfig.mockResolvedValue(configResponse);
     wrapper.instance().createProviderConfig(formData, () => {
@@ -59,7 +58,7 @@ describe('<SamlProviderConfiguration /> ', () => {
   });
 
   it('updating provider config states', () => {
-    const wrapper = shallow(<SamlProviderConfiguration enterpriseId="testEnterpriseId" />);
+    const wrapper = mount(<SamlProviderConfigurationCore enterpriseId="testEnterpriseId" learnerPortalEnabled />);
     wrapper.setState({ providerConfig: oldConfig });
 
     LmsApiService.updateProviderConfig.mockResolvedValue(configResponse);
@@ -69,7 +68,7 @@ describe('<SamlProviderConfiguration /> ', () => {
   });
 
   it('deleting provider config resets states', () => {
-    const wrapper = shallow(<SamlProviderConfiguration enterpriseId="testEnterpriseId" />);
+    const wrapper = mount(<SamlProviderConfigurationCore enterpriseId="testEnterpriseId" learnerPortalEnabled />);
     wrapper.setState({ providerConfig: oldConfig });
 
     LmsApiService.deleteProviderConfig.mockResolvedValue({});
@@ -79,7 +78,7 @@ describe('<SamlProviderConfiguration /> ', () => {
   });
 
   it('handling response errors', () => {
-    const wrapper = shallow(<SamlProviderConfiguration enterpriseId="testEnterpriseId" />);
+    const wrapper = shallow(<SamlProviderConfigurationCore enterpriseId="testEnterpriseId" learnerPortalEnabled />);
 
     const errorMessage = 'test error message.';
     LmsApiService.updateProviderConfig.mockImplementation(() => {


### PR DESCRIPTION
ENT-4286

Once SAML Provider Config is saved: shows the two urls: SP Metadata url (including tpa_hint), and Test link ( either the learner portal url or the dashboard, with tpa_hint)

I did not invest in adding tests other than manual test because we are going to rewrite the UIs in short order.

I also did not invest in CSS and layout for the new links added since this will change/be redone soon

## With learner portal disabled
<img width="1423" alt="Screen Shot 2022-01-11 at 2 22 44 PM" src="https://user-images.githubusercontent.com/528166/149008211-6fd326b1-2437-4c52-be0e-a4a26204c8e6.png">



## With learner portal enabled
<img width="711" alt="Screen Shot 2022-01-13 at 10 29 18 AM" src="https://user-images.githubusercontent.com/528166/149359326-46187727-f3ea-4080-be8e-13c55f7e3914.png">


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
