### PR TITLE
build: revert nvmrc nonoring in GH workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Setup Nodejs Env
-      run: echo "NODE_VER=`cat .nvmrc`" >> $GITHUB_ENV
     - name: Setup Nodejs
-      uses: dcodeIO/setup-node-nvm@v4
+      uses: actions/setup-node@v1
       with:
-        node-version: "${{ env.NODE_VER }}"
+        node-version: 12
     - name: Validate no uncommitted package-lock changes
       run: make validate-no-uncommitted-package-lock-changes
     - name: Install dependencies


### PR DESCRIPTION
Because ArbiBOM now has their own method of updating these workflows, we don't need to do this anymore

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
