### PR TITLE
feat: LMS config settings page checks for IDP configs

### DIFF
--- a/src/components/settings/SettingsLMSTab/LMSCard.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSCard.jsx
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 import { Card, Image, Stack } from '@edx/paragon';
 import { channelMapping } from '../../../utils';
 
-const LMSCard = ({ LMSType, onClick }) => (
+const LMSCard = ({ LMSType, onClick, disabled }) => (
   <Card
-    isClickable
-    className="pb-4"
-    onClick={() => onClick(LMSType)}
+    isClickable={!disabled}
+    className={`pb-4 ${disabled ? 'opacity-50' : ''}`}
+    onClick={() => !disabled && onClick(LMSType)}
   >
     <Card.Header
       title={(
@@ -23,5 +23,6 @@ const LMSCard = ({ LMSType, onClick }) => (
 LMSCard.propTypes = {
   LMSType: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired,
 };
 export default LMSCard;

--- a/src/components/settings/SettingsTabs.jsx
+++ b/src/components/settings/SettingsTabs.jsx
@@ -21,7 +21,12 @@ import {
 import SettingsAccessTab from './SettingsAccessTab';
 import SettingsLMSTab from './SettingsLMSTab';
 
-const SettingsTabs = ({ enterpriseId }) => {
+const SettingsTabs = ({
+  enterpriseId,
+  enterpriseSlug,
+  enableSamlConfigurationScreen,
+  identityProvider,
+}) => {
   const tab = useCurrentSettingsTab();
 
   const history = useHistory();
@@ -54,7 +59,12 @@ const SettingsTabs = ({ enterpriseId }) => {
           <SettingsAccessTab />
         </Tab>
         <Tab eventKey={SETTINGS_TABS_VALUES.lms} title={SETTINGS_TAB_LABELS.lms}>
-          <SettingsLMSTab enterpriseId={enterpriseId} />
+          <SettingsLMSTab
+            enterpriseId={enterpriseId}
+            enterpriseSlug={enterpriseSlug}
+            enableSamlConfigurationScreen={enableSamlConfigurationScreen}
+            identityProvider={identityProvider}
+          />
         </Tab>
       </Tabs>
     </Container>
@@ -63,10 +73,16 @@ const SettingsTabs = ({ enterpriseId }) => {
 
 const mapStateToProps = state => ({
   enterpriseId: state.portalConfiguration.enterpriseId,
+  enterpriseSlug: state.portalConfiguration.enterpriseSlug,
+  enableSamlConfigurationScreen: state.portalConfiguration.enableSamlConfigurationScreen,
+  identityProvider: state.portalConfiguration.identityProvider,
 });
 
 SettingsTabs.propTypes = {
   enterpriseId: PropTypes.string.isRequired,
+  enterpriseSlug: PropTypes.string.isRequired,
+  enableSamlConfigurationScreen: PropTypes.bool.isRequired,
+  identityProvider: PropTypes.string.isRequired,
 };
 
 export default connect(mapStateToProps)(SettingsTabs);

--- a/src/components/settings/settings.scss
+++ b/src/components/settings/settings.scss
@@ -39,6 +39,10 @@
   }
 }
 
+.sso-alert-modal-margin {
+  margin-right: 15% !important;
+}
+
 .lms-card-title-overflow {
   text-overflow: ellipsis !important;
   overflow: hidden !important;

--- a/src/data/reducers/portalConfiguration.js
+++ b/src/data/reducers/portalConfiguration.js
@@ -51,6 +51,7 @@ const portalConfiguration = (state = initialState, action) => {
         enableLearnerPortal: action.payload.data.enable_learner_portal,
         enableLmsConfigurationsScreen: action.payload.data.enable_portal_lms_configurations_screen,
         enableUniversalLink: action.payload.data.enable_universal_link,
+        identityProvider: action.payload.data.identity_provider,
       };
     case FETCH_PORTAL_CONFIGURATION_FAILURE:
       return {


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/67655836/156044181-0797c328-7e34-41de-9af9-d3dac759e371.png)

NEEDED BACKEND PR/BRANCH IN ORDER TO TEST:
https://github.com/openedx/edx-enterprise/pull/1465

This PR adds:
- a new LMS api service fetch method to a new backend endpoint that returns if a customer still needs to set up an IDP config.
- If the api fetch method returns `True`, 
    - renders an alert modal at the top of the LMS config settings page that has a redirect to the SSO settings tab
    - disables creation cards and display creation cards button on the LMS config page

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
