### PR TITLE
fix: use subscription expirate date instead of agreement net days

### DIFF
--- a/src/components/CodeManagement/ManageRequestsTab.jsx
+++ b/src/components/CodeManagement/ManageRequestsTab.jsx
@@ -49,7 +49,7 @@ const ManageRequestsTab = ({
         <h2>Enrollment requests</h2>
         <p>Approve or decline enrollment requests for individual learners below.</p>
       </div>
-      <NoAvailableCodesBanner couponsData={coupons} />
+      <NoAvailableCodesBanner coupons={coupons} />
       <SubsidyRequestManagementTable
         pageCount={requests.pageCount}
         itemCount={requests.itemCount}

--- a/src/components/settings/SettingsAccessTab/SettingsAccessLinkManagement.jsx
+++ b/src/components/settings/SettingsAccessTab/SettingsAccessLinkManagement.jsx
@@ -36,23 +36,24 @@ const SettingsAccessLinkManagement = ({
   } = useLinkManagement(enterpriseUUID);
 
   const {
-    customerAgreement: { netDaysUntilExpiration },
-    couponsData,
+    customerAgreement: { subscriptions },
+    couponsData: { results: coupons },
   } = useContext(SettingsContext);
 
   const [isLinkManagementAlertModalOpen, setIsLinkManagementAlertModalOpen] = useState(false);
   const [isLoadingLinkManagementEnabledChange, setIsLoadingLinkManagementEnabledChange] = useState(false);
   const [hasLinkManagementEnabledChangeError, setHasLinkManagementEnabledChangeError] = useState(false);
+
   const formattedLinkExpirationDate = useMemo(
     () => {
       const expirationDates = [
-        ...couponsData.results.map(coupon => moment(coupon.endDate)),
-        moment().add(netDaysUntilExpiration, 'days').startOf('day'),
+        ...coupons.map(coupon => moment(coupon.endDate)),
+        ...subscriptions.map(subscription => moment(subscription.expirationDate).startOf('day')),
       ];
       const furthestExpirationDate = moment.max(expirationDates);
       return furthestExpirationDate.format();
     },
-    [couponsData.results, netDaysUntilExpiration],
+    [coupons, subscriptions],
   );
 
   const toggleUniversalLink = async (newEnableUniversalLink) => {

--- a/src/components/settings/SettingsAccessTab/index.jsx
+++ b/src/components/settings/SettingsAccessTab/index.jsx
@@ -24,7 +24,7 @@ const SettingsAccessTab = ({
   } = useContext(SubsidyRequestConfigurationContext);
 
   const isEligibleForBrowseAndRequest = features.FEATURE_BROWSE_AND_REQUEST
-   && enableBrowseAndRequest && !!subsidyRequestConfiguration.subsidyType;
+   && enableBrowseAndRequest && !!subsidyRequestConfiguration?.subsidyType;
 
   const isBrowseAndRequestDisabled = !(enableUniversalLink || (
     identityProvider && enableIntegratedCustomerLearnerPortalSearch

--- a/src/components/settings/SettingsAccessTab/tests/TestUtils.jsx
+++ b/src/components/settings/SettingsAccessTab/tests/TestUtils.jsx
@@ -4,7 +4,6 @@ import configureMockStore from 'redux-mock-store';
 import PropTypes from 'prop-types';
 
 import SettingsContextProvider from '../../SettingsContext';
-import * as hooks from '../../data/hooks';
 
 const mockStore = configureMockStore();
 
@@ -25,10 +24,13 @@ const basicStore = {
 
 /**
  * Generates Store from `basicStore`
- * @param {Object} portalConfiguration
+ * @param {portalConfiguration: Object, coupons: Object} Object custom store data
  * @returns {Object} Generated store
  */
-export const generateStore = (portalConfiguration) => (mockStore({
+export const generateStore = ({
+  portalConfiguration,
+  coupons,
+}) => (mockStore({
   ...basicStore,
   portalConfiguration: {
     ...basicStore.portalConfiguration,
@@ -36,28 +38,18 @@ export const generateStore = (portalConfiguration) => (mockStore({
   },
   coupons: {
     loading: false,
+    ...coupons,
   },
 }));
 
-const mockSettingsHooks = (loadingCustomerAgreement = false) => {
-  jest.spyOn(hooks, 'useCustomerAgreementData').mockImplementation(
-    () => ({
-      customerAgreement: { netDaysUntilExpiration: NET_DAYS_UNTIL_EXPIRATION },
-      loadingCustomerAgreement,
-    }),
-  );
-};
-
-const MockSettingsContext = ({ store, children }) => {
-  mockSettingsHooks();
-  return (
-    <Provider store={store}>
-      <SettingsContextProvider>
-        {children}
-      </SettingsContextProvider>
-    </Provider>
-  );
-};
+// eslint-disable-next-line react/prop-types
+const MockSettingsContext = ({ store, children }) => (
+  <Provider store={store}>
+    <SettingsContextProvider>
+      {children}
+    </SettingsContextProvider>
+  </Provider>
+);
 
 MockSettingsContext.propTypes = {
   children: PropTypes.node.isRequired,

--- a/src/components/settings/data/hooks.js
+++ b/src/components/settings/data/hooks.js
@@ -63,6 +63,7 @@ export const useLinkManagement = (enterpriseUUID) => {
 
 const initialCustomerAgreementState = {
   netDaysUntilExpiration: 0,
+  subscriptions: [],
 };
 /**
  * @param {Object {enterpriseId: string}}

--- a/src/components/subscriptions/SubscriptionSubsidyRequests.jsx
+++ b/src/components/subscriptions/SubscriptionSubsidyRequests.jsx
@@ -44,7 +44,7 @@ const SubscriptionSubsidyRequests = ({ enterpriseId }) => {
         <h2>Enrollment requests</h2>
         <p>Approve or decline enrollment requests for individual learners below.</p>
       </div>
-      <NoAvailableLicensesBanner />
+      <NoAvailableLicensesBanner subscriptions={subscriptions} />
       <SubsidyRequestManagementTable
         pageCount={requests.pageCount}
         itemCount={requests.itemCount}

--- a/src/components/subsidy-request-management-alerts/tests/NoAvailableCodesBanner.test.jsx
+++ b/src/components/subsidy-request-management-alerts/tests/NoAvailableCodesBanner.test.jsx
@@ -9,51 +9,68 @@ import { NoAvailableCodesBanner } from '../NoAvailableCodesBanner';
 
 describe('<NoAvailableCodesBanner />', () => {
   it('should render null if there are no coupons', () => {
-    const { container } = render(<NoAvailableCodesBanner couponsData={{}} />);
+    const { container } = render(<NoAvailableCodesBanner coupons={[]} />);
     expect(container.childElementCount).toEqual(0);
   });
 
   it('should render alert if all coupons have expired', () => {
-    const { getByText } = render(<NoAvailableCodesBanner couponsData={{
-      results: [{
-        numUnassigned: 1,
-        endDate: moment().subtract(1, 'days').toISOString(),
-      }],
-    }}
-    />);
+    const { getByText } = render(
+      <NoAvailableCodesBanner
+        coupons={[
+          {
+            numUnassigned: 1,
+            endDate: moment().subtract(1, 'days').toISOString(),
+          },
+        ]}
+      />,
+    );
+
     expect(getByText('All code batches expired'));
   });
 
-  it('should render alert if all codes have been assigned', () => {
-    const { getByText } = render(<NoAvailableCodesBanner couponsData={{
-      results: [{
-        numUnassigned: 0,
-        endDate: moment().add(1, 'days').toISOString(),
-      }],
-    }}
+  it('should render alert if all active codes have been assigned', () => {
+    const { getByText } = render(<NoAvailableCodesBanner
+      coupons={[
+        {
+          numUnassigned: 0,
+          endDate: moment().add(1, 'days').toISOString(),
+        },
+        {
+          numUnassigned: 1,
+          endDate: moment().subtract(1, 'days').toISOString(),
+        },
+      ]}
     />);
     expect(getByText('Not enough codes'));
   });
 
   it('should render null if there are available codes', () => {
-    const { container } = render(<NoAvailableCodesBanner couponsData={{
-      results: [{
-        numUnassigned: 1,
-        endDate: moment().add(1, 'days').toISOString(),
-      }],
-    }}
-    />);
+    const { container } = render(
+      <NoAvailableCodesBanner
+        coupons={[
+          {
+            numUnassigned: 0,
+            endDate: moment().add(1, 'days').toISOString(),
+          },
+          {
+            numUnassigned: 1,
+            endDate: moment().add(1, 'days').toISOString(),
+          },
+        ]}
+      />,
+    );
     expect(container.childElementCount).toEqual(0);
   });
 
   it('should dimiss banner', async () => {
-    const { getByText, container } = render(<NoAvailableCodesBanner couponsData={{
-      results: [{
-        numUnassigned: 1,
-        endDate: moment().subtract(1, 'days').toISOString(),
-      }],
-    }}
-    />);
+    const { getByText, container } = render(
+      <NoAvailableCodesBanner
+        coupons={[{
+          numUnassigned: 1,
+          endDate: moment().subtract(1, 'days').toISOString(),
+        }]}
+      />,
+    );
     const dismissBtn = getByText('Dismiss');
     fireEvent.click(dismissBtn);
     await waitFor(() => {

--- a/src/components/subsidy-request-management-alerts/tests/NoAvailableLicensesBanner.test.jsx
+++ b/src/components/subsidy-request-management-alerts/tests/NoAvailableLicensesBanner.test.jsx
@@ -4,70 +4,77 @@ import {
   fireEvent,
   waitFor,
 } from '@testing-library/react';
-import { SubscriptionContext } from '../../subscriptions/SubscriptionData';
 import NoAvailableLicensesBanner from '../NoAvailableLicensesBanner';
-
-// eslint-disable-next-line react/prop-types
-const NoAvailalbeLicensesBannerWithContext = ({ subscriptions }) => (
-  <SubscriptionContext.Provider value={{
-    data: {
-      results: subscriptions,
-    },
-  }}
-  >
-    <NoAvailableLicensesBanner />
-  </SubscriptionContext.Provider>
-);
 
 describe('<NoAvailableLicensesBanner />', () => {
   it('should render null if there are no subscriptions', () => {
-    const { container } = render(<NoAvailalbeLicensesBannerWithContext subscriptions={[]} />);
+    const { container } = render(
+      <NoAvailableLicensesBanner subscriptions={[]} />,
+    );
     expect(container.childElementCount).toEqual(0);
   });
 
   it('should render alert if all subscriptions have expired', () => {
-    const { getByText } = render(<NoAvailalbeLicensesBannerWithContext subscriptions={[
-      {
-        agreementNetDaysUntilExpiration: 0,
-      },
-    ]}
-    />);
+    const { getByText } = render(
+      <NoAvailableLicensesBanner
+        subscriptions={[
+          {
+            daysUntilExpiration: 0,
+          },
+        ]}
+      />,
+    );
     expect(getByText('All subscriptions ended'));
   });
 
-  it('should render alert if all licenses have been assigned', () => {
-    const { getByText } = render(<NoAvailalbeLicensesBannerWithContext subscriptions={[
-      {
-        agreementNetDaysUntilExpiration: 1,
-        licenses: {
-          unassigned: 0,
-        },
-      },
-    ]}
-    />);
+  it('should render alert if all licenses in active subscriptions have been assigned', () => {
+    const { getByText } = render(
+      <NoAvailableLicensesBanner
+        subscriptions={[
+          {
+            daysUntilExpiration: 1,
+            licenses: {
+              unassigned: 0,
+            },
+          },
+          {
+            daysUntilExpiration: 0,
+            licenses: {
+              unassigned: 3,
+            },
+          },
+        ]}
+      />,
+    );
     expect(getByText('Not enough licenses'));
   });
 
   it('should render null if there are available licenses', () => {
-    const { container } = render(<NoAvailalbeLicensesBannerWithContext subscriptions={[
-      {
-        agreementNetDaysUntilExpiration: 1,
-        licenses: {
-          unassigned: 1,
-        },
-      },
-    ]}
-    />);
+    const { container } = render(
+      <NoAvailableLicensesBanner
+        subscriptions={[
+          {
+            daysUntilExpiration: 1,
+            licenses: {
+              unassigned: 1,
+            },
+          },
+        ]}
+      />,
+    );
     expect(container.childElementCount).toEqual(0);
   });
 
   it('should dimiss banner', async () => {
-    const { getByText, container } = render(<NoAvailalbeLicensesBannerWithContext subscriptions={[
-      {
-        agreementNetDaysUntilExpiration: 0,
-      },
-    ]}
-    />);
+    const { getByText, container } = render(
+      <NoAvailableLicensesBanner
+        subscriptions={[
+          {
+            daysUntilExpiration: 0,
+          },
+        ]}
+      />,
+    );
     const dismissBtn = getByText('Dismiss');
     fireEvent.click(dismissBtn);
     await waitFor(() => {


### PR DESCRIPTION
- We want to account for only active plans in these places
- Clean ups

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
