### PR TITLE
FEAT: LMS config page now displays existing configs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5890,7 +5890,7 @@
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-transform-imports": {
@@ -6360,7 +6360,7 @@
         },
         "p-cancelable": {
           "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+          "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
           "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
           "dev": true,
           "optional": true
@@ -7574,7 +7574,7 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },
@@ -8041,14 +8041,14 @@
       "dependencies": {
         "file-type": {
           "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
           "dev": true,
           "optional": true
         },
         "get-stream": {
           "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "optional": true,
@@ -9095,7 +9095,7 @@
         },
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -9840,7 +9840,7 @@
     },
     "file-saver": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-1.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/file-saver/-/file-saver-1.3.8.tgz",
       "integrity": "sha512-spKHSBQIxxS81N/O21WmuXA2F6wppUCsutpzenOeZzOCCJ5gEfcbqJP983IrpLXzYmXnMUa6J03SubcNPdKrlg=="
     },
     "file-type": {
@@ -10619,7 +10619,7 @@
     },
     "globby": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
@@ -11858,7 +11858,7 @@
     },
     "into-stream": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "dev": true,
       "optional": true,
@@ -11889,7 +11889,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
@@ -12023,7 +12023,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
@@ -13991,7 +13991,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -14931,13 +14931,13 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -15001,7 +15001,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true,
       "optional": true
@@ -15165,7 +15165,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -17604,7 +17604,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -18668,7 +18668,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -18868,7 +18868,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -19329,7 +19329,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/src/components/SubsidyRequestManagementTable/tests/__snapshots__/SubsidyRequestManagementTable.test.jsx.snap
+++ b/src/components/SubsidyRequestManagementTable/tests/__snapshots__/SubsidyRequestManagementTable.test.jsx.snap
@@ -23,7 +23,7 @@ exports[`SubsidyRequestManagementTable renders data in a table as expected 1`] =
               className="pgn__data-table-filters"
             >
               <div
-                className="mr-2"
+                className="pgn__data-table-filters-breakout-filter"
               >
                 <div
                   className="pgn__form-group"
@@ -65,9 +65,6 @@ exports[`SubsidyRequestManagementTable renders data in a table as expected 1`] =
           <div
             className="pgn__data-table-actions-right"
           >
-            <div
-              className="pgn__data-table-toggle"
-            />
             <div />
           </div>
         </div>
@@ -87,6 +84,9 @@ exports[`SubsidyRequestManagementTable renders data in a table as expected 1`] =
               .
             </div>
           </div>
+          <div
+            className="pgn__data-table-toggle"
+          />
         </div>
       </div>
       <div
@@ -364,75 +364,97 @@ exports[`SubsidyRequestManagementTable renders data in a table as expected 1`] =
           3
           .
         </div>
-        <div
-          className="btn-group btn-group-md"
-          role="group"
+        <nav
+          aria-label="table pagination"
+          className="pagination-minimal"
         >
-          <button
-            aria-label="Previous page"
-            className="btn-icon btn-icon-primary btn-icon-md"
-            disabled={true}
-            onClick={[Function]}
-            type="button"
+          <div
+            aria-atomic={true}
+            aria-live="polite"
+            aria-relevant="text"
+            className="sr-only"
           >
-            <span
-              className="btn-icon__icon-container"
-            >
-              <span
-                className="pgn__icon btn-icon__icon"
-                icon={Object {}}
-              >
-                <svg
-                  aria-hidden={true}
-                  fill="none"
-                  focusable={false}
-                  height={24}
-                  role="img"
-                  viewBox="0 0 24 24"
-                  width={24}
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M17.51 3.87L15.73 2.1 5.84 12l9.9 9.9 1.77-1.77L9.38 12l8.13-8.13z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </span>
-            </span>
-          </button>
-          <button
-            aria-label="Next page"
-            className="btn-icon btn-icon-primary btn-icon-md"
-            disabled={true}
-            onClick={[Function]}
-            type="button"
+            Page 1, Current Page, of 1
+          </div>
+          <ul
+            className="pagination"
           >
-            <span
-              className="btn-icon__icon-container"
+            <li
+              className="page-item disabled"
             >
-              <span
-                className="pgn__icon btn-icon__icon"
-                icon={Object {}}
+              <button
+                aria-label="Go to previous page"
+                className="btn-icon btn-icon-primary btn-icon-md previous page-link"
+                disabled={true}
+                onClick={[Function]}
+                tabIndex="-1"
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  fill="none"
-                  focusable={false}
-                  height={24}
-                  role="img"
-                  viewBox="0 0 24 24"
-                  width={24}
-                  xmlns="http://www.w3.org/2000/svg"
+                <span
+                  className="btn-icon__icon-container"
                 >
-                  <path
-                    d="M6.49 20.13l1.77 1.77 9.9-9.9-9.9-9.9-1.77 1.77L14.62 12l-8.13 8.13z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </span>
-            </span>
-          </button>
-        </div>
+                  <span
+                    className="pgn__icon btn-icon__icon"
+                    icon={Object {}}
+                  >
+                    <svg
+                      aria-hidden={true}
+                      fill="none"
+                      focusable={false}
+                      height={24}
+                      role="img"
+                      viewBox="0 0 24 24"
+                      width={24}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M17.51 3.87L15.73 2.1 5.84 12l9.9 9.9 1.77-1.77L9.38 12l8.13-8.13z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </button>
+            </li>
+            <li
+              className="page-item disabled"
+            >
+              <button
+                aria-label="Go to next page"
+                className="btn-icon btn-icon-primary btn-icon-md next page-link"
+                disabled={true}
+                onClick={[Function]}
+                tabIndex="-1"
+                type="button"
+              >
+                <span
+                  className="btn-icon__icon-container"
+                >
+                  <span
+                    className="pgn__icon btn-icon__icon"
+                    icon={Object {}}
+                  >
+                    <svg
+                      aria-hidden={true}
+                      fill="none"
+                      focusable={false}
+                      height={24}
+                      role="img"
+                      viewBox="0 0 24 24"
+                      width={24}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M6.49 20.13l1.77 1.77 9.9-9.9-9.9-9.9-1.77 1.77L14.62 12l-8.13 8.13z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </button>
+            </li>
+          </ul>
+        </nav>
       </div>
     </div>
   </div>

