### PR TITLE
fix: add pb-4 spacing to subs mgmt card when not active

### DIFF
--- a/src/components/subscriptions/SubscriptionCard.jsx
+++ b/src/components/subscriptions/SubscriptionCard.jsx
@@ -99,24 +99,35 @@ const SubscriptionCard = ({
     );
   };
 
-  const renderCardSection = () => (subscriptionStatus === ACTIVE && (
-    <Card.Section
-      title="Licenses"
-      muted
-    >
-      <Row className="d-flex flex-row justify-content-between w-md-75">
-        {['Assigned', 'Activated', 'Allocated', 'Unassigned'].map(licenseStatus => (
-          <Col xs="6" md="auto" className="d-flex flex-column mb-3 mb-md-0" key={licenseStatus}>
-            <span className="small">{licenseStatus}</span>
-            <span>{licenses[licenseStatus.toLowerCase()]} of {licenses.total}</span>
-          </Col>
-        ))}
-      </Row>
-    </Card.Section>
-  ));
+  const renderCardSection = () => {
+    if (subscriptionStatus !== ACTIVE) {
+      return null;
+    }
+
+    return (
+      <Card.Section
+        title="Licenses"
+        muted
+      >
+        <Row className="d-flex flex-row justify-content-between w-md-75">
+          {['Assigned', 'Activated', 'Allocated', 'Unassigned'].map(licenseStatus => (
+            <Col xs="6" md="auto" className="d-flex flex-column mb-3 mb-md-0" key={licenseStatus}>
+              <span className="small">{licenseStatus}</span>
+              <span>{licenses[licenseStatus.toLowerCase()]} of {licenses.total}</span>
+            </Col>
+          ))}
+        </Row>
+      </Card.Section>
+    );
+  };
 
   return (
-    <Card orientation="horizontal" className="subscription-card">
+    <Card
+      orientation="horizontal"
+      className={classNames('subscription-card', {
+        'pb-4': subscriptionStatus !== ACTIVE,
+      })}
+    >
       <Card.Body>
         <Stack gap={4}>
           {renderCardHeader()}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2828721/155800409-6993f981-9d54-4ae6-81ad-bb293332bd87.png)

Adds padding bottom to the Card on Subscription Management `MultipleSubscriptionsPage` when the subscription is not active so it has equal spacing on the top & bottom.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
