### PR TITLE
test: fix act warnings

### DIFF
--- a/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.test.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.test.jsx
@@ -311,8 +311,8 @@ describe('BulkEnrollmentSubmit', () => {
       />,
     );
     const button = screen.getByTestId(FINAL_BUTTON_TEST_ID);
-    await userEvent.click(button);
-    await flushPromises();
+    userEvent.click(button);
+    await act(() => flushPromises());
 
     expect(addToast).toBeCalledTimes(0);
     expect(logError).toBeCalledTimes(1);
@@ -330,8 +330,10 @@ describe('BulkEnrollmentSubmit', () => {
     );
     const button = screen.getByTestId(FINAL_BUTTON_TEST_ID);
 
-    await userEvent.click(button);
-    await flushPromises();
+    userEvent.click(button);
+    // interesting: doing an act(() => mockPromiseReject) does not work!
+    // we still get the act warnings.
+    await act(() => flushPromises());
     expect(screen.getByText(ALERT_MODAL_TITLE_TEXT)).toBeInTheDocument();
     expect(addToast).toBeCalledTimes(0);
   });
@@ -348,8 +350,8 @@ describe('BulkEnrollmentSubmit', () => {
       />,
     );
     const button = screen.getByTestId(FINAL_BUTTON_TEST_ID);
-    await userEvent.click(button);
-    await flushPromises();
+    userEvent.click(button);
+    await act(() => flushPromises());
     const alertModalCloseButton = screen.getByText('OK');
     userEvent.click(alertModalCloseButton);
     expect(screen.queryByText(ALERT_MODAL_TITLE_TEXT)).not.toBeInTheDocument();


### PR DESCRIPTION
By waiting on promise to be fulfilled and wrapping that in an act

I don't understand why act(() => promiseRejected) does not work, but the use of act against the flushPromises that was already there, does work.

Reference: https://kentcdodds.com/blog/fix-the-not-wrapped-in-act-warning?ck_subscriber_id=1215839415

ENT-3630

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
