### PR TITLE
Only pass page option if param exists

### DIFF
--- a/src/components/CodeSearchResults/CodeSearchResultsTable.jsx
+++ b/src/components/CodeSearchResults/CodeSearchResultsTable.jsx
@@ -142,15 +142,20 @@ const CodeSearchResultsTable = ({
       ) : defaultEmptyValue,
     }));
   };
+
+  const fetchOptions = {
+    [searchParameter(searchQuery)]: searchQuery,
+  };
+  if (queryParams.get('page')) {
+    fetchOptions.page = parseInt(queryParams.get('page'), 10);
+  }
+
   return (
     <TableContainer
       key={`code-search-results-${searchQuery}-${shouldRefreshTable}`}
       id="code-search-results"
       className="code-search-results-table"
-      fetchMethod={() => EcommerceApiService.fetchCodeSearchResults({
-        [searchParameter(searchQuery)]: searchQuery,
-        page: queryParams.get('page') && parseInt(queryParams.get('page'), 10),
-      })}
+      fetchMethod={() => EcommerceApiService.fetchCodeSearchResults(fetchOptions)}
       columns={handleTableColumns(searchQuery)}
       formatData={formatSearchResultsData}
     />


### PR DESCRIPTION
### [Cloeses ENT-5513](https://openedx.atlassian.net/browse/ENT-5513)

No longer passing `page: null` in the options for `fetchCodeSearchResults`. 