--- a/src/components/settings/SettingsLMSTab/ConfigError.jsx
+++ b/src/components/settings/SettingsLMSTab/ConfigError.jsx
@@ -9,7 +9,11 @@ const cardText400 = 'We were unable to process your request to submit a new LMS 
 const cardText500 = 'We were unable to process your request to submit a new LMS configuration. Please try submitting again later or contact support for help.';
 
 const ConfigError = ({
-  isOpen, close, submit, code,
+  isOpen,
+  close,
+  submit,
+  code,
+  configTextOverride,
 }) => (
   <AlertModal
     title="Something went wrong"
@@ -23,12 +27,17 @@ const ConfigError = ({
       </ActionRow>
     )}
   >
-    {code >= 500 && (
+    {configTextOverride && (
+      <p>
+        {configTextOverride}
+      </p>
+    )}
+    {!configTextOverride && code >= 500 && (
     <p>
       {cardText500}
     </p>
     )}
-    {code <= 499 && (
+    {!configTextOverride && code <= 499 && (
     <p>
       {cardText400}
     </p>
@@ -38,6 +47,7 @@ const ConfigError = ({
 
 ConfigError.defaultProps = {
   code: 400,
+  configTextOverride: '',
 };
 
 ConfigError.propTypes = {
@@ -45,5 +55,6 @@ ConfigError.propTypes = {
   close: PropTypes.func.isRequired,
   submit: PropTypes.func.isRequired,
   code: PropTypes.number,
+  configTextOverride: PropTypes.string,
 };
 export default ConfigError;

--- a/src/components/settings/SettingsLMSTab/ExistingLMSCardDeck.jsx
+++ b/src/components/settings/SettingsLMSTab/ExistingLMSCardDeck.jsx
@@ -1,0 +1,196 @@
+import React, { useState } from 'react';
+import isEmpty from 'lodash/isEmpty';
+import PropTypes from 'prop-types';
+import {
+  Badge, Card, CardGrid, Dropdown, Icon, IconButton, Image, useToggle,
+} from '@edx/paragon';
+import {
+  Delete, Edit, MoreVert, PlayCircleFilled, RemoveCircle,
+} from '@edx/paragon/icons';
+import { channelMapping } from '../../../utils';
+import { handleErrors } from './utils';
+import { TOGGLE_SUCCESS_LABEL, DELETE_SUCCESS_LABEL } from '../data/constants';
+import ConfigError from './ConfigError';
+
+const errorToggleModalText = 'We were unable to toggle your config. Please try submitting again later or contact support for help.';
+const errorDeleteModalText = 'We were unable to delete your config. Please try removing again later or contact support for help.';
+const TOGGLE_ACTION = 'toggle';
+const DELETE_ACTION = 'delete';
+
+const ExistingLMSCardDeck = ({
+  configData,
+  editExistingConfig,
+  enterpriseCustomerUuid,
+  onClick,
+}) => {
+  const [errorIsOpen, openError, closeError] = useToggle(false);
+  const [erroredConfig, setErroredConfig] = useState();
+  const [errorCardActionType, setErrorCardActionType] = useState();
+  const [errorModalText, setErrorModalText] = useState();
+
+  const toggleConfig = async (id, channelType, toggle) => {
+    const configOptions = {
+      active: toggle,
+      enterprise_customer: enterpriseCustomerUuid,
+    };
+    let err;
+    try {
+      await channelMapping[channelType].update(configOptions, id);
+    } catch (error) {
+      err = handleErrors(error);
+    }
+    if (err) {
+      setErrorModalText(errorToggleModalText);
+      openError();
+      setErroredConfig({ id, channelType, toggle });
+      setErrorCardActionType(TOGGLE_ACTION);
+    } else {
+      onClick(TOGGLE_SUCCESS_LABEL);
+    }
+  };
+
+  const deleteConfig = async (id, channelType) => {
+    let err;
+    try {
+      await channelMapping[channelType].delete(id);
+    } catch (error) {
+      err = handleErrors(error);
+    }
+    if (err) {
+      setErrorModalText(errorDeleteModalText);
+      openError();
+      setErroredConfig({ id, channelType });
+      setErrorCardActionType(DELETE_ACTION);
+    } else {
+      onClick(DELETE_SUCCESS_LABEL);
+    }
+  };
+
+  // Map the existing config data to individual cards
+  const listItems = configData.map((config) => (
+    <Card isClickable tabIndex="0" className="p-2.5 existing-lms-card-width" key={config.channelCode + config.id}>
+      <Card.Header
+        className="lms-card-content"
+        actions={(
+          <Dropdown>
+            <Dropdown.Toggle
+              id="dropdown-toggle-with-iconbutton"
+              data-testid={`existing-lms-config-card-dropdown-${config.id}`}
+              as={IconButton}
+              src={MoreVert}
+              iconAs={Icon}
+              variant="primary"
+              alt="Actions dropdown"
+            />
+            <Dropdown.Menu>
+              {isEmpty(config.isValid.missing) && !config.active && (
+                <div className="d-flex">
+                  <Dropdown.Item
+                    onClick={() => toggleConfig(config.id, config.channelCode, true)}
+                    data-testid="dropdown-enable-item"
+                  >
+                    <PlayCircleFilled /> Enable
+                  </Dropdown.Item>
+                </div>
+              )}
+              {isEmpty(config.isValid.missing) && config.active && (
+                <div className="d-flex">
+                  <Dropdown.Item
+                    onClick={() => toggleConfig(config.id, config.channelCode, false)}
+                    data-testid="dropdown-disable-item"
+                  >
+                    <RemoveCircle /> Disable
+                  </Dropdown.Item>
+                </div>
+              )}
+              {!isEmpty(config.isValid.missing) && !config.active && (
+                <div className="d-flex">
+                  <Dropdown.Item
+                    onClick={() => deleteConfig(config.id, config.channelCode)}
+                    data-testid="dropdown-delete-item"
+                  >
+                    <Delete /> Delete
+                  </Dropdown.Item>
+                </div>
+              )}
+              <Dropdown.Item
+                onClick={() => editExistingConfig(config, config.channelCode)}
+              >
+                <Edit /> Edit
+              </Dropdown.Item>
+            </Dropdown.Menu>
+          </Dropdown>
+        )}
+        title={(
+          <div className="ml-1 d-flex">
+            <Image className="lms-icon mr-2" src={channelMapping[config.channelCode].icon} />
+            <div className="lms-card-title-overflow">
+              <span>
+                {config.displayName}
+              </span>
+            </div>
+          </div>
+        )}
+      />
+      <Card.Body>
+        <h3 className="mb-6 mt-4 ml-4">
+          {!isEmpty(config.isValid.missing) && (
+            <Badge variant="secondary">Incomplete</Badge>
+          )}
+          {isEmpty(config.isValid.missing) && config.active && (
+            <Badge variant="success">Active</Badge>
+          )}
+          {isEmpty(config.isValid.missing) && !config.active && (
+            <Badge variant="light">Inactive</Badge>
+          )}
+        </h3>
+      </Card.Body>
+    </Card>
+  ));
+
+  return (
+    <span>
+      <ConfigError
+        isOpen={errorIsOpen}
+        close={closeError}
+        configTextOverride={errorModalText}
+        submit={() => {
+          if (errorCardActionType === DELETE_ACTION) {
+            deleteConfig(erroredConfig.id, erroredConfig.channelType);
+          } else if (errorCardActionType === TOGGLE_ACTION) {
+            toggleConfig(erroredConfig.id, erroredConfig.channelType, erroredConfig.toggle);
+          }
+        }}
+      />
+      <CardGrid
+        className="mr-6"
+        columnSizes={{
+          xs: 7,
+          s: 7,
+          m: 6,
+          l: 5,
+          xl: 4,
+        }}
+      >
+        { listItems }
+      </CardGrid>
+    </span>
+  );
+};
+
+ExistingLMSCardDeck.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  enterpriseCustomerUuid: PropTypes.string.isRequired,
+  configData: PropTypes.arrayOf(PropTypes.shape({
+    active: PropTypes.bool,
+    isValid: PropTypes.shape({
+      missing: PropTypes.arrayOf(PropTypes.string),
+    }),
+    channelCode: PropTypes.string,
+    id: PropTypes.number,
+    displayName: PropTypes.string,
+  })).isRequired,
+  editExistingConfig: PropTypes.func.isRequired,
+};
+
+export default ExistingLMSCardDeck;

--- a/src/components/settings/SettingsLMSTab/LMSCard.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSCard.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Card, Image, Stack } from '@edx/paragon';
-import { getLMSIcon } from '../../../utils';
+import { channelMapping } from '../../../utils';
 
 const LMSCard = ({ LMSType, onClick }) => (
   <Card
@@ -12,8 +12,8 @@ const LMSCard = ({ LMSType, onClick }) => (
     <Card.Header
       title={(
         <Stack direction="horizontal" gap={2} className="justify-content-center">
-          <Image className="lms-icon" src={getLMSIcon(LMSType)} />
-          <span>{LMSType}</span>
+          <Image className="lms-icon" src={channelMapping[LMSType].icon} />
+          <span>{channelMapping[LMSType].displayName}</span>
         </Stack>
       )}
     />

--- a/src/components/settings/SettingsLMSTab/LMSConfigPage.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigPage.jsx
@@ -2,13 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Image } from '@edx/paragon';
 import { connect } from 'react-redux';
-import { getLMSIcon } from '../../../utils';
+import { channelMapping } from '../../../utils';
 
 import {
   BLACKBOARD_TYPE,
   CANVAS_TYPE,
   CORNERSTONE_TYPE,
   DEGREED_TYPE,
+  DEGREED2_TYPE,
   MOODLE_TYPE,
   SAP_TYPE,
 } from '../data/constants';
@@ -16,44 +17,82 @@ import BlackboardConfig from './LMSConfigs/BlackboardConfig';
 import CanvasConfig from './LMSConfigs/CanvasConfig';
 import CornerstoneConfig from './LMSConfigs/CornerstoneConfig';
 import DegreedConfig from './LMSConfigs/DegreedConfig';
+import Degreed2Config from './LMSConfigs/Degreed2Config';
 import MoodleConfig from './LMSConfigs/MoodleConfig';
 import SAPConfig from './LMSConfigs/SAPConfig';
 
-const LMSConfigPage = ({ LMSType, onClick, enterpriseId }) => (
+const LMSConfigPage = ({
+  LMSType,
+  onClick,
+  enterpriseCustomerUuid,
+  existingConfigFormData,
+}) => (
   <span>
     <h3 className="mt-4.5 mb-3.5">
-      <Image className="lms-icon" src={getLMSIcon(LMSType)} />
-      <span className="ml-2">Connect {LMSType}</span>
+      <Image className="lms-icon" src={channelMapping[LMSType].icon} />
+      <span className="ml-2">Connect {channelMapping[LMSType].displayName}</span>
     </h3>
     {LMSType === BLACKBOARD_TYPE && (
-      <BlackboardConfig id={enterpriseId} onClick={onClick} />
+      <BlackboardConfig
+        enterpriseCustomerUuid={enterpriseCustomerUuid}
+        onClick={onClick}
+        existingData={existingConfigFormData}
+      />
     )}
     {LMSType === CANVAS_TYPE && (
-      <CanvasConfig id={enterpriseId} onClick={onClick} />
+      <CanvasConfig
+        enterpriseCustomerUuid={enterpriseCustomerUuid}
+        onClick={onClick}
+        existingData={existingConfigFormData}
+      />
     )}
     {LMSType === CORNERSTONE_TYPE && (
-      <CornerstoneConfig id={enterpriseId} onClick={onClick} />
+      <CornerstoneConfig
+        enterpriseCustomerUuid={enterpriseCustomerUuid}
+        onClick={onClick}
+        existingData={existingConfigFormData}
+      />
+    )}
+    {LMSType === DEGREED2_TYPE && (
+      <Degreed2Config
+        enterpriseCustomerUuid={enterpriseCustomerUuid}
+        onClick={onClick}
+        existingData={existingConfigFormData}
+      />
     )}
     {LMSType === DEGREED_TYPE && (
-      <DegreedConfig id={enterpriseId} onClick={onClick} />
+      <DegreedConfig
+        enterpriseCustomerUuid={enterpriseCustomerUuid}
+        onClick={onClick}
+        existingData={existingConfigFormData}
+      />
     )}
     {LMSType === MOODLE_TYPE && (
-      <MoodleConfig id={enterpriseId} onClick={onClick} />
+      <MoodleConfig
+        enterpriseCustomerUuid={enterpriseCustomerUuid}
+        onClick={onClick}
+        existingData={existingConfigFormData}
+      />
     )}
     {LMSType === SAP_TYPE && (
-      <SAPConfig id={enterpriseId} onClick={onClick} />
+      <SAPConfig
+        enterpriseCustomerUuid={enterpriseCustomerUuid}
+        onClick={onClick}
+        existingData={existingConfigFormData}
+      />
     )}
   </span>
 );
 
 const mapStateToProps = (state) => ({
-  enterpriseId: state.portalConfiguration.enterpriseId,
+  enterpriseCustomerUuid: state.portalConfiguration.enterpriseId,
 });
 
 LMSConfigPage.propTypes = {
-  enterpriseId: PropTypes.string.isRequired,
+  enterpriseCustomerUuid: PropTypes.string.isRequired,
   LMSType: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
+  existingConfigFormData: PropTypes.shape({}).isRequired,
 };
 
 export default connect(mapStateToProps)(LMSConfigPage);

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/BlackboardConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/BlackboardConfig.jsx
@@ -1,14 +1,16 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Button, Form, useToggle } from '@edx/paragon';
+import isEmpty from 'lodash/isEmpty';
 import { buttonBool, handleErrors } from '../utils';
+
 import LmsApiService from '../../../../data/services/LmsApiService';
 import { snakeCaseDict, urlValidation } from '../../../../utils';
 import ConfigError from '../ConfigError';
 import ConfigModal from '../ConfigModal';
 import { INVALID_LINK, INVALID_NAME, SUCCESS_LABEL } from '../../data/constants';
 
-const BlackboardConfig = ({ id, onClick }) => {
+const BlackboardConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
   const [displayName, setDisplayName] = React.useState('');
   const [nameValid, setNameValid] = React.useState(true);
   const [clientId, setClientId] = React.useState('');
@@ -18,6 +20,7 @@ const BlackboardConfig = ({ id, onClick }) => {
   const [errorIsOpen, openError, closeError] = useToggle(false);
   const [modalIsOpen, openModal, closeModal] = useToggle(false);
   const [errCode, setErrCode] = React.useState();
+  const [edited, setEdited] = React.useState(false);
 
   const config = {
     displayName,
@@ -26,18 +29,42 @@ const BlackboardConfig = ({ id, onClick }) => {
     blackboardBaseUrl,
   };
 
+  useEffect(() => {
+    setClientId(existingData.clientId);
+    setClientSecret(existingData.clientSecret);
+    setBlackboardBaseUrl(existingData.blackboardBaseUrl);
+    setDisplayName(existingData.displayName);
+  }, [existingData]);
+
+  const handleCancel = () => {
+    if (edited) {
+      openModal();
+    } else {
+      onClick('');
+    }
+  };
+
   const handleSubmit = async (event) => {
     event.preventDefault();
     const transformedConfig = snakeCaseDict(config);
     // this will need to change based on save draft/submit
     transformedConfig.active = false;
-    transformedConfig.enterprise_customer = id;
+    transformedConfig.enterprise_customer = enterpriseCustomerUuid;
     let err;
-    try {
-      await LmsApiService.postNewBlackboardConfig(transformedConfig);
-    } catch (error) {
-      err = handleErrors(error);
-    } if (err) {
+    if (!isEmpty(existingData)) {
+      try {
+        await LmsApiService.updateBlackboardConfig(transformedConfig, existingData.id);
+      } catch (error) {
+        err = handleErrors(error);
+      }
+    } else {
+      try {
+        await LmsApiService.postNewBlackboardConfig(transformedConfig);
+      } catch (error) {
+        err = handleErrors(error);
+      }
+    }
+    if (err) {
       setErrCode(errCode);
       openError();
     } else {
@@ -47,7 +74,7 @@ const BlackboardConfig = ({ id, onClick }) => {
 
   const validateField = (field, input) => {
     switch (field) {
-      case 'Canvas Base URL':
+      case 'Blackboard Base URL':
         setBlackboardBaseUrl(input);
         setUrlValid(urlValidation(input) || input.length === 0);
         break;
@@ -70,9 +97,11 @@ const BlackboardConfig = ({ id, onClick }) => {
             type="text"
             isInvalid={!nameValid}
             onChange={(e) => {
+              setEdited(true);
               validateField('Display Name', e.target.value);
             }}
             floatingLabel="Display Name"
+            defaultValue={existingData.displayName}
           />
           <Form.Text>Create a custom name for this LMS.</Form.Text>
           {!nameValid && (
@@ -87,9 +116,11 @@ const BlackboardConfig = ({ id, onClick }) => {
             className="mb-4"
             type="text"
             onChange={(e) => {
+              setEdited(true);
               setClientId(e.target.value);
             }}
             floatingLabel="API Client ID/Blackboard Application Key"
+            defaultValue={existingData.clientId}
           />
         </Form.Group>
         <Form.Group>
@@ -97,9 +128,11 @@ const BlackboardConfig = ({ id, onClick }) => {
             className="my-4"
             type="password"
             onChange={(e) => {
+              setEdited(true);
               setClientSecret(e.target.value);
             }}
             floatingLabel="API Client Secret/Application Secret"
+            defaultValue={existingData.clientSecret}
           />
         </Form.Group>
         <Form.Group className="my-4">
@@ -107,9 +140,11 @@ const BlackboardConfig = ({ id, onClick }) => {
             type="text"
             isInvalid={!urlValid}
             onChange={(e) => {
-              setBlackboardBaseUrl(e.target.value);
+              setEdited(true);
+              validateField('Blackboard Base URL', e.target.value);
             }}
             floatingLabel="Blackboard Base URL"
+            defaultValue={existingData.blackboardBaseUrl}
           />
           {!urlValid && (
             <Form.Control.Feedback type="invalid">
@@ -118,7 +153,7 @@ const BlackboardConfig = ({ id, onClick }) => {
           )}
         </Form.Group>
         <span className="d-flex">
-          <Button onClick={openModal} className="ml-auto mr-2" variant="outline-primary">Cancel</Button>
+          <Button onClick={handleCancel} className="ml-auto mr-2" variant="outline-primary">Cancel</Button>
           <Button onClick={handleSubmit} disabled={!buttonBool(config) || !urlValid || !nameValid}>Submit</Button>
         </span>
       </Form>
@@ -127,7 +162,14 @@ const BlackboardConfig = ({ id, onClick }) => {
 };
 
 BlackboardConfig.propTypes = {
-  id: PropTypes.string.isRequired,
+  enterpriseCustomerUuid: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
+  existingData: PropTypes.shape({
+    id: PropTypes.number,
+    displayName: PropTypes.string,
+    clientId: PropTypes.string,
+    clientSecret: PropTypes.string,
+    blackboardBaseUrl: PropTypes.string,
+  }).isRequired,
 };
 export default BlackboardConfig;

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/Degreed2Config.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/Degreed2Config.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect } from 'react';
-import isEmpty from 'lodash/isEmpty';
 import PropTypes from 'prop-types';
 import { Button, Form, useToggle } from '@edx/paragon';
+import isEmpty from 'lodash/isEmpty';
+
 import { buttonBool, handleErrors } from '../utils';
 import LmsApiService from '../../../../data/services/LmsApiService';
 import { snakeCaseDict, urlValidation } from '../../../../utils';
@@ -9,39 +10,29 @@ import ConfigError from '../ConfigError';
 import ConfigModal from '../ConfigModal';
 import { INVALID_LINK, INVALID_NAME, SUCCESS_LABEL } from '../../data/constants';
 
-const SAPConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
+const Degreed2Config = ({ enterpriseCustomerUuid, onClick, existingData }) => {
   const [displayName, setDisplayName] = React.useState('');
   const [nameValid, setNameValid] = React.useState(true);
-  const [sapsfBaseUrl, setSapsfBaseUrl] = React.useState('');
+  const [clientId, setClientId] = React.useState('');
+  const [clientSecret, setClientSecret] = React.useState('');
+  const [degreedBaseUrl, setDegreedBaseUrl] = React.useState('');
   const [urlValid, setUrlValid] = React.useState(true);
-  const [sapsfCompanyId, setSapsfCompanyId] = React.useState('');
-  const [sapsfUserId, setSapsfUserId] = React.useState('');
-  const [key, setKey] = React.useState('');
-  const [secret, setSecret] = React.useState('');
-  const [userType, setUserType] = React.useState('user');
   const [errorIsOpen, openError, closeError] = useToggle(false);
   const [modalIsOpen, openModal, closeModal] = useToggle(false);
-  const [errCode, setErrCode] = React.useState();
   const [edited, setEdited] = React.useState(false);
 
   const config = {
     displayName,
-    sapsfBaseUrl,
-    sapsfCompanyId,
-    sapsfUserId,
-    key,
-    secret,
-    userType,
+    clientId,
+    clientSecret,
+    degreedBaseUrl,
   };
 
   useEffect(() => {
+    setClientId(existingData.clientId);
+    setClientSecret(existingData.clientSecret);
+    setDegreedBaseUrl(existingData.degreedBaseUrl);
     setDisplayName(existingData.displayName);
-    setSapsfBaseUrl(existingData.sapsfBaseUrl);
-    setSapsfCompanyId(existingData.sapsfCompanyId);
-    setSapsfUserId(existingData.sapsfUserId);
-    setKey(existingData.key);
-    setSecret(existingData.secret);
-    setUserType(existingData.userType === 'user' ? 'user' : 'admin');
   }, [existingData]);
 
   const handleCancel = () => {
@@ -52,8 +43,7 @@ const SAPConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
     }
   };
 
-  const handleSubmit = async (event) => {
-    event.preventDefault();
+  const handleSubmit = async () => {
     const transformedConfig = snakeCaseDict(config);
     // this will need to change based on save draft/submit
     transformedConfig.active = false;
@@ -62,19 +52,19 @@ const SAPConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
 
     if (!isEmpty(existingData)) {
       try {
-        await LmsApiService.updateSuccessFactorsConfig(transformedConfig, existingData.id);
+        await LmsApiService.updateDegreed2Config(transformedConfig, existingData.id);
       } catch (error) {
         err = handleErrors(error);
       }
     } else {
       try {
-        await LmsApiService.postNewSuccessFactorsConfig(transformedConfig);
+        await LmsApiService.postNewDegreed2Config(transformedConfig);
       } catch (error) {
         err = handleErrors(error);
       }
     }
+
     if (err) {
-      setErrCode(err);
       openError();
     } else {
       onClick(SUCCESS_LABEL);
@@ -83,8 +73,8 @@ const SAPConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
 
   const validateField = (field, input) => {
     switch (field) {
-      case 'SAP Base URL':
-        setSapsfBaseUrl(input);
+      case 'Degreed Base URL':
+        setDegreedBaseUrl(input);
         setUrlValid(urlValidation(input) || input.length === 0);
         break;
       case 'Display Name':
@@ -98,7 +88,7 @@ const SAPConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
 
   return (
     <span>
-      <ConfigError isOpen={errorIsOpen} close={closeError} submit={handleSubmit} err={errCode} />
+      <ConfigError isOpen={errorIsOpen} close={closeError} submit={handleSubmit} />
       <ConfigModal isOpen={modalIsOpen} close={closeModal} onClick={onClick} />
       <Form style={{ maxWidth: '60rem' }}>
         <Form.Group className="my-2.5">
@@ -119,81 +109,46 @@ const SAPConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
             </Form.Control.Feedback>
           )}
         </Form.Group>
-        <Form.Group className="mb-4">
+        <Form.Group>
+          <Form.Control
+            className="mb-4"
+            type="text"
+            onChange={(e) => {
+              setEdited(true);
+              setClientId(e.target.value);
+            }}
+            floatingLabel="API Client ID"
+            defaultValue={existingData.clientId}
+          />
+        </Form.Group>
+        <Form.Group>
+          <Form.Control
+            className="my-4"
+            type="password"
+            onChange={(e) => {
+              setEdited(true);
+              setClientSecret(e.target.value);
+            }}
+            floatingLabel="API Client Secret"
+            defaultValue={existingData.clientSecret}
+          />
+        </Form.Group>
+        <Form.Group className="my-4">
           <Form.Control
             type="text"
             isInvalid={!urlValid}
             onChange={(e) => {
               setEdited(true);
-              validateField('SAP Base URL', e.target.value);
+              validateField('Degreed Base URL', e.target.value);
             }}
-            floatingLabel="SAP Base URL"
-            defaultValue={existingData.sapsfBaseUrl}
+            floatingLabel="Degreed Base URL"
+            defaultValue={existingData.degreedBaseUrl}
           />
           {!urlValid && (
             <Form.Control.Feedback type="invalid">
               {INVALID_LINK}
             </Form.Control.Feedback>
           )}
-        </Form.Group>
-        <Form.Group className="my-4">
-          <Form.Control
-            type="number"
-            onChange={(e) => {
-              setEdited(true);
-              setSapsfCompanyId(e.target.value);
-            }}
-            floatingLabel="SAP Company ID"
-            defaultValue={existingData.sapsfCompanyId}
-          />
-        </Form.Group>
-        <Form.Group className="my-4">
-          <Form.Control
-            type="text"
-            onChange={(e) => {
-              setEdited(true);
-              setSapsfUserId(e.target.value);
-            }}
-            floatingLabel="SAP User ID"
-            defaultValue={existingData.sapsfUserId}
-          />
-        </Form.Group>
-        <Form.Group className="mb-4">
-          <Form.Control
-            type="text"
-            onChange={(e) => {
-              setEdited(true);
-              setKey(e.target.value);
-            }}
-            floatingLabel="OAuth Client ID"
-            defaultValue={existingData.key}
-          />
-        </Form.Group>
-        <Form.Group className="my-4">
-          <Form.Control
-            type="password"
-            onChange={(e) => {
-              setEdited(true);
-              setSecret(e.target.value);
-            }}
-            floatingLabel="OAuth Client Secret"
-            defaultValue={existingData.secret}
-          />
-        </Form.Group>
-        <Form.Group>
-          <Form.Label>SAP User Type</Form.Label>
-          <Form.RadioSet
-            name="user-toggle"
-            onChange={(e) => {
-              setEdited(true);
-              setUserType(e.target.value);
-            }}
-            defaultValue={existingData.userType === 'user' ? 'user' : 'admin'}
-            isInline
-          >
-            <Form.Radio value="user">User</Form.Radio>
-            <Form.Radio value="admin">Admin</Form.Radio>
-          </Form.RadioSet>
         </Form.Group>
         <span className="d-flex">
           <Button onClick={handleCancel} className="ml-auto mr-2" variant="outline-primary">Cancel</Button>
@@ -204,18 +159,15 @@ const SAPConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
   );
 };
 
-SAPConfig.propTypes = {
+Degreed2Config.propTypes = {
   enterpriseCustomerUuid: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
   existingData: PropTypes.shape({
     displayName: PropTypes.string,
+    clientId: PropTypes.string,
     id: PropTypes.number,
-    sapsfBaseUrl: PropTypes.string,
-    sapsfCompanyId: PropTypes.string,
-    sapsfUserId: PropTypes.string,
-    key: PropTypes.string,
-    secret: PropTypes.string,
-    userType: PropTypes.string,
+    clientSecret: PropTypes.string,
+    degreedBaseUrl: PropTypes.string,
   }).isRequired,
 };
-export default SAPConfig;
+export default Degreed2Config;

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/MoodleConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/MoodleConfig.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Button, Form, useToggle } from '@edx/paragon';
+import isEmpty from 'lodash/isEmpty';
 import { buttonBool, handleErrors } from '../utils';
 import LmsApiService from '../../../../data/services/LmsApiService';
 import { snakeCaseDict, urlValidation } from '../../../../utils';
@@ -8,20 +9,55 @@ import ConfigError from '../ConfigError';
 import ConfigModal from '../ConfigModal';
 import { INVALID_LINK, INVALID_NAME, SUCCESS_LABEL } from '../../data/constants';
 
-const MoodleConfig = ({ id, onClick }) => {
+const MoodleConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
   const [moodleBaseUrl, setMoodleBaseUrl] = React.useState('');
   const [urlValid, setUrlValid] = React.useState(true);
   const [serviceShortName, setServiceShortName] = React.useState('');
   const [displayName, setDisplayName] = React.useState('');
+  const [token, setToken] = React.useState('');
+  const [username, setUsername] = React.useState('');
+  const [password, setPassword] = React.useState('');
   const [nameValid, setNameValid] = React.useState(true);
   const [errorIsOpen, openError, closeError] = useToggle(false);
   const [modalIsOpen, openModal, closeModal] = useToggle(false);
   const [errCode, setErrCode] = React.useState();
+  const [edited, setEdited] = React.useState(false);
 
   const config = {
     moodleBaseUrl,
     serviceShortName,
     displayName,
+    token,
+    username,
+    password,
+  };
+
+  const configToValidate = () => {
+    if (!token && (!username || !password)) {
+      return config;
+    }
+    return {
+      moodleBaseUrl,
+      serviceShortName,
+      displayName,
+    };
+  };
+
+  useEffect(() => {
+    setMoodleBaseUrl(existingData.moodleBaseUrl);
+    setServiceShortName(existingData.serviceShortName);
+    setDisplayName(existingData.displayName);
+    setToken(existingData.token);
+    setUsername(existingData.username);
+    setPassword(existingData.password);
+  }, [existingData]);
+
+  const handleCancel = () => {
+    if (edited) {
+      openModal();
+    } else {
+      onClick('');
+    }
   };
 
   const handleSubmit = async (event) => {
@@ -29,13 +65,23 @@ const MoodleConfig = ({ id, onClick }) => {
     const transformedConfig = snakeCaseDict(config);
     // this will need to change based on save draft/submit
     transformedConfig.active = false;
-    transformedConfig.enterprise_customer = id;
+    transformedConfig.enterprise_customer = enterpriseCustomerUuid;
     let err;
-    try {
-      await LmsApiService.postNewMoodleConfig(transformedConfig);
-    } catch (error) {
-      err = handleErrors(error);
+
+    if (!isEmpty(existingData)) {
+      try {
+        await LmsApiService.updateMoodleConfig(transformedConfig, existingData.id);
+      } catch (error) {
+        err = handleErrors(error);
+      }
+    } else {
+      try {
+        await LmsApiService.postNewMoodleConfig(transformedConfig);
+      } catch (error) {
+        err = handleErrors(error);
+      }
     }
+
     if (err) {
       setErrCode(err);
       openError();
@@ -69,9 +115,11 @@ const MoodleConfig = ({ id, onClick }) => {
             type="text"
             isInvalid={!nameValid}
             onChange={(e) => {
+              setEdited(true);
               validateField('Display Name', e.target.value);
             }}
             floatingLabel="Display Name"
+            defaultValue={existingData.displayName}
           />
           <Form.Text>Create a custom name for this LMS.</Form.Text>
           {!nameValid && (
@@ -85,9 +133,11 @@ const MoodleConfig = ({ id, onClick }) => {
             type="text"
             isInvalid={!urlValid}
             onChange={(e) => {
+              setEdited(true);
               validateField('Moodle Base URL', e.target.value);
             }}
             floatingLabel="Moodle Base URL"
+            defaultValue={existingData.moodleBaseUrl}
           />
           {!urlValid && (
             <Form.Control.Feedback type="invalid">
@@ -99,14 +149,60 @@ const MoodleConfig = ({ id, onClick }) => {
           <Form.Control
             type="text"
             onChange={(e) => {
+              setEdited(true);
               setServiceShortName(e.target.value);
             }}
             floatingLabel="Webservice Short Name"
+            defaultValue={existingData.serviceShortName}
+          />
+        </Form.Group>
+        <Form.Group className="my-4">
+          <Form.Control
+            type="text"
+            onChange={(e) => {
+              setEdited(true);
+              setToken(e.target.value);
+            }}
+            floatingLabel="Token"
+            defaultValue={existingData.token}
+            disabled={password || username}
+          />
+          {(username || password) && (
+            <Form.Text>Please provide either a token or a username and password.</Form.Text>
+          )}
+        </Form.Group>
+        <Form.Group className="my-4">
+          <Form.Control
+            type="text"
+            onChange={(e) => {
+              setEdited(true);
+              setUsername(e.target.value);
+            }}
+            floatingLabel="Username"
+            defaultValue={existingData.username}
+            disabled={token}
+          />
+          {token && (
+            <Form.Text>Please provide either a token or a username and password.</Form.Text>
+          )}
+        </Form.Group>
+        <Form.Group className="my-4">
+          <Form.Control
+            type="text"
+            onChange={(e) => {
+              setEdited(true);
+              setPassword(e.target.value);
+            }}
+            floatingLabel="Password"
+            defaultValue={existingData.password}
+            disabled={token}
           />
         </Form.Group>
         <span className="d-flex">
-          <Button onClick={openModal} className="ml-auto mr-2" variant="outline-primary">Cancel</Button>
-          <Button onClick={handleSubmit} disabled={!buttonBool(config) || !nameValid || !urlValid}>Submit</Button>
+          <Button onClick={handleCancel} className="ml-auto mr-2" variant="outline-primary">Cancel</Button>
+          <Button onClick={handleSubmit} disabled={!buttonBool(configToValidate()) || !nameValid || !urlValid}>
+            Submit
+          </Button>
         </span>
       </Form>
     </span>
@@ -114,7 +210,16 @@ const MoodleConfig = ({ id, onClick }) => {
 };
 
 MoodleConfig.propTypes = {
-  id: PropTypes.string.isRequired,
+  enterpriseCustomerUuid: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
+  existingData: PropTypes.shape({
+    token: PropTypes.string,
+    username: PropTypes.string,
+    password: PropTypes.string,
+    displayName: PropTypes.string,
+    id: PropTypes.number,
+    moodleBaseUrl: PropTypes.string,
+    serviceShortName: PropTypes.string,
+  }).isRequired,
 };
 export default MoodleConfig;

--- a/src/components/settings/SettingsLMSTab/index.jsx
+++ b/src/components/settings/SettingsLMSTab/index.jsx
@@ -1,30 +1,117 @@
-import React, { useState } from 'react';
-import { Hyperlink, CardGrid, Toast } from '@edx/paragon';
+import React, { useEffect, useState } from 'react';
+import {
+  Button, Hyperlink, CardGrid, Toast,
+} from '@edx/paragon';
+import { Add } from '@edx/paragon/icons';
+import { logError } from '@edx/frontend-platform/logging';
+
+import { camelCaseDictArray } from '../../../utils';
 import LMSCard from './LMSCard';
 import LMSConfigPage from './LMSConfigPage';
+import ExistingLMSCardDeck from './ExistingLMSCardDeck';
 import {
   BLACKBOARD_TYPE,
   CANVAS_TYPE,
   CORNERSTONE_TYPE,
-  DEGREED_TYPE,
+  DEGREED2_TYPE,
   HELP_CENTER_LINK,
   MOODLE_TYPE,
   SAP_TYPE,
   SUCCESS_LABEL,
+  DELETE_SUCCESS_LABEL,
+  TOGGLE_SUCCESS_LABEL,
 } from '../data/constants';
+import LmsApiService from '../../../data/services/LmsApiService';
 
-export default function SettingsLMSTab() {
+const SUBMIT_TOAST_MESSAGE = 'Configuration was submitted successfully.';
+const TOGGLE_TOAST_MESSAGE = 'Configuration was toggled successfully.';
+const DELETE_TOAST_MESSAGE = 'Configuration was successfully removed.';
+
+export default function SettingsLMSTab(enterpriseId) {
   const [config, setConfig] = useState();
   const [showToast, setShowToast] = useState(false);
 
+  const [existingConfigsData, setExistingConfigsData] = useState({});
+  const [configsExist, setConfigsExist] = useState(false);
+  const [showNewConfigButtons, setShowNewConfigButtons] = useState(true);
+
+  const [existingConfigFormData, setExistingConfigFormData] = useState({});
+  const [toastMessage, setToastMessage] = useState();
+
+  // onClick function for existing config cards' edit action
+  const editExistingConfig = (configData, configType) => {
+    // Set the form data to the card's
+    setExistingConfigFormData(configData);
+    // Set the config type to the card's type
+    setConfig(configType);
+    // Hide the create new configs button
+    setShowNewConfigButtons(true);
+    // Since the user is editing, hide the existing config cards
+    setConfigsExist(false);
+  };
+
+  const fetchExistingConfigs = () => {
+    const options = { enterprise_customer: enterpriseId.enterpriseId };
+    LmsApiService.fetchEnterpriseCustomerIntegrationConfigs(options)
+      .then((response) => {
+        // If the enterprise has existing configs
+        if (response.data.length !== 0) {
+          // Save all existing configs
+          setExistingConfigsData(camelCaseDictArray(response.data));
+          // toggle the existing configs bool
+          setConfigsExist(true);
+          // Hide the create cards and show the create button
+          setShowNewConfigButtons(false);
+        }
+      })
+      .catch((error) => {
+        // We can ignore errors here as user will se the banner in the next page refresh.
+        logError(error);
+      });
+  };
+
   const onClick = (input) => {
+    // Either we're creating a new config (a create config card was clicked), or we're navigating
+    // back to the landing state from a form (submit or cancel was hit on the forms). In both cases,
+    // we want to clear existing config form data.
+    setExistingConfigFormData({});
+
+    // If either the user has submit or canceled
+    if (input === '' || [SUCCESS_LABEL, DELETE_SUCCESS_LABEL, TOGGLE_SUCCESS_LABEL].includes(input)) {
+      // Re-fetch existing configs to get newly created ones
+      fetchExistingConfigs();
+    }
+    // If the user submitted
     if (input === SUCCESS_LABEL) {
+      // show the toast and reset the config state
       setShowToast(true);
       setConfig('');
+      setToastMessage(SUBMIT_TOAST_MESSAGE);
+    } else if (input === TOGGLE_SUCCESS_LABEL) {
+      setShowToast(true);
+      setConfig('');
+      setToastMessage(TOGGLE_TOAST_MESSAGE);
+    } else if (input === DELETE_SUCCESS_LABEL) {
+      setShowToast(true);
+      setConfig('');
+      setToastMessage(DELETE_TOAST_MESSAGE);
     } else {
+      // Otherwise the user has clicked a create card and we need to set existing config bool to
+      // false and set the config type to the card that was clicked type
+      setConfigsExist(false);
       setConfig(input);
     }
   };
+
+  // onClick function for the show create cards button
+  const showCreateConfigCards = () => {
+    setShowNewConfigButtons(true);
+  };
+
+  useEffect(() => {
+    // On load fetch potential existing configs
+    fetchExistingConfigs();
+  }, []);
 
   return (
     <div>
@@ -42,7 +129,30 @@ export default function SettingsLMSTab() {
         Enabling a learning management system for your edX account allows quick
         access to the catalog
       </p>
-      {!config && (
+      {configsExist && (
+        <span>
+          <h4 className="mt-5 mb-4">Existing configurations</h4>
+          <ExistingLMSCardDeck
+            configData={existingConfigsData}
+            editExistingConfig={editExistingConfig}
+            enterpriseCustomerUuid={enterpriseId.enterpriseId}
+            onClick={onClick}
+          />
+        </span>
+      )}
+      {!showNewConfigButtons && (
+        <Button
+          varient="primary"
+          className="mr-6"
+          iconBefore={Add}
+          size="lg"
+          block
+          onClick={showCreateConfigCards}
+        >
+          New configuration
+        </Button>
+      )}
+      {showNewConfigButtons && !config && (
         <span>
           <h4 className="mt-5">New configurations</h4>
           <p className="mb-4">Click on a card to start a new configuration</p>
@@ -60,21 +170,21 @@ export default function SettingsLMSTab() {
             <LMSCard LMSType={MOODLE_TYPE} onClick={onClick} />
             <LMSCard LMSType={CORNERSTONE_TYPE} onClick={onClick} />
             <LMSCard LMSType={CANVAS_TYPE} onClick={onClick} />
-            <LMSCard LMSType={DEGREED_TYPE} onClick={onClick} />
+            <LMSCard LMSType={DEGREED2_TYPE} onClick={onClick} />
             <LMSCard LMSType={BLACKBOARD_TYPE} onClick={onClick} />
           </CardGrid>
         </span>
       )}
       {config && (
         <span>
-          <LMSConfigPage LMSType={config} onClick={onClick} />
+          <LMSConfigPage LMSType={config} onClick={onClick} existingConfigFormData={existingConfigFormData} />
         </span>
       )}
       <Toast
         onClose={() => setShowToast(false)}
         show={showToast}
       >
-        Configuration was submitted successfully.
+        {toastMessage}
       </Toast>
     </div>
   );

--- a/src/components/settings/SettingsLMSTab/tests/BlackboardConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/BlackboardConfig.test.jsx
@@ -6,15 +6,24 @@ import '@testing-library/jest-dom/extend-expect';
 
 import BlackboardConfig from '../LMSConfigs/BlackboardConfig';
 import { INVALID_LINK, INVALID_NAME } from '../../data/constants';
+import LmsApiService from '../../../../data/services/LmsApiService';
 
+jest.mock('../../../../data/services/LmsApiService');
+
+const enterpriseId = 'test-enterprise-id';
 const mockOnClick = jest.fn();
+const noExistingData = {};
+const existingConfigData = {
+  id: 1,
+};
 
 describe('<BlackboardConfig />', () => {
   test('renders Blackboard Config Form', () => {
     render(
       <BlackboardConfig
-        id="test-enterprise-id"
+        enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
+        existingData={noExistingData}
       />,
     );
     screen.getByLabelText('Display Name');
@@ -25,8 +34,9 @@ describe('<BlackboardConfig />', () => {
   test('test validation and button disable', () => {
     render(
       <BlackboardConfig
-        id="test-enterprise-id"
+        enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
+        existingData={noExistingData}
       />,
     );
     expect(screen.getByText('Submit')).toBeDisabled();
@@ -53,5 +63,71 @@ describe('<BlackboardConfig />', () => {
       target: { value: 'https://www.test.com' },
     });
     expect(screen.getByText('Submit')).not.toBeDisabled();
+  });
+  test('it edits existing configs on submit', () => {
+    render(
+      <BlackboardConfig
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={existingConfigData}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('API Client ID/Blackboard Application Key'), {
+      target: { value: 'test1' },
+    });
+    fireEvent.change(screen.getByLabelText('API Client Secret/Application Secret'), {
+      target: { value: 'test2' },
+    });
+    fireEvent.change(screen.getByLabelText('Display Name'), {
+      target: { value: 'displayName' },
+    });
+    fireEvent.change(screen.getByLabelText('Blackboard Base URL'), {
+      target: { value: 'https://www.test.com' },
+    });
+    expect(screen.getByText('Submit')).not.toBeDisabled();
+    fireEvent.click(screen.getByText('Submit'));
+
+    const expectedConfig = {
+      active: false,
+      blackboard_base_url: 'https://www.test.com',
+      client_id: 'test1',
+      client_secret: 'test2',
+      display_name: 'displayName',
+      enterprise_customer: enterpriseId,
+    };
+    expect(LmsApiService.updateBlackboardConfig).toHaveBeenCalledWith(expectedConfig, 1);
+  });
+  test('it creates new configs on submit', () => {
+    render(
+      <BlackboardConfig
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={noExistingData}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('API Client ID/Blackboard Application Key'), {
+      target: { value: 'test1' },
+    });
+    fireEvent.change(screen.getByLabelText('API Client Secret/Application Secret'), {
+      target: { value: 'test2' },
+    });
+    fireEvent.change(screen.getByLabelText('Display Name'), {
+      target: { value: 'displayName' },
+    });
+    fireEvent.change(screen.getByLabelText('Blackboard Base URL'), {
+      target: { value: 'https://www.test.com' },
+    });
+    expect(screen.getByText('Submit')).not.toBeDisabled();
+    fireEvent.click(screen.getByText('Submit'));
+
+    const expectedConfig = {
+      active: false,
+      blackboard_base_url: 'https://www.test.com',
+      client_id: 'test1',
+      client_secret: 'test2',
+      display_name: 'displayName',
+      enterprise_customer: enterpriseId,
+    };
+    expect(LmsApiService.postNewBlackboardConfig).toHaveBeenCalledWith(expectedConfig);
   });
 });

--- a/src/components/settings/SettingsLMSTab/tests/CanvasConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/CanvasConfig.test.jsx
@@ -6,15 +6,25 @@ import '@testing-library/jest-dom/extend-expect';
 
 import CanvasConfig from '../LMSConfigs/CanvasConfig';
 import { INVALID_LINK, INVALID_NAME } from '../../data/constants';
+import LmsApiService from '../../../../data/services/LmsApiService';
+
+jest.mock('../../../../data/services/LmsApiService');
+
+const enterpriseId = 'test-enterprise-id';
 
 const mockOnClick = jest.fn();
+const noExistingData = {};
+const existingConfigData = {
+  id: 1,
+};
 
 describe('<CanvasConfig />', () => {
   test('renders Canvas Config Form', () => {
     render(
       <CanvasConfig
-        id="test-enterprise-id"
+        enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
+        existingData={noExistingData}
       />,
     );
     screen.getByLabelText('Display Name');
@@ -26,8 +36,9 @@ describe('<CanvasConfig />', () => {
   test('test button disable', () => {
     render(
       <CanvasConfig
-        id="test-enterprise-id"
+        enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
+        existingData={noExistingData}
       />,
     );
     expect(screen.getByText('Submit')).toBeDisabled();
@@ -58,5 +69,79 @@ describe('<CanvasConfig />', () => {
       target: { value: 'https://www.test4.com' },
     });
     expect(screen.getByText('Submit')).not.toBeDisabled();
+  });
+  test('it edits existing configs on submit', () => {
+    render(
+      <CanvasConfig
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={existingConfigData}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('API Client ID'), {
+      target: { value: 'test1' },
+    });
+    fireEvent.change(screen.getByLabelText('API Client Secret'), {
+      target: { value: 'test2' },
+    });
+    fireEvent.change(screen.getByLabelText('Canvas Account Number'), {
+      target: { value: '3' },
+    });
+    fireEvent.change(screen.getByLabelText('Display Name'), {
+      target: { value: 'displayName' },
+    });
+    fireEvent.change(screen.getByLabelText('Canvas Base URL'), {
+      target: { value: 'https://www.test4.com' },
+    });
+    expect(screen.getByText('Submit')).not.toBeDisabled();
+    fireEvent.click(screen.getByText('Submit'));
+
+    const expectedConfig = {
+      active: false,
+      canvas_base_url: 'https://www.test4.com',
+      canvas_account_id: '3',
+      client_id: 'test1',
+      client_secret: 'test2',
+      display_name: 'displayName',
+      enterprise_customer: enterpriseId,
+    };
+    expect(LmsApiService.updateCanvasConfig).toHaveBeenCalledWith(expectedConfig, 1);
+  });
+  test('it creates new configs on submit', () => {
+    render(
+      <CanvasConfig
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={noExistingData}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('API Client ID'), {
+      target: { value: 'test1' },
+    });
+    fireEvent.change(screen.getByLabelText('API Client Secret'), {
+      target: { value: 'test2' },
+    });
+    fireEvent.change(screen.getByLabelText('Canvas Account Number'), {
+      target: { value: '3' },
+    });
+    fireEvent.change(screen.getByLabelText('Display Name'), {
+      target: { value: 'displayName' },
+    });
+    fireEvent.change(screen.getByLabelText('Canvas Base URL'), {
+      target: { value: 'https://www.test4.com' },
+    });
+    expect(screen.getByText('Submit')).not.toBeDisabled();
+    fireEvent.click(screen.getByText('Submit'));
+
+    const expectedConfig = {
+      active: false,
+      canvas_base_url: 'https://www.test4.com',
+      canvas_account_id: '3',
+      client_id: 'test1',
+      client_secret: 'test2',
+      display_name: 'displayName',
+      enterprise_customer: enterpriseId,
+    };
+    expect(LmsApiService.postNewCanvasConfig).toHaveBeenCalledWith(expectedConfig);
   });
 });

--- a/src/components/settings/SettingsLMSTab/tests/ConfigError.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/ConfigError.test.jsx
@@ -9,6 +9,7 @@ const mockClose = jest.fn();
 
 const testCode1 = 400;
 const testCode2 = 500;
+const overrideText = 'ayylmao';
 
 describe('<ConfigError />', () => {
   test('renders 400 Error Modal', () => {
@@ -36,5 +37,18 @@ describe('<ConfigError />', () => {
     expect(screen.queryByText('We were unable to process your request to submit a new LMS configuration. Please try submitting again later or contact support for help.'));
     expect(screen.queryByText('Contact Support'));
     expect(screen.queryByText('Try Again')).toBeFalsy();
+  });
+  test('renders Error Modal with text override', () => {
+    render(
+      <ConfigError
+        isOpen
+        close={mockClose}
+        submit={mockSubmit}
+        configTextOverride={overrideText}
+      />,
+    );
+    expect(screen.queryByText('ayylmao'));
+    expect(screen.queryByText('Contact Support'));
+    expect(screen.queryByText('Try Again'));
   });
 });

--- a/src/components/settings/SettingsLMSTab/tests/CornerstoneConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/CornerstoneConfig.test.jsx
@@ -6,15 +6,25 @@ import '@testing-library/jest-dom/extend-expect';
 
 import CornerstoneConfig from '../LMSConfigs/CornerstoneConfig';
 import { INVALID_LINK, INVALID_NAME } from '../../data/constants';
+import LmsApiService from '../../../../data/services/LmsApiService';
+
+jest.mock('../../../../data/services/LmsApiService');
+
+const enterpriseId = 'test-enterprise-id';
 
 const mockOnClick = jest.fn();
+const noExistingData = {};
+const existingConfigData = {
+  id: 1,
+};
 
 describe('<CornerstoneConfig />', () => {
   test('renders Cornerstone Config Form', () => {
     render(
       <CornerstoneConfig
-        id="test-enterprise-id"
+        enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
+        existingData={noExistingData}
       />,
     );
     screen.getByLabelText('Display Name');
@@ -23,8 +33,9 @@ describe('<CornerstoneConfig />', () => {
   test('test button disable', () => {
     render(
       <CornerstoneConfig
-        id="test-enterprise-id"
+        enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
+        existingData={noExistingData}
       />,
     );
     expect(screen.getByText('Submit')).toBeDisabled();
@@ -45,5 +56,55 @@ describe('<CornerstoneConfig />', () => {
       target: { value: 'https://www.test1.com' },
     });
     expect(screen.getByText('Submit')).not.toBeDisabled();
+  });
+  test('it edits existing configs on submit', () => {
+    render(
+      <CornerstoneConfig
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={existingConfigData}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('Display Name'), {
+      target: { value: 'displayName' },
+    });
+    fireEvent.change(screen.getByLabelText('Cornerstone Base URL'), {
+      target: { value: 'https://www.test1.com' },
+    });
+    expect(screen.getByText('Submit')).not.toBeDisabled();
+    fireEvent.click(screen.getByText('Submit'));
+
+    const expectedConfig = {
+      active: false,
+      cornerstone_base_url: 'https://www.test1.com',
+      display_name: 'displayName',
+      enterprise_customer: enterpriseId,
+    };
+    expect(LmsApiService.updateCornerstoneConfig).toHaveBeenCalledWith(expectedConfig, 1);
+  });
+  test('it creates new configs on submit', () => {
+    render(
+      <CornerstoneConfig
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={noExistingData}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('Display Name'), {
+      target: { value: 'displayName' },
+    });
+    fireEvent.change(screen.getByLabelText('Cornerstone Base URL'), {
+      target: { value: 'https://www.test1.com' },
+    });
+    expect(screen.getByText('Submit')).not.toBeDisabled();
+    fireEvent.click(screen.getByText('Submit'));
+
+    const expectedConfig = {
+      active: false,
+      cornerstone_base_url: 'https://www.test1.com',
+      display_name: 'displayName',
+      enterprise_customer: enterpriseId,
+    };
+    expect(LmsApiService.postNewCornerstoneConfig).toHaveBeenCalledWith(expectedConfig);
   });
 });

--- a/src/components/settings/SettingsLMSTab/tests/Degreed2Config.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/Degreed2Config.test.jsx
@@ -4,7 +4,7 @@ import {
 } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
-import MoodleConfig from '../LMSConfigs/MoodleConfig';
+import Degreed2Config from '../LMSConfigs/Degreed2Config';
 import { INVALID_LINK, INVALID_NAME } from '../../data/constants';
 import LmsApiService from '../../../../data/services/LmsApiService';
 
@@ -17,116 +17,117 @@ const existingConfigData = {
   id: 1,
 };
 
-describe('<MoodleConfig />', () => {
-  test('renders Moodle Config Form', () => {
+describe('<DegreedConfig />', () => {
+  test('renders Degreed Config Form', () => {
     render(
-      <MoodleConfig
+      <Degreed2Config
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={noExistingData}
       />,
     );
     screen.getByLabelText('Display Name');
-    screen.getByLabelText('Moodle Base URL');
-    screen.getByLabelText('Webservice Short Name');
+    screen.getByLabelText('API Client ID');
+    screen.getByLabelText('API Client Secret');
+    screen.getByLabelText('Degreed Base URL');
   });
   test('test button disable', () => {
     render(
-      <MoodleConfig
+      <Degreed2Config
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={noExistingData}
       />,
     );
     expect(screen.getByText('Submit')).toBeDisabled();
+
     fireEvent.change(screen.getByLabelText('Display Name'), {
       target: { value: 'reallyreallyreallyreallyreallylongname' },
     });
-    fireEvent.change(screen.getByLabelText('Moodle Base URL'), {
+    fireEvent.change(screen.getByLabelText('API Client ID'), {
       target: { value: 'test1' },
     });
-    fireEvent.change(screen.getByLabelText('Webservice Short Name'), {
+    fireEvent.change(screen.getByLabelText('API Client Secret'), {
       target: { value: 'test2' },
     });
-    expect(screen.queryByText(INVALID_NAME));
-    expect(screen.queryByText(INVALID_LINK));
+    fireEvent.change(screen.getByLabelText('Degreed Base URL'), {
+      target: { value: 'test4' },
+    });
     expect(screen.getByText('Submit')).toBeDisabled();
-
-    fireEvent.change(screen.getByLabelText('Moodle Base URL'), {
-      target: { value: 'https://test1.com' },
-    });
+    expect(screen.queryByText(INVALID_LINK));
+    expect(screen.queryByText(INVALID_NAME));
     fireEvent.change(screen.getByLabelText('Display Name'), {
-      target: { value: 'test2' },
+      target: { value: 'test1' },
     });
-    fireEvent.change(screen.getByLabelText('Token'), {
-      target: { value: 'token111' },
+    fireEvent.change(screen.getByLabelText('Degreed Base URL'), {
+      target: { value: 'https://test1.com' },
     });
     expect(screen.getByText('Submit')).not.toBeDisabled();
   });
   test('it edits existing configs on submit', () => {
     render(
-      <MoodleConfig
+      <Degreed2Config
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={existingConfigData}
       />,
     );
-    fireEvent.change(screen.getByLabelText('Moodle Base URL'), {
-      target: { value: 'https://www.test1.com' },
+    fireEvent.change(screen.getByLabelText('API Client ID'), {
+      target: { value: 'test1' },
+    });
+    fireEvent.change(screen.getByLabelText('API Client Secret'), {
+      target: { value: 'test2' },
     });
     fireEvent.change(screen.getByLabelText('Display Name'), {
       target: { value: 'displayName' },
     });
-    fireEvent.change(screen.getByLabelText('Webservice Short Name'), {
-      target: { value: 'test2' },
-    });
-    fireEvent.change(screen.getByLabelText('Token'), {
-      target: { value: 'token111' },
+    fireEvent.change(screen.getByLabelText('Degreed Base URL'), {
+      target: { value: 'https://test1.com' },
     });
     expect(screen.getByText('Submit')).not.toBeDisabled();
     fireEvent.click(screen.getByText('Submit'));
 
     const expectedConfig = {
       active: false,
-      moodle_base_url: 'https://www.test1.com',
-      service_short_name: 'test2',
+      degreed_base_url: 'https://test1.com',
       display_name: 'displayName',
+      client_id: 'test1',
+      client_secret: 'test2',
       enterprise_customer: enterpriseId,
-      token: 'token111',
     };
-    expect(LmsApiService.updateMoodleConfig).toHaveBeenCalledWith(expectedConfig, 1);
+    expect(LmsApiService.updateDegreed2Config).toHaveBeenCalledWith(expectedConfig, 1);
   });
   test('it creates new configs on submit', () => {
     render(
-      <MoodleConfig
+      <Degreed2Config
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={noExistingData}
       />,
     );
-    fireEvent.change(screen.getByLabelText('Moodle Base URL'), {
-      target: { value: 'https://www.test1.com' },
+    fireEvent.change(screen.getByLabelText('API Client ID'), {
+      target: { value: 'test1' },
+    });
+    fireEvent.change(screen.getByLabelText('API Client Secret'), {
+      target: { value: 'test2' },
     });
     fireEvent.change(screen.getByLabelText('Display Name'), {
       target: { value: 'displayName' },
     });
-    fireEvent.change(screen.getByLabelText('Webservice Short Name'), {
-      target: { value: 'test2' },
-    });
-    fireEvent.change(screen.getByLabelText('Token'), {
-      target: { value: 'token111' },
+    fireEvent.change(screen.getByLabelText('Degreed Base URL'), {
+      target: { value: 'https://test1.com' },
     });
     expect(screen.getByText('Submit')).not.toBeDisabled();
     fireEvent.click(screen.getByText('Submit'));
 
     const expectedConfig = {
       active: false,
-      moodle_base_url: 'https://www.test1.com',
-      service_short_name: 'test2',
+      degreed_base_url: 'https://test1.com',
       display_name: 'displayName',
-      token: 'token111',
+      client_id: 'test1',
+      client_secret: 'test2',
       enterprise_customer: enterpriseId,
     };
-    expect(LmsApiService.postNewMoodleConfig).toHaveBeenCalledWith(expectedConfig);
+    expect(LmsApiService.postNewDegreed2Config).toHaveBeenCalledWith(expectedConfig);
   });
 });

--- a/src/components/settings/SettingsLMSTab/tests/DegreedConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/DegreedConfig.test.jsx
@@ -6,15 +6,24 @@ import '@testing-library/jest-dom/extend-expect';
 
 import DegreedConfig from '../LMSConfigs/DegreedConfig';
 import { INVALID_LINK, INVALID_NAME } from '../../data/constants';
+import LmsApiService from '../../../../data/services/LmsApiService';
 
+jest.mock('../../../../data/services/LmsApiService');
+
+const enterpriseId = 'test-enterprise-id';
 const mockOnClick = jest.fn();
+const noExistingData = {};
+const existingConfigData = {
+  id: 1,
+};
 
 describe('<DegreedConfig />', () => {
   test('renders Degreed Config Form', () => {
     render(
       <DegreedConfig
-        id="test-enterprise-id"
+        enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
+        existingData={noExistingData}
       />,
     );
     screen.getByLabelText('Display Name');
@@ -28,8 +37,9 @@ describe('<DegreedConfig />', () => {
   test('test button disable', () => {
     render(
       <DegreedConfig
-        id="test-enterprise-id"
+        enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
+        existingData={noExistingData}
       />,
     );
     expect(screen.getByText('Submit')).toBeDisabled();
@@ -65,5 +75,95 @@ describe('<DegreedConfig />', () => {
       target: { value: 'https://test1.com' },
     });
     expect(screen.getByText('Submit')).not.toBeDisabled();
+  });
+  test('it edits existing configs on submit', () => {
+    render(
+      <DegreedConfig
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={existingConfigData}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('API Client ID'), {
+      target: { value: 'test1' },
+    });
+    fireEvent.change(screen.getByLabelText('API Client Secret'), {
+      target: { value: 'test2' },
+    });
+    fireEvent.change(screen.getByLabelText('Degreed User ID'), {
+      target: { value: 'test5' },
+    });
+    fireEvent.change(screen.getByLabelText('Degreed User Password'), {
+      target: { value: 'test5' },
+    });
+    fireEvent.change(screen.getByLabelText('Degreed Organization Code'), {
+      target: { value: 'test3' },
+    });
+    fireEvent.change(screen.getByLabelText('Display Name'), {
+      target: { value: 'displayName' },
+    });
+    fireEvent.change(screen.getByLabelText('Degreed Base URL'), {
+      target: { value: 'https://test1.com' },
+    });
+    expect(screen.getByText('Submit')).not.toBeDisabled();
+    fireEvent.click(screen.getByText('Submit'));
+
+    const expectedConfig = {
+      active: false,
+      degreed_base_url: 'https://test1.com',
+      degreed_company_id: 'test3',
+      degreed_user_id: 'test5',
+      degreed_user_password: 'test5',
+      display_name: 'displayName',
+      key: 'test1',
+      secret: 'test2',
+      enterprise_customer: enterpriseId,
+    };
+    expect(LmsApiService.updateDegreedConfig).toHaveBeenCalledWith(expectedConfig, 1);
+  });
+  test('it creates new configs on submit', () => {
+    render(
+      <DegreedConfig
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={noExistingData}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('API Client ID'), {
+      target: { value: 'test1' },
+    });
+    fireEvent.change(screen.getByLabelText('API Client Secret'), {
+      target: { value: 'test2' },
+    });
+    fireEvent.change(screen.getByLabelText('Degreed User ID'), {
+      target: { value: 'test5' },
+    });
+    fireEvent.change(screen.getByLabelText('Degreed User Password'), {
+      target: { value: 'test5' },
+    });
+    fireEvent.change(screen.getByLabelText('Degreed Organization Code'), {
+      target: { value: 'test3' },
+    });
+    fireEvent.change(screen.getByLabelText('Display Name'), {
+      target: { value: 'displayName' },
+    });
+    fireEvent.change(screen.getByLabelText('Degreed Base URL'), {
+      target: { value: 'https://test1.com' },
+    });
+    expect(screen.getByText('Submit')).not.toBeDisabled();
+    fireEvent.click(screen.getByText('Submit'));
+
+    const expectedConfig = {
+      active: false,
+      degreed_base_url: 'https://test1.com',
+      degreed_company_id: 'test3',
+      degreed_user_id: 'test5',
+      degreed_user_password: 'test5',
+      display_name: 'displayName',
+      key: 'test1',
+      secret: 'test2',
+      enterprise_customer: enterpriseId,
+    };
+    expect(LmsApiService.postNewDegreedConfig).toHaveBeenCalledWith(expectedConfig);
   });
 });

--- a/src/components/settings/SettingsLMSTab/tests/ExistingLMSCardDeck.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/ExistingLMSCardDeck.test.jsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import {
+  fireEvent,
+  render, screen,
+} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import ExistingLMSCardDeck from '../ExistingLMSCardDeck';
+import LmsApiService from '../../../../data/services/LmsApiService';
+
+jest.mock('../../../../data/services/LmsApiService');
+
+const enterpriseCustomerUuid = 'test-enterprise-id';
+const mockEditExistingConfigFn = jest.fn();
+const mockOnClick = jest.fn();
+const configData = [
+  {
+    channelCode: 'BLACKBOARD',
+    id: 1,
+    isValid: {},
+    active: true,
+    displayName: 'foobar',
+  },
+];
+
+const disabledConfigData = [
+  {
+    channelCode: 'BLACKBOARD',
+    id: 1,
+    isValid: {},
+    active: false,
+    displayName: 'foobar',
+  },
+];
+
+const incompleteConfigData = [
+  {
+    channelCode: 'BLACKBOARD',
+    id: 2,
+    isValid: { missing: ['client_id'] },
+    active: false,
+    displayName: 'barfoo',
+  },
+];
+
+describe('<ExistingLMSCardDeck />', () => {
+  it('renders active config card', () => {
+    render(
+      <ExistingLMSCardDeck
+        configData={configData}
+        editExistingConfig={mockEditExistingConfigFn}
+        onClick={mockOnClick}
+        enterpriseCustomerUuid={enterpriseCustomerUuid}
+      />,
+    );
+    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.getByText('foobar')).toBeInTheDocument();
+  });
+  it('renders incomplete config card', () => {
+    render(
+      <ExistingLMSCardDeck
+        configData={incompleteConfigData}
+        editExistingConfig={mockEditExistingConfigFn}
+        onClick={mockOnClick}
+        enterpriseCustomerUuid={enterpriseCustomerUuid}
+      />,
+    );
+    expect(screen.getByText('Incomplete')).toBeInTheDocument();
+    expect(screen.getByText('barfoo')).toBeInTheDocument();
+  });
+  it('renders multiple config cards', () => {
+    render(
+      <ExistingLMSCardDeck
+        configData={configData.concat(incompleteConfigData)}
+        editExistingConfig={mockEditExistingConfigFn}
+        onClick={mockOnClick}
+        enterpriseCustomerUuid={enterpriseCustomerUuid}
+      />,
+    );
+    expect(screen.getByText('barfoo')).toBeInTheDocument();
+    expect(screen.getByText('foobar')).toBeInTheDocument();
+  });
+  it('renders delete card action', () => {
+    render(
+      <ExistingLMSCardDeck
+        configData={incompleteConfigData}
+        editExistingConfig={mockEditExistingConfigFn}
+        onClick={mockOnClick}
+        enterpriseCustomerUuid={enterpriseCustomerUuid}
+      />,
+    );
+    expect(screen.getByTestId(`existing-lms-config-card-dropdown-${incompleteConfigData[0].id}`)).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId(`existing-lms-config-card-dropdown-${incompleteConfigData[0].id}`));
+
+    expect(screen.getByTestId('dropdown-delete-item')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('dropdown-delete-item'));
+    expect(LmsApiService.deleteBlackboardConfig).toHaveBeenCalledWith(incompleteConfigData[0].id);
+  });
+  it('renders disable card action', () => {
+    render(
+      <ExistingLMSCardDeck
+        configData={configData}
+        editExistingConfig={mockEditExistingConfigFn}
+        onClick={mockOnClick}
+        enterpriseCustomerUuid={enterpriseCustomerUuid}
+      />,
+    );
+    expect(screen.getByTestId(`existing-lms-config-card-dropdown-${configData[0].id}`)).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId(`existing-lms-config-card-dropdown-${configData[0].id}`));
+
+    expect(screen.getByTestId('dropdown-disable-item')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('dropdown-disable-item'));
+    const expectedConfigOptions = {
+      active: false,
+      enterprise_customer: enterpriseCustomerUuid,
+    };
+    expect(LmsApiService.updateBlackboardConfig).toHaveBeenCalledWith(expectedConfigOptions, configData[0].id);
+  });
+  it('renders enable card action', () => {
+    render(
+      <ExistingLMSCardDeck
+        configData={disabledConfigData}
+        editExistingConfig={mockEditExistingConfigFn}
+        onClick={mockOnClick}
+        enterpriseCustomerUuid={enterpriseCustomerUuid}
+      />,
+    );
+    expect(screen.getByTestId(`existing-lms-config-card-dropdown-${configData[0].id}`)).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId(`existing-lms-config-card-dropdown-${configData[0].id}`));
+
+    expect(screen.getByTestId('dropdown-enable-item')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('dropdown-enable-item'));
+    const expectedConfigOptions = {
+      active: true,
+      enterprise_customer: enterpriseCustomerUuid,
+    };
+    expect(LmsApiService.updateBlackboardConfig).toHaveBeenCalledWith(expectedConfigOptions, configData[0].id);
+  });
+});

--- a/src/components/settings/SettingsLMSTab/tests/LmsConfigPage.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/LmsConfigPage.test.jsx
@@ -12,9 +12,11 @@ import {
   CANVAS_TYPE,
   CORNERSTONE_TYPE,
   DEGREED_TYPE,
+  DEGREED2_TYPE,
   MOODLE_TYPE,
   SAP_TYPE,
 } from '../../data/constants';
+import { channelMapping } from '../../../../utils';
 
 import SettingsLMSTab from '../index';
 import { buttonBool } from '../utils';
@@ -48,83 +50,171 @@ const SettingsLMSWrapper = () => (
 describe('<SettingsLMSTab />', () => {
   it('Renders with all LMS cards present', () => {
     renderWithRouter(<SettingsLMSWrapper />);
-    expect(screen.queryByText(BLACKBOARD_TYPE)).toBeTruthy();
-    expect(screen.queryByText(CANVAS_TYPE)).toBeTruthy();
-    expect(screen.queryByText(CORNERSTONE_TYPE)).toBeTruthy();
-    expect(screen.queryByText(DEGREED_TYPE)).toBeTruthy();
-    expect(screen.queryByText(MOODLE_TYPE)).toBeTruthy();
-    expect(screen.queryByText(SAP_TYPE)).toBeTruthy();
+    expect(screen.queryByText(channelMapping[BLACKBOARD_TYPE].displayName)).toBeTruthy();
+    expect(screen.queryByText(channelMapping[CANVAS_TYPE].displayName)).toBeTruthy();
+    expect(screen.queryByText(channelMapping[CORNERSTONE_TYPE].displayName)).toBeTruthy();
+    expect(screen.queryByText(channelMapping[DEGREED2_TYPE].displayName)).toBeTruthy();
+    expect(screen.queryByText(channelMapping[MOODLE_TYPE].displayName)).toBeTruthy();
+    expect(screen.queryByText(channelMapping[SAP_TYPE].displayName)).toBeTruthy();
   });
   test('Blackboard card cancel flow', async () => {
     renderWithRouter(<SettingsLMSWrapper />);
-    const blackboardCard = screen.getByText(BLACKBOARD_TYPE);
+    const blackboardCard = screen.getByText(channelMapping[BLACKBOARD_TYPE].displayName);
     fireEvent.click(blackboardCard);
     expect(screen.queryByText('Connect Blackboard')).toBeTruthy();
+    fireEvent.change(screen.getByLabelText('Display Name'), {
+      target: { value: 'displayName' },
+    });
     const cancelButton = screen.getByText('Cancel');
     fireEvent.click(cancelButton);
-    expect(screen.queryByText('Do you want to save your work?')).toBeTruthy();
+    expect(await screen.findByText('Do you want to save your work?')).toBeTruthy();
     const exitButton = screen.getByText('Exit without saving');
     fireEvent.click(exitButton);
     expect(screen.queryByText('Connect Blackboard')).toBeFalsy();
   });
   test('Canvas card cancel flow', async () => {
     renderWithRouter(<SettingsLMSWrapper />);
-    const canvasCard = screen.getByText(CANVAS_TYPE);
+    const canvasCard = screen.getByText(channelMapping[CANVAS_TYPE].displayName);
     fireEvent.click(canvasCard);
     expect(screen.queryByText('Connect Canvas')).toBeTruthy();
+    fireEvent.change(screen.getByLabelText('Display Name'), {
+      target: { value: 'displayName' },
+    });
     const cancelButton = screen.getByText('Cancel');
     fireEvent.click(cancelButton);
-    expect(screen.queryByText('Do you want to save your work?')).toBeTruthy();
+    expect(await screen.findByText('Do you want to save your work?')).toBeTruthy();
     const exitButton = screen.getByText('Exit without saving');
     fireEvent.click(exitButton);
     expect(screen.queryByText('Connect Canvas')).toBeFalsy();
   });
   test('Cornerstone card cancel flow', async () => {
     renderWithRouter(<SettingsLMSWrapper />);
-    const cornerstoneCard = screen.getByText(CORNERSTONE_TYPE);
+    const cornerstoneCard = screen.getByText(channelMapping[CORNERSTONE_TYPE].displayName);
     fireEvent.click(cornerstoneCard);
     expect(screen.queryByText('Connect Cornerstone')).toBeTruthy();
+    fireEvent.change(screen.getByLabelText('Display Name'), {
+      target: { value: 'displayName' },
+    });
     const cancelButton = screen.getByText('Cancel');
     fireEvent.click(cancelButton);
-    expect(screen.queryByText('Do you want to save your work?')).toBeTruthy();
+    expect(await screen.findByText('Do you want to save your work?')).toBeTruthy();
     const exitButton = screen.getByText('Exit without saving');
     fireEvent.click(exitButton);
     expect(screen.queryByText('Connect Cornerstone')).toBeFalsy();
   });
   test('Degreed card cancel flow', async () => {
     renderWithRouter(<SettingsLMSWrapper />);
-    const degreedCard = screen.getByText(DEGREED_TYPE);
+    const degreedCard = screen.getByText(channelMapping[DEGREED2_TYPE].displayName);
     fireEvent.click(degreedCard);
     expect(screen.queryByText('Connect Degreed')).toBeTruthy();
+    fireEvent.change(screen.getByLabelText('Display Name'), {
+      target: { value: 'displayName' },
+    });
     const cancelButton = screen.getByText('Cancel');
     fireEvent.click(cancelButton);
-    expect(screen.queryByText('Do you want to save your work?')).toBeTruthy();
+    expect(await screen.findByText('Do you want to save your work?')).toBeTruthy();
     const exitButton = screen.getByText('Exit without saving');
     fireEvent.click(exitButton);
     expect(screen.queryByText('Connect Degreed')).toBeFalsy();
   });
   test('Moodle card cancel flow', async () => {
     renderWithRouter(<SettingsLMSWrapper />);
-    const moodleCard = screen.getByText(MOODLE_TYPE);
+    const moodleCard = screen.getByText(channelMapping[MOODLE_TYPE].displayName);
     fireEvent.click(moodleCard);
     expect(screen.queryByText('Connect Moodle')).toBeTruthy();
+    fireEvent.change(screen.getByLabelText('Display Name'), {
+      target: { value: 'displayName' },
+    });
     const cancelButton = screen.getByText('Cancel');
     fireEvent.click(cancelButton);
-    expect(screen.queryByText('Do you want to save your work?')).toBeTruthy();
+    expect(await screen.findByText('Do you want to save your work?')).toBeTruthy();
     const exitButton = screen.getByText('Exit without saving');
     fireEvent.click(exitButton);
     expect(screen.queryByText('Connect Moodle')).toBeFalsy();
   });
   test('SAP card cancel flow', async () => {
     renderWithRouter(<SettingsLMSWrapper />);
-    const sapCard = screen.getByText(SAP_TYPE);
+    const sapCard = screen.getByText(channelMapping[SAP_TYPE].displayName);
+    fireEvent.click(sapCard);
+    expect(screen.queryByText('Connect SAP')).toBeTruthy();
+    fireEvent.change(screen.getByLabelText('Display Name'), {
+      target: { value: 'displayName' },
+    });
+    const cancelButton = screen.getByText('Cancel');
+    fireEvent.click(cancelButton);
+    expect(await screen.findByText('Do you want to save your work?')).toBeTruthy();
+    const exitButton = screen.getByText('Exit without saving');
+    fireEvent.click(exitButton);
+    expect(screen.queryByText('Connect SAP')).toBeFalsy();
+  });
+  test('No action Moodle card cancel flow', async () => {
+    renderWithRouter(<SettingsLMSWrapper />);
+    const sapCard = screen.getByText(channelMapping[MOODLE_TYPE].displayName);
+    fireEvent.click(sapCard);
+    expect(screen.queryByText('Connect Moodle')).toBeTruthy();
+    const cancelButton = screen.getByText('Cancel');
+    fireEvent.click(cancelButton);
+    expect(screen.queryByText('Exit without saving')).toBeFalsy();
+    expect(screen.queryByText('Connect Moodle')).toBeFalsy();
+  });
+  test('No action Degreed2 card cancel flow', async () => {
+    renderWithRouter(<SettingsLMSWrapper />);
+    const sapCard = screen.getByText(channelMapping[DEGREED2_TYPE].displayName);
+    fireEvent.click(sapCard);
+    expect(screen.queryByText('Connect Degreed')).toBeTruthy();
+    const cancelButton = screen.getByText('Cancel');
+    fireEvent.click(cancelButton);
+    expect(screen.queryByText('Exit without saving')).toBeFalsy();
+    expect(screen.queryByText('Connect Degreed')).toBeFalsy();
+  });
+  test('No action Degreed card cancel flow', async () => {
+    renderWithRouter(<SettingsLMSWrapper />);
+    const sapCard = screen.getByText(channelMapping[DEGREED_TYPE].displayName);
+    fireEvent.click(sapCard);
+    expect(screen.queryByText('Connect Degreed')).toBeTruthy();
+    const cancelButton = screen.getByText('Cancel');
+    fireEvent.click(cancelButton);
+    expect(screen.queryByText('Exit without saving')).toBeFalsy();
+    expect(screen.queryByText('Connect Degreed')).toBeFalsy();
+  });
+  test('No action Cornerstone card cancel flow', async () => {
+    renderWithRouter(<SettingsLMSWrapper />);
+    const sapCard = screen.getByText(channelMapping[CORNERSTONE_TYPE].displayName);
+    fireEvent.click(sapCard);
+    expect(screen.queryByText('Connect Cornerstone')).toBeTruthy();
+    const cancelButton = screen.getByText('Cancel');
+    fireEvent.click(cancelButton);
+    expect(screen.queryByText('Exit without saving')).toBeFalsy();
+    expect(screen.queryByText('Connect Cornerstone')).toBeFalsy();
+  });
+  test('No action Canvas card cancel flow', async () => {
+    renderWithRouter(<SettingsLMSWrapper />);
+    const sapCard = screen.getByText(channelMapping[CANVAS_TYPE].displayName);
+    fireEvent.click(sapCard);
+    expect(screen.queryByText('Connect Canvas')).toBeTruthy();
+    const cancelButton = screen.getByText('Cancel');
+    fireEvent.click(cancelButton);
+    expect(screen.queryByText('Exit without saving')).toBeFalsy();
+    expect(screen.queryByText('Connect Canvas')).toBeFalsy();
+  });
+  test('No action Blackboard card cancel flow', async () => {
+    renderWithRouter(<SettingsLMSWrapper />);
+    const sapCard = screen.getByText(channelMapping[BLACKBOARD_TYPE].displayName);
+    fireEvent.click(sapCard);
+    expect(screen.queryByText('Connect Blackboard')).toBeTruthy();
+    const cancelButton = screen.getByText('Cancel');
+    fireEvent.click(cancelButton);
+    expect(screen.queryByText('Exit without saving')).toBeFalsy();
+    expect(screen.queryByText('Connect Blackbard')).toBeFalsy();
+  });
+  test('No action SAP card cancel flow', async () => {
+    renderWithRouter(<SettingsLMSWrapper />);
+    const sapCard = screen.getByText(channelMapping[SAP_TYPE].displayName);
     fireEvent.click(sapCard);
     expect(screen.queryByText('Connect SAP')).toBeTruthy();
     const cancelButton = screen.getByText('Cancel');
     fireEvent.click(cancelButton);
-    expect(screen.queryByText('Do you want to save your work?')).toBeTruthy();
-    const exitButton = screen.getByText('Exit without saving');
-    fireEvent.click(exitButton);
+    expect(screen.queryByText('Exit without saving')).toBeFalsy();
     expect(screen.queryByText('Connect SAP')).toBeFalsy();
   });
   test('test button text', () => {

--- a/src/components/settings/SettingsLMSTab/tests/SAPConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/SAPConfig.test.jsx
@@ -6,15 +6,24 @@ import '@testing-library/jest-dom/extend-expect';
 
 import SAPConfig from '../LMSConfigs/SAPConfig';
 import { INVALID_LINK, INVALID_NAME } from '../../data/constants';
+import LmsApiService from '../../../../data/services/LmsApiService';
 
+jest.mock('../../../../data/services/LmsApiService');
+
+const enterpriseId = 'test-enterprise-id';
 const mockOnClick = jest.fn();
+const noExistingData = {};
+const existingConfigData = {
+  id: 1,
+};
 
 describe('<SAPConfig />', () => {
   test('renders SAP Config Form', () => {
     render(
       <SAPConfig
-        id="test-enterprise-id"
+        enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
+        existingData={noExistingData}
       />,
     );
     screen.getByLabelText('Display Name');
@@ -28,8 +37,9 @@ describe('<SAPConfig />', () => {
   test('test button disable', () => {
     render(
       <SAPConfig
-        id="test-enterprise-id"
+        enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
+        existingData={noExistingData}
       />,
     );
     expect(screen.getByText('Submit')).toBeDisabled();
@@ -64,5 +74,89 @@ describe('<SAPConfig />', () => {
       target: { value: 'test2' },
     });
     expect(screen.getByText('Submit')).not.toBeDisabled();
+  });
+  test('it edits existing configs on submit', () => {
+    render(
+      <SAPConfig
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={existingConfigData}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('SAP Company ID'), {
+      target: { value: '3' },
+    });
+    fireEvent.change(screen.getByLabelText('SAP User ID'), {
+      target: { value: 'test4' },
+    });
+    fireEvent.change(screen.getByLabelText('OAuth Client ID'), {
+      target: { value: 'test5' },
+    });
+    fireEvent.change(screen.getByLabelText('OAuth Client Secret'), {
+      target: { value: 'test6' },
+    });
+    fireEvent.change(screen.getByLabelText('SAP Base URL'), {
+      target: { value: 'https://www.test.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Display Name'), {
+      target: { value: 'displayName' },
+    });
+    expect(screen.getByText('Submit')).not.toBeDisabled();
+    fireEvent.click(screen.getByText('Submit'));
+
+    const expectedConfig = {
+      active: false,
+      sapsf_base_url: 'https://www.test.com',
+      sapsf_company_id: '3',
+      sapsf_user_id: 'test4',
+      secret: 'test6',
+      key: 'test5',
+      user_type: 'admin',
+      display_name: 'displayName',
+      enterprise_customer: enterpriseId,
+    };
+    expect(LmsApiService.updateSuccessFactorsConfig).toHaveBeenCalledWith(expectedConfig, 1);
+  });
+  test('it creates new configs on submit', () => {
+    render(
+      <SAPConfig
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={noExistingData}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('SAP Company ID'), {
+      target: { value: '3' },
+    });
+    fireEvent.change(screen.getByLabelText('SAP User ID'), {
+      target: { value: 'test4' },
+    });
+    fireEvent.change(screen.getByLabelText('OAuth Client ID'), {
+      target: { value: 'test5' },
+    });
+    fireEvent.change(screen.getByLabelText('OAuth Client Secret'), {
+      target: { value: 'test6' },
+    });
+    fireEvent.change(screen.getByLabelText('SAP Base URL'), {
+      target: { value: 'https://www.test.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Display Name'), {
+      target: { value: 'displayName' },
+    });
+    expect(screen.getByText('Submit')).not.toBeDisabled();
+    fireEvent.click(screen.getByText('Submit'));
+
+    const expectedConfig = {
+      active: false,
+      sapsf_base_url: 'https://www.test.com',
+      sapsf_company_id: '3',
+      sapsf_user_id: 'test4',
+      secret: 'test6',
+      key: 'test5',
+      user_type: 'admin',
+      display_name: 'displayName',
+      enterprise_customer: enterpriseId,
+    };
+    expect(LmsApiService.postNewSuccessFactorsConfig).toHaveBeenCalledWith(expectedConfig);
   });
 });

--- a/src/components/settings/SettingsTabs.jsx
+++ b/src/components/settings/SettingsTabs.jsx
@@ -9,6 +9,8 @@ import {
   generatePath,
   useRouteMatch,
 } from 'react-router-dom';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 import { useCurrentSettingsTab } from './data/hooks';
 import {
@@ -19,7 +21,7 @@ import {
 import SettingsAccessTab from './SettingsAccessTab';
 import SettingsLMSTab from './SettingsLMSTab';
 
-const SettingsTabs = () => {
+const SettingsTabs = ({ enterpriseId }) => {
   const tab = useCurrentSettingsTab();
 
   const history = useHistory();
@@ -52,11 +54,19 @@ const SettingsTabs = () => {
           <SettingsAccessTab />
         </Tab>
         <Tab eventKey={SETTINGS_TABS_VALUES.lms} title={SETTINGS_TAB_LABELS.lms}>
-          <SettingsLMSTab />
+          <SettingsLMSTab enterpriseId={enterpriseId} />
         </Tab>
       </Tabs>
     </Container>
   );
 };
 
-export default SettingsTabs;
+const mapStateToProps = state => ({
+  enterpriseId: state.portalConfiguration.enterpriseId,
+});
+
+SettingsTabs.propTypes = {
+  enterpriseId: PropTypes.string.isRequired,
+};
+
+export default connect(mapStateToProps)(SettingsTabs);

--- a/src/components/settings/data/constants.js
+++ b/src/components/settings/data/constants.js
@@ -7,12 +7,15 @@ const LMS_TAB_LABEL = 'LMS';
 export const HELP_CENTER_LINK = 'https://business-support.edx.org/hc/en-us/categories/360000368453-Integrations';
 export const HELP_CENTER_EMAIL = 'customersuccess@edx.org';
 export const SUCCESS_LABEL = 'success';
+export const TOGGLE_SUCCESS_LABEL = 'toggle success';
+export const DELETE_SUCCESS_LABEL = 'delete success';
 
-export const BLACKBOARD_TYPE = 'Blackboard';
-export const CANVAS_TYPE = 'Canvas';
-export const CORNERSTONE_TYPE = 'Cornerstone';
-export const DEGREED_TYPE = 'Degreed';
-export const MOODLE_TYPE = 'Moodle';
+export const BLACKBOARD_TYPE = 'BLACKBOARD';
+export const CANVAS_TYPE = 'CANVAS';
+export const CORNERSTONE_TYPE = 'CSOD';
+export const DEGREED_TYPE = 'DEGREED';
+export const DEGREED2_TYPE = 'DEGREED2';
+export const MOODLE_TYPE = 'MOODLE';
 export const SAP_TYPE = 'SAP';
 
 export const INVALID_LINK = 'Link must be properly formatted and start with http or https';

--- a/src/components/settings/settings.scss
+++ b/src/components/settings/settings.scss
@@ -1,3 +1,50 @@
+@import "~@edx/brand/paragon/variables";
+
+.lms-card-content .pgn__card-header-content {
+  flex-grow: 1 !important;
+}
+
 .lms-icon {
   max-width: 35px;
+}
+
+.lms-card-hover {
+  &:hover {
+    box-shadow: $box-shadow;
+    cursor: pointer;
+  }
+
+  &:focus,
+  &.focus {
+    box-shadow: $box-shadow;
+    outline: none;
+    border-color: $dark-300;
+  }
+}
+
+.lms-card {
+  width: 22rem !important;
+  box-shadow: $box-shadow-sm;
+
+  &:hover {
+    box-shadow: $box-shadow;
+    cursor: pointer;
+  }
+
+  &:focus,
+  &.focus {
+    box-shadow: $box-shadow;
+    outline: none;
+    border-color: $dark-300;
+  }
+}
+
+.lms-card-title-overflow {
+  text-overflow: ellipsis !important;
+  overflow: hidden !important;
+  white-space: nowrap;
+}
+
+.existing-lms-card-width {
+  width: 70rem !important;
 }

--- a/src/components/settings/tests/SettingsTabs.test.jsx
+++ b/src/components/settings/tests/SettingsTabs.test.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
 import {
   screen,
   render,
@@ -6,6 +8,7 @@ import {
   act,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import configureMockStore from 'redux-mock-store';
 
 import { MemoryRouter, Route } from 'react-router-dom';
 import SettingsTabs from '../SettingsTabs';
@@ -24,11 +27,26 @@ jest.mock(
   () => () => (<div>{LMS_MOCK_CONTENT}</div>),
 );
 
+const enterpriseId = 'test-enterprise';
+const initialStore = {
+  portalConfiguration: {
+    enterpriseId,
+    enterpriseSlug: 'sluggy',
+    enableLearnerPortal: false,
+  },
+};
+
+const mockStore = configureMockStore([thunk]);
+const getMockStore = store => mockStore(store);
+const store = getMockStore({ ...initialStore });
+
 const settingsTabsWithRouter = () => (
   <MemoryRouter initialEntries={['settings/']}>
-    <Route path="settings/">
-      <SettingsTabs />
-    </Route>
+    <Provider store={store}>
+      <Route path="settings/">
+        <SettingsTabs />
+      </Route>
+    </Provider>
   </MemoryRouter>
 );
 

--- a/src/data/services/LmsApiService.js
+++ b/src/data/services/LmsApiService.js
@@ -147,6 +147,10 @@ class LmsApiService {
     return LmsApiService.apiClient().put(`${LmsApiService.lmsIntegrationUrl}/moodle/configuration/${configId}/`, formData);
   }
 
+  static deleteMoodleConfig(configId) {
+    return LmsApiService.apiClient().delete(`${LmsApiService.lmsIntegrationUrl}/moodle/configuration/${configId}/`);
+  }
+
   static fetchCanvasConfig(uuid) {
     return LmsApiService.apiClient().get(`${LmsApiService.lmsIntegrationUrl}/canvas/configuration/?enterprise_customer=${uuid}`);
   }
@@ -157,6 +161,10 @@ class LmsApiService {
 
   static updateCanvasConfig(formData, id) {
     return LmsApiService.apiClient().put(`${LmsApiService.lmsIntegrationUrl}/canvas/configuration/${id}/`, formData);
+  }
+
+  static deleteCanvasConfig(configId) {
+    return LmsApiService.apiClient().delete(`${LmsApiService.lmsIntegrationUrl}/Canvas/configuration/${configId}/`);
   }
 
   static fetchBlackboardConfig(uuid) {
@@ -171,6 +179,10 @@ class LmsApiService {
     return LmsApiService.apiClient().put(`${LmsApiService.lmsIntegrationUrl}/blackboard/configuration/${configId}/`, formData);
   }
 
+  static deleteBlackboardConfig(configId) {
+    return LmsApiService.apiClient().delete(`${LmsApiService.lmsIntegrationUrl}/blackboard/configuration/${configId}/`);
+  }
+
   static fetchSuccessFactorsConfig(uuid) {
     return LmsApiService.apiClient().get(`${LmsApiService.lmsIntegrationUrl}/sap_success_factors/configuration/?enterprise_customer=${uuid}`);
   }
@@ -181,6 +193,10 @@ class LmsApiService {
 
   static updateSuccessFactorsConfig(formData, configId) {
     return LmsApiService.apiClient().put(`${LmsApiService.lmsIntegrationUrl}/sap_success_factors/configuration/${configId}/`, formData);
+  }
+
+  static deleteSuccessFactorsConfig(configId) {
+    return LmsApiService.apiClient().delete(`${LmsApiService.lmsIntegrationUrl}/sap_success_factors/configuration/${configId}/`);
   }
 
   static fetchDegreedConfig(uuid) {
@@ -195,6 +211,22 @@ class LmsApiService {
     return LmsApiService.apiClient().put(`${LmsApiService.lmsIntegrationUrl}/degreed/configuration/${configId}/`, formData);
   }
 
+  static deleteDegreedConfig(configId) {
+    return LmsApiService.apiClient().delete(`${LmsApiService.lmsIntegrationUrl}/degreed/configuration/${configId}/`);
+  }
+
+  static postNewDegreed2Config(formData) {
+    return LmsApiService.apiClient().post(`${LmsApiService.lmsIntegrationUrl}/degreed2/configuration/`, formData);
+  }
+
+  static updateDegreed2Config(formData, configId) {
+    return LmsApiService.apiClient().put(`${LmsApiService.lmsIntegrationUrl}/degreed2/configuration/${configId}/`, formData);
+  }
+
+  static deleteDegreed2Config(configId) {
+    return LmsApiService.apiClient().delete(`${LmsApiService.lmsIntegrationUrl}/degreed2/configuration/${configId}/`);
+  }
+
   static fetchCornerstoneConfig(uuid) {
     return LmsApiService.apiClient().get(`${LmsApiService.lmsIntegrationUrl}/cornerstone/configuration/?enterprise_customer=${uuid}`);
   }
@@ -207,6 +239,10 @@ class LmsApiService {
     return LmsApiService.apiClient().put(`${LmsApiService.lmsIntegrationUrl}/cornerstone/configuration/${configId}/`, formData);
   }
 
+  static deleteCornerstoneConfig(configId) {
+    return LmsApiService.apiClient().delete(`${LmsApiService.lmsIntegrationUrl}/cornerstone/configuration/${configId}/`);
+  }
+
   static createPendingEnterpriseUsers(formData, uuid) {
     return LmsApiService.apiClient().post(`${LmsApiService.createPendingUsersUrl}/${uuid}`, formData);
   }
@@ -217,6 +253,11 @@ class LmsApiService {
 
   static markBannerNotificationAsRead(formData) {
     return LmsApiService.apiClient().post(LmsApiService.notificationReadUrl, formData);
+  }
+
+  static fetchEnterpriseCustomerIntegrationConfigs(options) {
+    const queryParams = new URLSearchParams(options);
+    return LmsApiService.apiClient().get(`${LmsApiService.lmsIntegrationUrl}/configs/?${queryParams.toString()}`);
   }
 
   /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import camelCase from 'lodash/camelCase';
 import snakeCase from 'lodash/snakeCase';
 import isArray from 'lodash/isArray';
 import mergeWith from 'lodash/mergeWith';
@@ -10,7 +11,7 @@ import { history } from '@edx/frontend-platform/initialize';
 import { features } from './config';
 
 import {
-  BLACKBOARD_TYPE, CANVAS_TYPE, CORNERSTONE_TYPE, DEGREED_TYPE, MOODLE_TYPE,
+  BLACKBOARD_TYPE, CANVAS_TYPE, CORNERSTONE_TYPE, DEGREED_TYPE, DEGREED2_TYPE, MOODLE_TYPE, SAP_TYPE,
 } from './components/settings/data/constants';
 import BlackboardIcon from './icons/Blackboard.svg';
 import CanvasIcon from './icons/Canvas.svg';
@@ -19,22 +20,7 @@ import DegreedIcon from './icons/Degreed.png';
 import MoodleIcon from './icons/Moodle.png';
 import SAPIcon from './icons/SAP.svg';
 
-export function getLMSIcon(LMSType) {
-  switch (LMSType) {
-    case BLACKBOARD_TYPE:
-      return BlackboardIcon;
-    case CANVAS_TYPE:
-      return CanvasIcon;
-    case CORNERSTONE_TYPE:
-      return CornerstoneIcon;
-    case DEGREED_TYPE:
-      return DegreedIcon;
-    case MOODLE_TYPE:
-      return MoodleIcon;
-    default:
-      return SAPIcon;
-  }
-}
+import LmsApiService from './data/services/LmsApiService';
 
 const formatTimestamp = ({ timestamp, format = 'MMMM D, YYYY' }) => {
   if (timestamp) {
@@ -151,6 +137,23 @@ const modifyObjectKeys = (object, modify) => {
   return result;
 };
 
+const camelCaseDict = (data) => {
+  const transformedData = {};
+  [...Object.entries(data)]
+    .forEach(entry => {
+      [, transformedData[camelCase(entry[0])]] = entry;
+    });
+  return transformedData;
+};
+
+const camelCaseDictArray = (data) => {
+  const transformedData = [];
+  data.forEach(config => {
+    transformedData.push(camelCaseDict(config));
+  });
+  return transformedData;
+};
+
 const snakeCaseDict = (data) => {
   const transformedData = {};
   [...Object.entries(data)]
@@ -238,7 +241,55 @@ function urlValidation(urlString) {
 
 const normalizeFileUpload = (value) => value && value.split(/\r\n|\n/);
 
+const channelMapping = {
+  [BLACKBOARD_TYPE]: {
+    displayName: 'Blackboard',
+    icon: BlackboardIcon,
+    update: LmsApiService.updateBlackboardConfig,
+    delete: LmsApiService.deleteBlackboardConfig,
+  },
+  [CANVAS_TYPE]: {
+    displayName: 'Canvas',
+    icon: CanvasIcon,
+    update: LmsApiService.updateCanvasConfig,
+    delete: LmsApiService.deleteCanvasConfig,
+  },
+  [CORNERSTONE_TYPE]: {
+    displayName: 'Cornerstone',
+    icon: CornerstoneIcon,
+    update: LmsApiService.updateCornerstoneConfig,
+    delete: LmsApiService.deleteCornerstoneConfig,
+  },
+  [MOODLE_TYPE]: {
+    displayName: 'Moodle',
+    icon: MoodleIcon,
+    update: LmsApiService.updateMoodleConfig,
+    delete: LmsApiService.deleteMoodleConfig,
+  },
+  [SAP_TYPE]: {
+    displayName: 'SAP',
+    icon: SAPIcon,
+    update: LmsApiService.updateSuccessFactorsConfig,
+    delete: LmsApiService.deleteSuccessFactorsConfig,
+  },
+  [DEGREED2_TYPE]: {
+    displayName: 'Degreed',
+    icon: DegreedIcon,
+    update: LmsApiService.updateDegreed2Config,
+    delete: LmsApiService.deleteDegreed2Config,
+  },
+  [DEGREED_TYPE]: {
+    displayName: 'Degreed',
+    icon: DegreedIcon,
+    update: LmsApiService.updateDegreedConfig,
+    delete: LmsApiService.deleteDegreedConfig,
+  },
+};
+
 export {
+  camelCaseDict,
+  camelCaseDictArray,
+  channelMapping,
   formatPercentage,
   formatPassedTimestamp,
   formatTimestamp,

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,0 +1,39 @@
+import {
+  camelCaseDict, camelCaseDictArray, snakeCaseDict, snakeCaseFormData,
+} from './utils';
+
+describe('utils', () => {
+  describe('camel casing methods', () => {
+    it('formats dictionaries into camel case', () => {
+      const startingSnakeCaseDict = { snake_case_key: 'foobar' };
+      const expectedCamelCaseDict = { snakeCaseKey: 'foobar' };
+      expect(camelCaseDict(startingSnakeCaseDict)).toEqual(expectedCamelCaseDict);
+    });
+    it('does not format dictionary value', () => {
+      const startingDict = { fooBar: 'example_value' };
+      expect(camelCaseDict(startingDict)).toEqual(startingDict);
+    });
+    it('formats an array of dictionaries into camel case', () => {
+      const snakeCaseDictArray = [{ foo_bar: 'example_value' }, { ayy_lmao: 'example_value' }];
+      const expectedCamelCaseArray = [{ fooBar: 'example_value' }, { ayyLmao: 'example_value' }];
+      expect(camelCaseDictArray(snakeCaseDictArray)).toEqual(expectedCamelCaseArray);
+    });
+  });
+
+  describe('snake casing methods', () => {
+    it('formats dictionaries into snake case', () => {
+      const startingSnakeCaseDict = { snakeCaseKey: 'foobar' };
+      const expectedCamelCaseDict = { snake_case_key: 'foobar' };
+      expect(snakeCaseDict(startingSnakeCaseDict)).toEqual(expectedCamelCaseDict);
+    });
+    it('does not format dictionary value', () => {
+      const startingDict = { foo_bar: 'example_value' };
+      expect(snakeCaseDict(startingDict)).toEqual(startingDict);
+    });
+    it('format form data to snake case', () => {
+      const camelCaseFormData = new FormData();
+      camelCaseFormData.append('userName', 'ayyLmao');
+      expect(snakeCaseFormData(camelCaseFormData).get('user_name')).toEqual('ayyLmao');
+    });
+  });
+});


### PR DESCRIPTION
New features:
- LMS config settings page now fetches customer config data on load
    - submitting a config or toggling a config will trigger a re-fetch 
- existing configurations are displayed as cards above the creation cards
    - if and only if configs exists, creation cards are hidden behind a button
    - navigating from a config form back to the landing page, will reset the show create cards buttons (if there are existing configs) 
- existing configuration cards display 1) channel type 2) display name 3) config status
- user is able to toggle completed configs from active to inactive
    - basic error handling added to toggle API call
- user is able to edit existing config information
    - clicking edit will bring the user to the config form with all existing fields automatically filled out
    - if the user navigates from the edit button, the form will make an update API request, not a post
- swapped Degreed create config card with Degreed2 create card
    - Users are still able to edit existing Degreed configs
- unit tests for non-state based functionality
- various bug fixes

<img width="800" alt="image" src="https://user-images.githubusercontent.com/67655836/154767203-6958d94c-5ee5-4f69-a36a-d56fab7cdb91.png">

<img width="359" alt="image" src="https://user-images.githubusercontent.com/67655836/154767246-7ba4e9c1-b1f0-4dcf-8802-648f324494ac.png">

prefilled form when editing 
<img width="799" alt="image" src="https://user-images.githubusercontent.com/67655836/154767294-cc8939bf-4a2f-48af-989e-a4f00ec6ad9e.png">


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
