### PR TITLE
fix: add data-hj-suppress to email in license data table

### DIFF
--- a/src/components/subscriptions/expiration/SubscriptionExpirationBanner.jsx
+++ b/src/components/subscriptions/expiration/SubscriptionExpirationBanner.jsx
@@ -106,7 +106,7 @@ const SubscriptionExpirationBanner = ({ isSubscriptionPlanDetails }) => {
 
   const actions = [];
   if (!isSubscriptionPlanDetails || daysUntilContractExpiration > SUBSCRIPTION_DAYS_REMAINING_SEVERE) {
-    actions.push(<ContactCustomerSupportButton onClick={() => emitAlertActionEvent()} />);
+    actions.push(<ContactCustomerSupportButton variant="primary" onClick={() => emitAlertActionEvent()} />);
   }
 
   const dismissBanner = () => {
@@ -114,8 +114,11 @@ const SubscriptionExpirationBanner = ({ isSubscriptionPlanDetails }) => {
     emitAlertDismissedEvent();
   };
 
-  return (showExpirationNotifications
-    && (
+  if (!showExpirationNotifications) {
+    return null;
+  }
+
+  return (
     <Alert
       className="expiration-alert mt-1"
       variant={alertType}
@@ -126,7 +129,6 @@ const SubscriptionExpirationBanner = ({ isSubscriptionPlanDetails }) => {
     >
       {isSubscriptionPlanDetails ? renderPlanDetailsMessage() : renderContractDetailsMessage()}
     </Alert>
-    )
   );
 };
 

--- a/src/components/subscriptions/licenses/LicenseManagementTable/index.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/index.jsx
@@ -235,6 +235,8 @@ const LicenseManagementTable = () => {
           {
             Header: 'Email address',
             accessor: 'emailLabel',
+            // eslint-disable-next-line react/prop-types
+            Cell: ({ row }) => <span data-hj-suppress>{row.values.emailLabel}</span>,
           },
           {
             Header: 'Status',


### PR DESCRIPTION
Adds missing `data-hj-suppress` to the email column in the `LicenseManagementTable` component such that the email PII gets masked in Hotjar.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
