### PR TITLE
fix: add logic to not display reset filter on ordering

### DIFF
--- a/src/components/Admin/Admin.test.jsx
+++ b/src/components/Admin/Admin.test.jsx
@@ -426,6 +426,17 @@ describe('<Admin />', () => {
       ));
       expect(wrapper.text()).not.toContain('Reset Filters');
     });
+    it('should not be present if query is null', () => {
+      const wrapper = mount((
+        <AdminWrapper
+          {...baseProps}
+          location={
+            { search: null }
+          }
+        />
+      ));
+      expect(wrapper.text()).not.toContain('Reset Filters');
+    });
     it('should be present if there is a querystring', () => {
       const path = '/lael/';
       const wrapper = mount((

--- a/src/components/Admin/Admin.test.jsx
+++ b/src/components/Admin/Admin.test.jsx
@@ -415,6 +415,17 @@ describe('<Admin />', () => {
       ));
       expect(wrapper.text()).not.toContain('Reset Filters');
     });
+    it('should not be present if only query is ordering', () => {
+      const wrapper = mount((
+        <AdminWrapper
+          {...baseProps}
+          location={
+            { search: 'ordering=xyz' }
+          }
+        />
+      ));
+      expect(wrapper.text()).not.toContain('Reset Filters');
+    });
     it('should be present if there is a querystring', () => {
       const path = '/lael/';
       const wrapper = mount((
@@ -428,6 +439,21 @@ describe('<Admin />', () => {
       expect(wrapper.text()).toContain('Reset Filters');
       const link = wrapper.find(Link).find('#reset-filters');
       expect(link.first().props().to).toEqual(path);
+    });
+    it('should be present if there is a querystring mixed with ordering', () => {
+      const path = '/lael/';
+      const nonSearchQuery = 'ordering=xyz';
+      const wrapper = mount((
+        <AdminWrapper
+          {...baseProps}
+          location={
+            { search: `search=foo&${nonSearchQuery}`, pathname: path }
+          }
+        />
+      ));
+      expect(wrapper.text()).toContain('Reset Filters');
+      const link = wrapper.find(Link).find('#reset-filters');
+      expect(link.first().props().to).toEqual(`${path}?${nonSearchQuery}`);
     });
     it('should not disturb non-search-releated queries', () => {
       const path = '/lael/';

--- a/src/components/Admin/index.jsx
+++ b/src/components/Admin/index.jsx
@@ -281,11 +281,12 @@ class Admin extends React.Component {
 
     const { params: { actionSlug } } = match;
 
-    const params = Object.keys(qs.parse(search));
-    const filtersActive = params.length !== 0 && !(params.length === 1 && params[0] === 'ordering');
+    const queryParams = new URLSearchParams(search);
+    const queryParamsLength = Array.from(queryParams.entries()).length;
+    const filtersActive = queryParamsLength !== 0 && !(queryParamsLength === 1 && queryParams.has('ordering'));
     const tableMetadata = this.getMetadataForAction(actionSlug);
     const csvErrorMessage = this.getCsvErrorMessage(tableMetadata.csvButtonId);
-    const queryParams = new URLSearchParams(search);
+
     const searchParams = {
       searchQuery: queryParams.get('search') || '',
       searchCourseQuery: queryParams.get('search_course') || '',

--- a/src/components/Admin/index.jsx
+++ b/src/components/Admin/index.jsx
@@ -281,7 +281,7 @@ class Admin extends React.Component {
 
     const { params: { actionSlug } } = match;
 
-    const queryParams = new URLSearchParams(search);
+    const queryParams = new URLSearchParams(search || '');
     const queryParamsLength = Array.from(queryParams.entries()).length;
     const filtersActive = queryParamsLength !== 0 && !(queryParamsLength === 1 && queryParams.has('ordering'));
     const tableMetadata = this.getMetadataForAction(actionSlug);

--- a/src/components/Admin/index.jsx
+++ b/src/components/Admin/index.jsx
@@ -280,7 +280,9 @@ class Admin extends React.Component {
     } = this.props;
 
     const { params: { actionSlug } } = match;
-    const filtersActive = search;
+
+    const params = Object.keys(qs.parse(search));
+    const filtersActive = params.length !== 0 && !(params.length === 1 && params[0] === 'ordering');
     const tableMetadata = this.getMetadataForAction(actionSlug);
     const csvErrorMessage = this.getCsvErrorMessage(tableMetadata.csvButtonId);
     const queryParams = new URLSearchParams(search);

--- a/src/components/settings/index.jsx
+++ b/src/components/settings/index.jsx
@@ -14,6 +14,7 @@ import {
   SETTINGS_PARAM_MATCH,
 } from './data/constants';
 import SettingsTabs from './SettingsTabs';
+// eslint-disable-next-line import/no-named-as-default
 import SettingsContext from './SettingsContext';
 
 const PAGE_TILE = 'Settings';


### PR DESCRIPTION
# For all changes

https://user-images.githubusercontent.com/49611774/152346357-3a4674b5-07c7-4bb9-8cb0-dc9ab7aaa8c9.mov


- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [x] Ensure to have UX team confirm screenshots
