### PR TITLE
fix: don't need saml- prefix for metadata url

### DIFF
--- a/src/components/SamlProviderConfiguration/index.jsx
+++ b/src/components/SamlProviderConfiguration/index.jsx
@@ -161,7 +161,7 @@ export class SamlProviderConfigurationCore extends React.Component {
 
     const learnerPortalUrl = `${configuration.ENTERPRISE_LEARNER_PORTAL_URL}/${this.props.enterpriseSlug}`;
     const testLink = this.props.learnerPortalEnabled === true ? learnerPortalUrl : `${configuration.LMS_BASE_URL}/dashboard?tpa_hint=saml-${slug}`;
-    const spMetadataLink = `${configuration.LMS_BASE_URL}/auth/saml/metadata.xml?tpa_hint=saml-${slug}`;
+    const spMetadataLink = `${configuration.LMS_BASE_URL}/auth/saml/metadata.xml?tpa_hint=${slug}`;
 
     return (
       <main role="main">

--- a/src/components/SamlProviderConfiguration/index.jsx
+++ b/src/components/SamlProviderConfiguration/index.jsx
@@ -14,6 +14,7 @@ import LmsApiService from '../../data/services/LmsApiService';
 import LoadingMessage from '../LoadingMessage';
 import ErrorPage from '../ErrorPage';
 import { configuration } from '../../config';
+import { createSAMLURLs } from './utils';
 
 export class SamlProviderConfigurationCore extends React.Component {
   state = {
@@ -157,11 +158,15 @@ export class SamlProviderConfigurationCore extends React.Component {
       );
     }
 
-    const { id, slug, metadata_source } = providerConfig || { id: '', slug: '', metadata_source: '' };
+    const { id, slug: idpSlug, metadata_source } = providerConfig || { id: '', slug: '', metadata_source: '' };
 
-    const learnerPortalUrl = `${configuration.ENTERPRISE_LEARNER_PORTAL_URL}/${this.props.enterpriseSlug}`;
-    const testLink = this.props.learnerPortalEnabled === true ? learnerPortalUrl : `${configuration.LMS_BASE_URL}/dashboard?tpa_hint=saml-${slug}`;
-    const spMetadataLink = `${configuration.LMS_BASE_URL}/auth/saml/metadata.xml?tpa_hint=${slug}`;
+    const { learnerPortalEnabled, enterpriseSlug } = this.props;
+    const { testLink, spMetadataLink } = createSAMLURLs({
+      configuration,
+      idpSlug,
+      enterpriseSlug,
+      learnerPortalEnabled,
+    });
 
     return (
       <main role="main">

--- a/src/components/SamlProviderConfiguration/utils.js
+++ b/src/components/SamlProviderConfiguration/utils.js
@@ -1,0 +1,11 @@
+/* eslint-disable import/prefer-default-export */
+function createSAMLURLs({
+  configuration, idpSlug, enterpriseSlug, learnerPortalEnabled,
+}) {
+  const learnerPortalUrl = `${configuration.ENTERPRISE_LEARNER_PORTAL_URL}/${enterpriseSlug}`;
+  const testLink = learnerPortalEnabled === true ? learnerPortalUrl : `${configuration.LMS_BASE_URL}/dashboard?tpa_hint=saml-${idpSlug}`;
+  const spMetadataLink = `${configuration.LMS_BASE_URL}/auth/saml/metadata.xml?tpa_hint=${idpSlug}`;
+  return { testLink, spMetadataLink };
+}
+
+export { createSAMLURLs };

--- a/src/components/SamlProviderConfiguration/utils.test.js
+++ b/src/components/SamlProviderConfiguration/utils.test.js
@@ -1,0 +1,30 @@
+import { createSAMLURLs } from './utils';
+
+describe('tests for utils', () => {
+  test('generates correct urls for SAML with learner portal enabled', () => {
+    const configuration = { ENTERPRISE_LEARNER_PORTAL_URL: 'http://base', LMS_BASE_URL: 'http://baselms' };
+    const idpSlug = 'test-slug';
+    const enterpriseSlug = 'enterprise-slug';
+    const { testLink, spMetadataLink } = createSAMLURLs({
+      configuration,
+      idpSlug,
+      enterpriseSlug,
+      learnerPortalEnabled: true,
+    });
+    expect(testLink).toBe('http://base/enterprise-slug');
+    expect(spMetadataLink).toBe('http://baselms/auth/saml/metadata.xml?tpa_hint=test-slug');
+  });
+  test('generates correct urls for SAML with learner portal off', () => {
+    const configuration = { ENTERPRISE_LEARNER_PORTAL_URL: 'http://base', LMS_BASE_URL: 'http://baselms' };
+    const idpSlug = 'test-slug';
+    const enterpriseSlug = 'enterprise-slug';
+    const { testLink, spMetadataLink } = createSAMLURLs({
+      configuration,
+      idpSlug,
+      enterpriseSlug,
+      learnerPortalEnabled: false,
+    });
+    expect(testLink).toBe('http://baselms/dashboard?tpa_hint=saml-test-slug');
+    expect(spMetadataLink).toBe('http://baselms/auth/saml/metadata.xml?tpa_hint=test-slug');
+  });
+});


### PR DESCRIPTION
When forming metadata url, the tpa_hint parameter need not contain the saml- prefix, unlike what we do for the SSO link like test link.

This is because [the backend](https://github.com/openedx/edx-platform/blob/db32ff2cdf678fa8edd12c9da76a76eef0478614/common/djangoapps/third_party_auth/views.py#L60) simply use tpa_hint as the saml idp slug, and does not expect a saml- prefix.

## Testing notes

Added automated test for util function that generates the urls: which is used as such

```
const { testLink, spMetadataLink } = createSAMLURLs({
      configuration,
      idpSlug,
      enterpriseSlug,
      learnerPortalEnabled,
    });
```

After this change, verified in admin portal the metadata url works
<img width="1915" alt="Screen Shot 2022-01-19 at 12 22 24 PM" src="https://user-images.githubusercontent.com/528166/150181991-59301d4d-165c-44e6-a41d-1e5c27ed4814.png">

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
