### PR TITLE
fix: add isLoading prop to DataTable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1655,9 +1655,9 @@
       }
     },
     "@edx/paragon": {
-      "version": "17.3.2",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-17.3.2.tgz",
-      "integrity": "sha512-QcK8LrbAxGEF+mPoDur2mYW3M87CUrIHHfTqfOUsUCQGH4ZRfmMkBkcsV3C+0x+UHnrWLV2v6eo6XGwUYsMplA==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-17.5.0.tgz",
+      "integrity": "sha512-sA4I2JB2RZ8c1tg9251/LFCrbI6+GI5J4Qf6ElQy4PHxR5EvR3pkI9Nu0CP9zSa2oO+aHRoTs9TDFuiDKVWH+g==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.30",
         "@fortawesome/free-solid-svg-icons": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@edx/frontend-enterprise-logistration": "0.1.11",
     "@edx/frontend-enterprise-utils": "1.1.1",
     "@edx/frontend-platform": "1.11.0",
-    "@edx/paragon": "17.3.2",
+    "@edx/paragon": "17.5.0",
     "@fortawesome/fontawesome-svg-core": "1.2.35",
     "@fortawesome/free-brands-svg-icons": "5.15.3",
     "@fortawesome/free-regular-svg-icons": "5.15.3",

--- a/src/components/settings/SettingsAccessTab/SettingsAccessLinkManagement.jsx
+++ b/src/components/settings/SettingsAccessTab/SettingsAccessLinkManagement.jsx
@@ -69,8 +69,8 @@ const SettingsAccessLinkManagement = ({ enterpriseUUID }) => {
         <DataTable
           data={links}
           itemCount={links.length}
-          // eslint-disable-next-line no-unused-vars
-          tableActions={(i) => (
+          isLoading={loadingLinks}
+          tableActions={() => (
             <SettingsAccessGenerateLinkButton
               onSuccess={handleGenerateLinkSuccess}
               disabled={!isLinkManagementEnabled}
@@ -108,7 +108,7 @@ const SettingsAccessLinkManagement = ({ enterpriseUUID }) => {
         >
           <DataTable.TableControlBar />
           <DataTable.Table />
-          <DataTable.EmptyTable content={loadingLinks ? 'Loading...' : 'No links found'} />
+          {!loadingLinks && <DataTable.EmptyTable content="No links found" />}
         </DataTable>
       </SettingsAccessTabSection>
       <DisableLinkManagementAlertModal

--- a/src/components/settings/SettingsAccessTab/tests/DateCreatedTableCell.test.jsx
+++ b/src/components/settings/SettingsAccessTab/tests/DateCreatedTableCell.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import DateCreatedTableCell from '../DateCreatedTableCell';
+
+describe('DateCreatedTableCell', () => {
+  it('renders correctly', () => {
+    const props = {
+      row: {
+        original: {
+          created: '2022-01-10T12:00:00Z',
+        },
+      },
+    };
+    const tree = renderer
+      .create(<DateCreatedTableCell {...props} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/settings/SettingsAccessTab/tests/LinkTableCell.test.jsx
+++ b/src/components/settings/SettingsAccessTab/tests/LinkTableCell.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import LinkTableCell from '../LinkTableCell';
+
+jest.mock('@edx/frontend-platform/config', () => ({
+  getConfig: () => ({ ENTERPRISE_LEARNER_PORTAL_URL: 'http://localhost:8734' }),
+}));
+
+describe('LinkTableCell', () => {
+  it('renders correctly', () => {
+    const props = {
+      row: {
+        original: {
+          uuid: 'test-invite-key-uuid',
+        },
+      },
+    };
+    const tree = renderer
+      .create(<LinkTableCell {...props} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/settings/SettingsAccessTab/tests/StatusTableCell.test.jsx
+++ b/src/components/settings/SettingsAccessTab/tests/StatusTableCell.test.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import StatusTableCell from '../StatusTableCell';
+
+describe('StatusTableCell', () => {
+  it('renders valid status correctly', () => {
+    const props = {
+      row: {
+        original: {
+          isValid: true,
+        },
+      },
+    };
+    const tree = renderer
+      .create(<StatusTableCell {...props} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders invalid status correctly', () => {
+    const props = {
+      row: {
+        original: {
+          isValid: false,
+        },
+      },
+    };
+    const tree = renderer
+      .create(<StatusTableCell {...props} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/settings/SettingsAccessTab/tests/UsageTableCell.test.jsx
+++ b/src/components/settings/SettingsAccessTab/tests/UsageTableCell.test.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import UsageTableCell from '../UsageTableCell';
+
+describe('UsageTableCell', () => {
+  it('renders correctly', () => {
+    const props = {
+      row: {
+        original: {
+          usageCount: 10,
+          usageLimit: 100,
+        },
+      },
+    };
+    const tree = renderer
+      .create(<UsageTableCell {...props} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/settings/SettingsAccessTab/tests/__snapshots__/DateCreatedTableCell.test.jsx.snap
+++ b/src/components/settings/SettingsAccessTab/tests/__snapshots__/DateCreatedTableCell.test.jsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DateCreatedTableCell renders correctly 1`] = `"January 10, 2022"`;

--- a/src/components/settings/SettingsAccessTab/tests/__snapshots__/LinkTableCell.test.jsx.snap
+++ b/src/components/settings/SettingsAccessTab/tests/__snapshots__/LinkTableCell.test.jsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LinkTableCell renders correctly 1`] = `"http://localhost:8734/invite/test-invite-key-uuid"`;

--- a/src/components/settings/SettingsAccessTab/tests/__snapshots__/StatusTableCell.test.jsx.snap
+++ b/src/components/settings/SettingsAccessTab/tests/__snapshots__/StatusTableCell.test.jsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StatusTableCell renders invalid status correctly 1`] = `
+<span
+  className="badge badge-light"
+>
+  Inactive
+</span>
+`;
+
+exports[`StatusTableCell renders valid status correctly 1`] = `
+<span
+  className="badge badge-success"
+>
+  Active
+</span>
+`;

--- a/src/components/settings/SettingsAccessTab/tests/__snapshots__/UsageTableCell.test.jsx.snap
+++ b/src/components/settings/SettingsAccessTab/tests/__snapshots__/UsageTableCell.test.jsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UsageTableCell renders correctly 1`] = `"10 of 100"`;

--- a/src/components/subscriptions/licenses/LicenseManagementTable/index.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/index.jsx
@@ -188,6 +188,7 @@ const LicenseManagementTable = () => {
       {showSubscriptionZeroStateMessage && <SubscriptionZeroStateMessage /> }
       <DataTable
         showFiltersInSidebar={showFiltersInSidebar}
+        isLoading={loadingUsers}
         isFilterable
         manualFilters
         isSelectable={!isExpired}
@@ -212,7 +213,12 @@ const LicenseManagementTable = () => {
           getRowId: row => row.id,
         }}
         EmptyTableComponent={
-          () => <DataTable.EmptyTable content={loadingUsers ? 'Loading...' : 'No results found'} />
+          () => {
+            if (loadingUsers) {
+              return null;
+            }
+            return <DataTable.EmptyTable content="No results found" />;
+          }
         }
         fetchData={fetchData}
         data={rows}

--- a/src/components/subscriptions/licenses/LicenseManagementTable/tests/index.test.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/tests/index.test.jsx
@@ -83,17 +83,27 @@ describe('<LicenseManagementTable />', () => {
     jest.clearAllMocks();
   });
 
+  describe('loading', () => {
+    it('renders initially loading state', () => {
+      const subscriptionPlan = generateSubscriptionPlan();
+      mockSubscriptionHooks(subscriptionPlan, [], true);
+      render(tableWithContext({
+        subscriptionPlan,
+      }));
+      // assert that the spinner is shown (`isLoading` is properly passed to `DataTable`)
+      expect(screen.getByRole('status'));
+    });
+  });
+
   describe('zero state (no subscription users)', () => {
     it('renders zero state message', () => {
       const subscriptionPlan = generateSubscriptionPlan();
-      mockSubscriptionHooks({
-        subscriptionPlan,
-        subscriptionUsers: [],
-      });
+      mockSubscriptionHooks(subscriptionPlan, []);
       render(tableWithContext({
         subscriptionPlan,
       }));
       expect(screen.getByText('Get Started'));
+      expect(screen.getByText('No results found'));
     });
   });
 
@@ -106,9 +116,9 @@ describe('<LicenseManagementTable />', () => {
         },
       });
       beforeEach(() => {
-        mockSubscriptionHooks({
+        mockSubscriptionHooks(
           subscriptionPlan,
-          subscriptionUsers: [{
+          [{
             activationDate: moment(),
             activationKey: 'test-activation-key',
             lastRemindDate: moment(),
@@ -118,7 +128,7 @@ describe('<LicenseManagementTable />', () => {
             userEmail: 'edx@example.com',
             uuid: 'test-uuid',
           }],
-        });
+        );
         expect(screen.queryByText('Get Started')).toBeFalsy();
       });
 
@@ -168,10 +178,7 @@ describe('<LicenseManagementTable />', () => {
       jest.clearAllMocks();
     });
     beforeEach(() => {
-      mockSubscriptionHooks({
-        subscriptionPlan,
-        subscriptionUsers: users,
-      });
+      mockSubscriptionHooks(subscriptionPlan, users);
     });
     it('when clicking status filters', async () => {
       render(tableWithContext({

--- a/src/components/subscriptions/tests/TestUtilities.jsx
+++ b/src/components/subscriptions/tests/TestUtilities.jsx
@@ -275,7 +275,11 @@ export const generateSubscriptionUser = ({
  * @param {function} forceRefresh override force refresh function
  * @returns subscription data hook output
  */
-const generateUseSubscriptionData = (subscriptionPlan, forceRefresh = () => {}) => ({
+const generateUseSubscriptionData = (
+  subscriptionPlan,
+  forceRefresh = () => {},
+  isLoading = false,
+) => ({
   subscriptions: {
     count: 1,
     next: null,
@@ -285,7 +289,7 @@ const generateUseSubscriptionData = (subscriptionPlan, forceRefresh = () => {}) 
   errors: {},
   setErrors: () => {},
   forceRefresh,
-  loading: false,
+  loading: isLoading,
 });
 
 /**
@@ -320,16 +324,17 @@ const generateUseSubscriptionUsersData = (subscriptionUsers) => ({
 export const mockSubscriptionHooks = (
   subscriptionPlan,
   subscriptionUsers = [],
+  isLoading = false,
 ) => {
   const forceRefreshSubscription = jest.fn();
   const forceRefreshUsers = jest.fn();
   const forceRefreshUsersOverview = jest.fn();
 
   jest.spyOn(hooks, 'useSubscriptionData').mockImplementation(
-    () => generateUseSubscriptionData(subscriptionPlan, forceRefreshSubscription),
+    () => generateUseSubscriptionData(subscriptionPlan, forceRefreshSubscription, isLoading),
   );
   jest.spyOn(hooks, 'useSubscriptionUsers').mockImplementation(
-    () => [generateUseSubscriptionUsersData(subscriptionUsers), forceRefreshUsers],
+    () => [generateUseSubscriptionUsersData(subscriptionUsers), forceRefreshUsers, isLoading],
   );
   jest.spyOn(hooks, 'useSubscriptionUsersOverview').mockImplementation(
     () => [generateUseSubscriptionUsersOverviewData(), forceRefreshUsersOverview],


### PR DESCRIPTION
Upgrades Paragon to 17.5.0 and adds `isLoading` prop to `DataTable` for universal link loading and subscription management detail page loading.

![image](https://user-images.githubusercontent.com/2828721/149340926-15686068-1e20-4c16-b75d-6f38094a8e84.png)

![image](https://user-images.githubusercontent.com/2828721/149340954-f893cd7d-3b54-4acb-a8cb-7506ebb4f1d1.png)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
