### PR TITLE
fix: properly waiting for and validating effects of custom hooks in lms tests

### DIFF
--- a/src/components/settings/SettingsLMSTab/tests/BlackboardConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/BlackboardConfig.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  act, render, fireEvent, screen,
+  act, render, fireEvent, screen, waitFor,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
@@ -142,7 +142,7 @@ describe('<BlackboardConfig />', () => {
     userEvent.click(screen.getByText('Authorize'));
 
     // Await a find by text in order to account for state changes in the button callback
-    expect(await screen.findByText('Authorize')).toBeInTheDocument();
+    await waitFor(() => screen.getByText('Submit'));
 
     const expectedConfig = {
       active: false,
@@ -150,7 +150,7 @@ describe('<BlackboardConfig />', () => {
       display_name: 'displayName',
       enterprise_customer: enterpriseId,
     };
-    expect(LmsApiService.postNewBlackboardConfig).toHaveBeenCalledWith(expectedConfig);
+    expect(mockPostConfigApi).toHaveBeenCalledWith(expectedConfig);
   });
   test('saves draft correctly', async () => {
     render(
@@ -165,11 +165,11 @@ describe('<BlackboardConfig />', () => {
 
     expect(screen.getByText('Authorize')).not.toBeDisabled();
     userEvent.click(screen.getByText('Authorize'));
+    // Await a find by text in order to account for state changes in the button callback
+    await waitFor(() => screen.getByText('Submit'));
+
     userEvent.click(screen.getByText('Cancel'));
     userEvent.click(screen.getByText('Save'));
-
-    // Await a find by text in order to account for state changes in the button callback
-    expect(await screen.findByText('Save')).toBeInTheDocument();
 
     const expectedConfig = {
       active: false,
@@ -194,7 +194,7 @@ describe('<BlackboardConfig />', () => {
     userEvent.click(screen.getByText('Authorize'));
 
     // Await a find by text in order to account for state changes in the button callback
-    expect(await screen.findByText('Authorize')).toBeInTheDocument();
+    await waitFor(() => screen.getByText('Submit'));
 
     await screen.findByText('Display Name');
     expect(window.open).toHaveBeenCalled();
@@ -221,9 +221,7 @@ describe('<BlackboardConfig />', () => {
 
     expect(screen.getByText('Authorize')).not.toBeDisabled();
     userEvent.click(screen.getByText('Authorize'));
-
-    // Await a find by text in order to account for state changes in the button callback
-    expect(await screen.findByText('Authorize')).toBeInTheDocument();
+    await waitFor(() => screen.getByText('Submit'));
 
     await screen.findByText('Display Name');
     expect(window.open).toHaveBeenCalled();
@@ -241,9 +239,10 @@ describe('<BlackboardConfig />', () => {
     expect(screen.getByText('Authorize')).not.toBeDisabled();
 
     userEvent.click(screen.getByText('Authorize'));
+
     // Await a find by text in order to account for state changes in the button callback
-    expect(await screen.findByText('Authorize')).toBeInTheDocument();
-    expect(await screen.findByText('Display Name')).toBeInTheDocument();
+    await waitFor(() => screen.getByText('Submit'));
+    expect(screen.getByText('Display Name')).toBeInTheDocument();
 
     expect(mockUpdateConfigApi).not.toHaveBeenCalled();
     expect(window.open).toHaveBeenCalled();

--- a/src/components/settings/SettingsLMSTab/tests/CanvasConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/CanvasConfig.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  act, render, fireEvent, screen,
+  act, render, fireEvent, screen, waitFor,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
@@ -132,7 +132,7 @@ describe('<CanvasConfig />', () => {
     userEvent.click(screen.getByText('Submit'));
 
     // Await a find by text in order to account for state changes in the button callback
-    expect(await screen.findByText('Submit')).toBeInTheDocument();
+    await waitFor(() => screen.getByText('Submit'));
 
     const expectedConfig = {
       active: false,
@@ -162,8 +162,9 @@ describe('<CanvasConfig />', () => {
     expect(screen.getByText('Authorize')).not.toBeDisabled();
 
     userEvent.click(screen.getByText('Authorize'));
+
     // Await a find by text in order to account for state changes in the button callback
-    expect(await screen.findByText('Authorize')).toBeInTheDocument();
+    await waitFor(() => screen.getByText('Submit'));
 
     const expectedConfig = {
       active: false,
@@ -192,11 +193,12 @@ describe('<CanvasConfig />', () => {
 
     expect(screen.getByText('Authorize')).not.toBeDisabled();
     userEvent.click(screen.getByText('Authorize'));
-    userEvent.click(screen.getByText('Cancel'));
-    userEvent.click(screen.getByText('Save'));
 
     // Await a find by text in order to account for state changes in the button callback
-    expect(await screen.findByText('Authorize')).toBeInTheDocument();
+    await waitFor(() => screen.getByText('Submit'));
+
+    userEvent.click(screen.getByText('Cancel'));
+    userEvent.click(screen.getByText('Save'));
 
     const expectedConfig = {
       active: false,
@@ -227,8 +229,7 @@ describe('<CanvasConfig />', () => {
     userEvent.click(screen.getByText('Authorize'));
 
     // Await a find by text in order to account for state changes in the button callback
-    expect(await screen.findByText('Authorize')).toBeInTheDocument();
-    expect(await screen.findByText('Display Name')).toBeInTheDocument();
+    await waitFor(() => screen.getByText('Submit'));
 
     expect(window.open).toHaveBeenCalled();
     expect(mockFetchSingleConfig).toHaveBeenCalledWith(1);
@@ -256,8 +257,7 @@ describe('<CanvasConfig />', () => {
     userEvent.click(screen.getByText('Authorize'));
 
     // Await a find by text in order to account for state changes in the button callback
-    expect(await screen.findByText('Authorize')).toBeInTheDocument();
-    expect(await screen.findByText('Display Name')).toBeInTheDocument();
+    await waitFor(() => screen.getByText('Submit'));
 
     expect(mockUpdateConfigApi).toHaveBeenCalled();
     expect(window.open).toHaveBeenCalled();
@@ -276,7 +276,7 @@ describe('<CanvasConfig />', () => {
     userEvent.click(screen.getByText('Authorize'));
 
     // Await a find by text in order to account for state changes in the button callback
-    expect(await screen.findByText('Display Name')).toBeInTheDocument();
+    await waitFor(() => screen.getByText('Submit'));
 
     expect(mockUpdateConfigApi).not.toHaveBeenCalled();
     expect(window.open).toHaveBeenCalled();


### PR DESCRIPTION
Issue: when authorize is clicked on the LMS config settings page form, a custom hook starts making API calls ever second to the enterprise backend to validate that the user has completed the oauth process. Tests were flaky because it wasn't guaranteed that the hook would be called or not in the test, and the result of that hook running would change the state of the page. I've added a delay each time we initiate the authorization process in the tests and updated the expected state to be the expected results post hook run.  

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
