### PR TITLE
ci: add nvmrc detection/use to github workflow ENT-4178

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,12 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+    - name: Setup Nodejs Env
+      run: echo "NODE_VER=`cat .nvmrc`" >> $GITHUB_ENV
     - name: Setup Nodejs
-      uses: actions/setup-node@v1
+      uses: dcodeIO/setup-node-nvm@v4
       with:
-        node-version: 12
+        node-version: "${{ env.NODE_VER }}"
     - name: Validate no uncommitted package-lock changes
       run: make validate-no-uncommitted-package-lock-changes
     - name: Install dependencies


### PR DESCRIPTION
This allows github workflow to honor the nvmrc when choosing node/npm versions

if .nvmrc has `12` for example, it basically runs `nvm use` and fetches the correct (latest minor release of) nodejs and npm version running the rest of the github action workflow

To verify, check the 'checks' screen for this PR it will show

```
Computing checksum with sha256sum
Checksums matched!
Now using node v12.22.9 (npm v6.14.15)
Creating default alias: default -> 12.22.9 (-> v12.22.9 *)
```

or similar

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
