### PR TITLE
feat: make identityprovider optional

### DIFF
--- a/src/components/settings/SettingsLMSTab/index.jsx
+++ b/src/components/settings/SettingsLMSTab/index.jsx
@@ -223,9 +223,13 @@ export default function SettingsLMSTab({
   );
 }
 
+SettingsLMSTab.defaultProps = {
+  identityProvider: null,
+};
+
 SettingsLMSTab.propTypes = {
   enterpriseId: PropTypes.string.isRequired,
   enterpriseSlug: PropTypes.string.isRequired,
   enableSamlConfigurationScreen: PropTypes.bool.isRequired,
-  identityProvider: PropTypes.string.isRequired,
+  identityProvider: PropTypes.string,
 };

--- a/src/components/settings/SettingsTabs.jsx
+++ b/src/components/settings/SettingsTabs.jsx
@@ -87,11 +87,15 @@ const mapStateToProps = state => ({
   identityProvider: state.portalConfiguration.identityProvider,
 });
 
+SettingsTabs.defaultProps = {
+  identityProvider: null,
+};
+
 SettingsTabs.propTypes = {
   enterpriseId: PropTypes.string.isRequired,
   enterpriseSlug: PropTypes.string.isRequired,
   enableSamlConfigurationScreen: PropTypes.bool.isRequired,
-  identityProvider: PropTypes.string.isRequired,
+  identityProvider: PropTypes.string,
 };
 
 export default connect(mapStateToProps)(SettingsTabs);


### PR DESCRIPTION
since some enteprrises won't have IDP configured, we are currently getting console warnings from proptypes when identityProvider is null

The code already checks for null identityProvider so we don't need to mark it as reqwuired in proptypes, instead we can give it a null default value to avoid the warnings

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
