### PR TITLE
ENT-5573: Config bug bash fixes

### DIFF
--- a/src/components/settings/SettingsLMSTab/ConfigError.jsx
+++ b/src/components/settings/SettingsLMSTab/ConfigError.jsx
@@ -1,18 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  AlertModal, ActionRow, Button, MailtoLink,
+  AlertModal, ActionRow, MailtoLink,
 } from '@edx/paragon';
 import { HELP_CENTER_EMAIL } from '../data/constants';
 
-const cardText400 = 'We were unable to process your request to submit a new LMS configuration. Please try submitting again or contact support for help.';
-const cardText500 = 'We were unable to process your request to submit a new LMS configuration. Please try submitting again later or contact support for help.';
+const cardText = 'We were unable to process your request to submit a new LMS configuration. Please try submitting again or contact support for help.';
 
 const ConfigError = ({
   isOpen,
   close,
-  submit,
-  code,
   configTextOverride,
 }) => (
   <AlertModal
@@ -23,7 +20,6 @@ const ConfigError = ({
     footerNode={(
       <ActionRow>
         <MailtoLink className="ml-auto my-2 mr-2" to={HELP_CENTER_EMAIL}>Contact Support</MailtoLink>
-        {code <= 499 && <Button variant="primary" onClick={submit}>Try Again</Button>}
       </ActionRow>
     )}
   >
@@ -32,29 +28,21 @@ const ConfigError = ({
         {configTextOverride}
       </p>
     )}
-    {!configTextOverride && code >= 500 && (
+    {!configTextOverride && (
     <p>
-      {cardText500}
-    </p>
-    )}
-    {!configTextOverride && code <= 499 && (
-    <p>
-      {cardText400}
+      {cardText}
     </p>
     )}
   </AlertModal>
 );
 
 ConfigError.defaultProps = {
-  code: 400,
   configTextOverride: '',
 };
 
 ConfigError.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   close: PropTypes.func.isRequired,
-  submit: PropTypes.func.isRequired,
-  code: PropTypes.number,
   configTextOverride: PropTypes.string,
 };
 export default ConfigError;

--- a/src/components/settings/SettingsLMSTab/ExistingLMSCardDeck.jsx
+++ b/src/components/settings/SettingsLMSTab/ExistingLMSCardDeck.jsx
@@ -12,10 +12,8 @@ import { handleErrors } from './utils';
 import { TOGGLE_SUCCESS_LABEL, DELETE_SUCCESS_LABEL } from '../data/constants';
 import ConfigError from './ConfigError';
 
-const errorToggleModalText = 'We were unable to toggle your config. Please try submitting again later or contact support for help.';
-const errorDeleteModalText = 'We were unable to delete your config. Please try removing again later or contact support for help.';
-const TOGGLE_ACTION = 'toggle';
-const DELETE_ACTION = 'delete';
+const errorToggleModalText = 'We were unable to toggle your configuration. Please try submitting again or contact support for help.';
+const errorDeleteModalText = 'We were unable to delete your configuration. Please try removing again or contact support for help.';
 const INCOMPLETE = 'incomplete';
 const ACTIVE = 'active';
 const INACTIVE = 'inactive';
@@ -27,8 +25,6 @@ const ExistingLMSCardDeck = ({
   onClick,
 }) => {
   const [errorIsOpen, openError, closeError] = useToggle(false);
-  const [erroredConfig, setErroredConfig] = useState();
-  const [errorCardActionType, setErrorCardActionType] = useState();
   const [errorModalText, setErrorModalText] = useState();
 
   const toggleConfig = async (id, channelType, toggle) => {
@@ -45,8 +41,6 @@ const ExistingLMSCardDeck = ({
     if (err) {
       setErrorModalText(errorToggleModalText);
       openError();
-      setErroredConfig({ id, channelType, toggle });
-      setErrorCardActionType(TOGGLE_ACTION);
     } else {
       onClick(TOGGLE_SUCCESS_LABEL);
     }
@@ -62,8 +56,6 @@ const ExistingLMSCardDeck = ({
     if (err) {
       setErrorModalText(errorDeleteModalText);
       openError();
-      setErroredConfig({ id, channelType });
-      setErrorCardActionType(DELETE_ACTION);
     } else {
       onClick(DELETE_SUCCESS_LABEL);
     }
@@ -203,13 +195,6 @@ const ExistingLMSCardDeck = ({
         isOpen={errorIsOpen}
         close={closeError}
         configTextOverride={errorModalText}
-        submit={() => {
-          if (errorCardActionType === DELETE_ACTION) {
-            deleteConfig(erroredConfig.id, erroredConfig.channelType);
-          } else if (errorCardActionType === TOGGLE_ACTION) {
-            toggleConfig(erroredConfig.id, erroredConfig.channelType, erroredConfig.toggle);
-          }
-        }}
       />
       <CardGrid
         className="mr-6"

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/BlackboardConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/BlackboardConfig.jsx
@@ -206,12 +206,13 @@ const BlackboardConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => 
 
   return (
     <span>
-      <ConfigError isOpen={errorIsOpen} close={closeError} submit={handleSubmit} err={errCode} />
+      <ConfigError isOpen={errorIsOpen} close={closeError} />
       <ConfigModal isOpen={modalIsOpen} close={closeModal} onClick={onClick} saveDraft={handleSubmit} />
       <Form style={{ maxWidth: '60rem' }}>
         <Form.Group className="my-2.5">
           <Form.Control
             type="text"
+            maxLength={255}
             isInvalid={!nameValid}
             onChange={(e) => {
               setEdited(true);
@@ -230,6 +231,7 @@ const BlackboardConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => 
         <Form.Group className="my-4">
           <Form.Control
             type="text"
+            maxLength={255}
             isInvalid={!urlValid}
             onChange={(e) => {
               setEdited(true);

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/CanvasConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/CanvasConfig.jsx
@@ -29,7 +29,6 @@ const CanvasConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
   const [urlValid, setUrlValid] = React.useState(true);
   const [errorIsOpen, openError, closeError] = useToggle(false);
   const [modalIsOpen, openModal, closeModal] = useToggle(false);
-  const [errCode, setErrCode] = React.useState();
   const [edited, setEdited] = React.useState(false);
   const [authorized, setAuthorized] = React.useState(false);
   const [oauthPollingInterval, setOauthPollingInterval] = React.useState(null);
@@ -62,7 +61,6 @@ const CanvasConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
         err = handleErrors(error);
       }
       if (err) {
-        setErrCode(errCode);
         openError();
       }
     }
@@ -125,7 +123,6 @@ const CanvasConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
       fetchedConfigId = existingData.id;
     }
     if (err) {
-      setErrCode(errCode);
       openError();
     } else {
       setConfigId(fetchedConfigId);
@@ -167,7 +164,6 @@ const CanvasConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
       }
     }
     if (err) {
-      setErrCode(errCode);
       openError();
     } else {
       onClick(SUCCESS_LABEL);
@@ -191,7 +187,7 @@ const CanvasConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
 
   return (
     <span>
-      <ConfigError isOpen={errorIsOpen} close={closeError} submit={handleSubmit} err={errCode} />
+      <ConfigError isOpen={errorIsOpen} close={closeError} />
       <ConfigModal isOpen={modalIsOpen} close={closeModal} onClick={onClick} saveDraft={handleSubmit} />
       <Form style={{ maxWidth: '60rem' }}>
         <Form.Group className="my-2.5">
@@ -216,6 +212,7 @@ const CanvasConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
           <Form.Control
             className="mb-4"
             type="text"
+            maxLength={255}
             onChange={(e) => {
               setEdited(true);
               setClientId(e.target.value);
@@ -228,7 +225,9 @@ const CanvasConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
           <Form.Control
             className="my-4"
             type="password"
+            maxLength={255}
             onChange={(e) => {
+              setEdited(true);
               setClientSecret(e.target.value);
             }}
             floatingLabel="API Client Secret"
@@ -239,6 +238,7 @@ const CanvasConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
           <Form.Control
             className="my-4"
             type="number"
+            maxLength={255}
             onChange={(e) => {
               setEdited(true);
               setCanvasAccountId(e.target.value);
@@ -250,6 +250,7 @@ const CanvasConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
         <Form.Group className="my-4">
           <Form.Control
             type="text"
+            maxLength={255}
             isInvalid={!urlValid}
             onChange={(e) => {
               setEdited(true);

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/CornerstoneConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/CornerstoneConfig.jsx
@@ -18,7 +18,6 @@ const CornerstoneConfig = ({ enterpriseCustomerUuid, onClick, existingData }) =>
 
   const [errorIsOpen, openError, closeError] = useToggle(false);
   const [modalIsOpen, openModal, closeModal] = useToggle(false);
-  const [errCode, setErrCode] = React.useState();
   const [edited, setEdited] = React.useState(false);
 
   const config = {
@@ -62,7 +61,6 @@ const CornerstoneConfig = ({ enterpriseCustomerUuid, onClick, existingData }) =>
     }
 
     if (err) {
-      setErrCode(err);
       openError();
     } else {
       onClick(SUCCESS_LABEL);
@@ -86,7 +84,7 @@ const CornerstoneConfig = ({ enterpriseCustomerUuid, onClick, existingData }) =>
 
   return (
     <span>
-      <ConfigError isOpen={errorIsOpen} close={closeError} submit={handleSubmit} err={errCode} />
+      <ConfigError isOpen={errorIsOpen} close={closeError} />
       <ConfigModal isOpen={modalIsOpen} close={closeModal} onClick={onClick} saveDraft={handleSubmit} />
       <Form style={{ maxWidth: '60rem' }}>
         <Form.Group className="my-2.5">
@@ -110,6 +108,7 @@ const CornerstoneConfig = ({ enterpriseCustomerUuid, onClick, existingData }) =>
         <Form.Group className="mb-4">
           <Form.Control
             type="text"
+            maxLength={255}
             isInvalid={!urlValid}
             onChange={(e) => {
               setEdited(true);

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/Degreed2Config.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/Degreed2Config.jsx
@@ -12,11 +12,13 @@ import { INVALID_LINK, INVALID_NAME, SUCCESS_LABEL } from '../../data/constants'
 
 const Degreed2Config = ({ enterpriseCustomerUuid, onClick, existingData }) => {
   const [displayName, setDisplayName] = React.useState('');
-  const [nameValid, setNameValid] = React.useState(true);
   const [clientId, setClientId] = React.useState('');
   const [clientSecret, setClientSecret] = React.useState('');
   const [degreedBaseUrl, setDegreedBaseUrl] = React.useState('');
+  const [degreedFetchUrl, setDegreedFetchUrl] = React.useState('');
+  const [nameValid, setNameValid] = React.useState(true);
   const [urlValid, setUrlValid] = React.useState(true);
+  const [fetchUrlValid, setFetchUrlValid] = React.useState(true);
   const [errorIsOpen, openError, closeError] = useToggle(false);
   const [modalIsOpen, openModal, closeModal] = useToggle(false);
   const [edited, setEdited] = React.useState(false);
@@ -26,12 +28,14 @@ const Degreed2Config = ({ enterpriseCustomerUuid, onClick, existingData }) => {
     clientId,
     clientSecret,
     degreedBaseUrl,
+    degreedFetchUrl,
   };
 
   useEffect(() => {
     setClientId(existingData.clientId);
     setClientSecret(existingData.clientSecret);
     setDegreedBaseUrl(existingData.degreedBaseUrl);
+    setDegreedFetchUrl(existingData.degreedFetchUrl);
     setDisplayName(existingData.displayName);
   }, [existingData]);
 
@@ -73,6 +77,10 @@ const Degreed2Config = ({ enterpriseCustomerUuid, onClick, existingData }) => {
 
   const validateField = (field, input) => {
     switch (field) {
+      case 'Degreed Token Fetch Base Url':
+        setDegreedFetchUrl(input);
+        setFetchUrlValid(urlValidation(input) || input.length === 0);
+        break;
       case 'Degreed Base URL':
         setDegreedBaseUrl(input);
         setUrlValid(urlValidation(input) || input.length === 0);
@@ -88,12 +96,13 @@ const Degreed2Config = ({ enterpriseCustomerUuid, onClick, existingData }) => {
 
   return (
     <span>
-      <ConfigError isOpen={errorIsOpen} close={closeError} submit={handleSubmit} />
+      <ConfigError isOpen={errorIsOpen} close={closeError} />
       <ConfigModal isOpen={modalIsOpen} close={closeModal} onClick={onClick} saveDraft={handleSubmit} />
       <Form style={{ maxWidth: '60rem' }}>
         <Form.Group className="my-2.5">
           <Form.Control
             type="text"
+            maxLength={255}
             isInvalid={!nameValid}
             onChange={(e) => {
               setEdited(true);
@@ -113,8 +122,10 @@ const Degreed2Config = ({ enterpriseCustomerUuid, onClick, existingData }) => {
           <Form.Control
             className="mb-4"
             type="text"
+            maxLength={255}
             onChange={(e) => {
               setEdited(true);
+              validateField('API Client ID', e.target.value);
               setClientId(e.target.value);
             }}
             floatingLabel="API Client ID"
@@ -125,8 +136,10 @@ const Degreed2Config = ({ enterpriseCustomerUuid, onClick, existingData }) => {
           <Form.Control
             className="my-4"
             type="password"
+            maxLength={255}
             onChange={(e) => {
               setEdited(true);
+              validateField('API Client Secret', e.target.value);
               setClientSecret(e.target.value);
             }}
             floatingLabel="API Client Secret"
@@ -136,6 +149,7 @@ const Degreed2Config = ({ enterpriseCustomerUuid, onClick, existingData }) => {
         <Form.Group className="my-4">
           <Form.Control
             type="text"
+            maxLength={255}
             isInvalid={!urlValid}
             onChange={(e) => {
               setEdited(true);
@@ -145,6 +159,27 @@ const Degreed2Config = ({ enterpriseCustomerUuid, onClick, existingData }) => {
             defaultValue={existingData.degreedBaseUrl}
           />
           {!urlValid && (
+            <Form.Control.Feedback type="invalid">
+              {INVALID_LINK}
+            </Form.Control.Feedback>
+          )}
+        </Form.Group>
+        <Form.Group className="my-4">
+          <Form.Control
+            type="text"
+            maxLength={255}
+            isInvalid={!fetchUrlValid}
+            onChange={(e) => {
+              setEdited(true);
+              validateField('Degreed Token Fetch Base Url', e.target.value);
+            }}
+            floatingLabel="Degreed Token Fetch Base Url"
+            defaultValue={existingData.degreedFetchUrl}
+          />
+          <Form.Text>
+            Optional: If provided, will be used as base url instead of Degreed Base URL to fetch tokens.
+          </Form.Text>
+          {!fetchUrlValid && (
             <Form.Control.Feedback type="invalid">
               {INVALID_LINK}
             </Form.Control.Feedback>
@@ -168,6 +203,7 @@ Degreed2Config.propTypes = {
     id: PropTypes.number,
     clientSecret: PropTypes.string,
     degreedBaseUrl: PropTypes.string,
+    degreedFetchUrl: PropTypes.string,
   }).isRequired,
 };
 export default Degreed2Config;

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/Degreed2Config.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/Degreed2Config.jsx
@@ -177,7 +177,7 @@ const Degreed2Config = ({ enterpriseCustomerUuid, onClick, existingData }) => {
             defaultValue={existingData.degreedFetchUrl}
           />
           <Form.Text>
-            Optional: If provided, will be used as base url instead of Degreed Base URL to fetch tokens.
+            Optional: If provided, will be used as the url to fetch tokens.
           </Form.Text>
           {!fetchUrlValid && (
             <Form.Control.Feedback type="invalid">

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/DegreedConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/DegreedConfig.jsx
@@ -22,7 +22,6 @@ const DegreedConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
   const [degreedUserPassword, setDegreedUserPassword] = React.useState('');
   const [errorIsOpen, openError, closeError] = useToggle(false);
   const [modalIsOpen, openModal, closeModal] = useToggle(false);
-  const [errCode, setErrCode] = React.useState();
   const [edited, setEdited] = React.useState(false);
 
   const config = {
@@ -75,7 +74,6 @@ const DegreedConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
     }
 
     if (err) {
-      setErrCode(err);
       openError();
     } else {
       onClick(SUCCESS_LABEL);
@@ -99,7 +97,7 @@ const DegreedConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
 
   return (
     <span>
-      <ConfigError isOpen={errorIsOpen} close={closeError} submit={handleSubmit} err={errCode} />
+      <ConfigError isOpen={errorIsOpen} close={closeError} />
       <ConfigModal isOpen={modalIsOpen} close={closeModal} onClick={onClick} saveDraft={handleSubmit} />
       <Form style={{ maxWidth: '60rem' }}>
         <Form.Group className="my-2.5">
@@ -124,6 +122,7 @@ const DegreedConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
           <Form.Control
             className="mb-4"
             type="text"
+            maxLength={255}
             onChange={(e) => {
               setEdited(true);
               setKey(e.target.value);
@@ -136,6 +135,7 @@ const DegreedConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
           <Form.Control
             className="my-4"
             type="password"
+            maxLength={255}
             onChange={(e) => {
               setEdited(true);
               setSecret(e.target.value);
@@ -148,6 +148,7 @@ const DegreedConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
           <Form.Control
             className="my-4"
             type="text"
+            maxLength={255}
             onChange={(e) => {
               setEdited(true);
               setDegreedCompanyId(e.target.value);
@@ -159,6 +160,7 @@ const DegreedConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
         <Form.Group className="my-4">
           <Form.Control
             type="text"
+            maxLength={255}
             isInvalid={!urlValid}
             onChange={(e) => {
               setEdited(true);
@@ -177,7 +179,9 @@ const DegreedConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
           <Form.Control
             className="my-1"
             type="username"
+            maxLength={255}
             onChange={(e) => {
+              setEdited(true);
               setDegreedUserId(e.target.value);
             }}
             floatingLabel="Degreed User ID"
@@ -189,7 +193,9 @@ const DegreedConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
           <Form.Control
             className="my-1"
             type="password"
+            maxLength={255}
             onChange={(e) => {
+              setEdited(true);
               setDegreedUserPassword(e.target.value);
             }}
             floatingLabel="Degreed User Password"

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/MoodleConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/MoodleConfig.jsx
@@ -20,7 +20,6 @@ const MoodleConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
   const [nameValid, setNameValid] = React.useState(true);
   const [errorIsOpen, openError, closeError] = useToggle(false);
   const [modalIsOpen, openModal, closeModal] = useToggle(false);
-  const [errCode, setErrCode] = React.useState();
   const [edited, setEdited] = React.useState(false);
 
   const config = {
@@ -83,7 +82,6 @@ const MoodleConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
     }
 
     if (err) {
-      setErrCode(err);
       openError();
     } else {
       onClick(SUCCESS_LABEL);
@@ -107,7 +105,7 @@ const MoodleConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
 
   return (
     <span>
-      <ConfigError isOpen={errorIsOpen} close={closeError} submit={handleSubmit} err={errCode} />
+      <ConfigError isOpen={errorIsOpen} close={closeError} />
       <ConfigModal isOpen={modalIsOpen} close={closeModal} onClick={onClick} saveDraft={handleSubmit} />
       <Form style={{ maxWidth: '60rem' }}>
         <Form.Group className="my-2.5">
@@ -131,6 +129,7 @@ const MoodleConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
         <Form.Group className="mb-4">
           <Form.Control
             type="text"
+            maxLength={255}
             isInvalid={!urlValid}
             onChange={(e) => {
               setEdited(true);
@@ -148,6 +147,7 @@ const MoodleConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
         <Form.Group className="my-4">
           <Form.Control
             type="text"
+            maxLength={255}
             onChange={(e) => {
               setEdited(true);
               setServiceShortName(e.target.value);
@@ -159,6 +159,7 @@ const MoodleConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
         <Form.Group className="my-4">
           <Form.Control
             type="text"
+            maxLength={255}
             onChange={(e) => {
               setEdited(true);
               setToken(e.target.value);
@@ -174,6 +175,7 @@ const MoodleConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
         <Form.Group className="my-4">
           <Form.Control
             type="text"
+            maxLength={255}
             onChange={(e) => {
               setEdited(true);
               setUsername(e.target.value);
@@ -188,7 +190,8 @@ const MoodleConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
         </Form.Group>
         <Form.Group className="my-4">
           <Form.Control
-            type="text"
+            type="password"
+            maxLength={255}
             onChange={(e) => {
               setEdited(true);
               setPassword(e.target.value);

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/SAPConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/SAPConfig.jsx
@@ -21,7 +21,6 @@ const SAPConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
   const [userType, setUserType] = React.useState('user');
   const [errorIsOpen, openError, closeError] = useToggle(false);
   const [modalIsOpen, openModal, closeModal] = useToggle(false);
-  const [errCode, setErrCode] = React.useState();
   const [edited, setEdited] = React.useState(false);
 
   const config = {
@@ -74,7 +73,6 @@ const SAPConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
       }
     }
     if (err) {
-      setErrCode(err);
       openError();
     } else {
       onClick(SUCCESS_LABEL);
@@ -98,7 +96,7 @@ const SAPConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
 
   return (
     <span>
-      <ConfigError isOpen={errorIsOpen} close={closeError} submit={handleSubmit} err={errCode} />
+      <ConfigError isOpen={errorIsOpen} close={closeError} />
       <ConfigModal isOpen={modalIsOpen} close={closeModal} onClick={onClick} saveDraft={handleSubmit} />
       <Form style={{ maxWidth: '60rem' }}>
         <Form.Group className="my-2.5">
@@ -122,6 +120,7 @@ const SAPConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
         <Form.Group className="mb-4">
           <Form.Control
             type="text"
+            maxLength={255}
             isInvalid={!urlValid}
             onChange={(e) => {
               setEdited(true);
@@ -138,7 +137,8 @@ const SAPConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
         </Form.Group>
         <Form.Group className="my-4">
           <Form.Control
-            type="number"
+            type="text"
+            maxLength={255}
             onChange={(e) => {
               setEdited(true);
               setSapsfCompanyId(e.target.value);
@@ -150,6 +150,7 @@ const SAPConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
         <Form.Group className="my-4">
           <Form.Control
             type="text"
+            maxLength={255}
             onChange={(e) => {
               setEdited(true);
               setSapsfUserId(e.target.value);
@@ -161,6 +162,7 @@ const SAPConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
         <Form.Group className="mb-4">
           <Form.Control
             type="text"
+            maxLength={255}
             onChange={(e) => {
               setEdited(true);
               setKey(e.target.value);
@@ -172,6 +174,7 @@ const SAPConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
         <Form.Group className="my-4">
           <Form.Control
             type="password"
+            maxLength={255}
             onChange={(e) => {
               setEdited(true);
               setSecret(e.target.value);

--- a/src/components/settings/SettingsLMSTab/tests/ConfigError.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/ConfigError.test.jsx
@@ -4,51 +4,30 @@ import '@testing-library/jest-dom/extend-expect';
 
 import ConfigError from '../ConfigError';
 
-const mockSubmit = jest.fn();
 const mockClose = jest.fn();
 
-const testCode1 = 400;
-const testCode2 = 500;
 const overrideText = 'ayylmao';
 
 describe('<ConfigError />', () => {
-  test('renders 400 Error Modal', () => {
+  test('renders Error Modal', () => {
     render(
       <ConfigError
         isOpen
         close={mockClose}
-        submit={mockSubmit}
-        code={testCode1}
       />,
     );
     expect(screen.queryByText('We were unable to process your request to submit a new LMS configuration. Please try submitting again or contact support for help.'));
     expect(screen.queryByText('Contact Support'));
-    expect(screen.queryByText('Try Again'));
-  });
-  test('renders 500 Error Modal', () => {
-    render(
-      <ConfigError
-        isOpen
-        close={mockClose}
-        submit={mockSubmit}
-        code={testCode2}
-      />,
-    );
-    expect(screen.queryByText('We were unable to process your request to submit a new LMS configuration. Please try submitting again later or contact support for help.'));
-    expect(screen.queryByText('Contact Support'));
-    expect(screen.queryByText('Try Again')).toBeFalsy();
   });
   test('renders Error Modal with text override', () => {
     render(
       <ConfigError
         isOpen
         close={mockClose}
-        submit={mockSubmit}
         configTextOverride={overrideText}
       />,
     );
     expect(screen.queryByText('ayylmao'));
     expect(screen.queryByText('Contact Support'));
-    expect(screen.queryByText('Try Again'));
   });
 });

--- a/src/components/settings/SettingsLMSTab/tests/Degreed2Config.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/Degreed2Config.test.jsx
@@ -57,14 +57,21 @@ describe('<DegreedConfig />', () => {
     fireEvent.change(screen.getByLabelText('Degreed Base URL'), {
       target: { value: 'test4' },
     });
+    fireEvent.change(screen.getByLabelText('Degreed Token Fetch Base Url'), {
+      target: { value: 'test5' },
+    });
     expect(screen.getByText('Submit')).toBeDisabled();
-    expect(screen.queryByText(INVALID_LINK));
     expect(screen.queryByText(INVALID_NAME));
+    const linkText = screen.queryAllByText(INVALID_LINK);
+    expect(linkText.length).toBe(2);
     fireEvent.change(screen.getByLabelText('Display Name'), {
       target: { value: 'test1' },
     });
     fireEvent.change(screen.getByLabelText('Degreed Base URL'), {
       target: { value: 'https://test1.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Degreed Base URL'), {
+      target: { value: 'https://test2.com' },
     });
     expect(screen.getByText('Submit')).not.toBeDisabled();
   });
@@ -88,12 +95,16 @@ describe('<DegreedConfig />', () => {
     fireEvent.change(screen.getByLabelText('Degreed Base URL'), {
       target: { value: 'https://test1.com' },
     });
+    fireEvent.change(screen.getByLabelText('Degreed Token Fetch Base Url'), {
+      target: { value: 'https://test2.com' },
+    });
     expect(screen.getByText('Submit')).not.toBeDisabled();
     fireEvent.click(screen.getByText('Submit'));
 
     const expectedConfig = {
       active: false,
       degreed_base_url: 'https://test1.com',
+      degreed_fetch_url: 'https://test2.com',
       display_name: 'displayName',
       client_id: 'test1',
       client_secret: 'test2',

--- a/src/components/settings/SettingsLMSTab/tests/SAPConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/SAPConfig.test.jsx
@@ -56,7 +56,7 @@ describe('<SAPConfig />', () => {
       target: { value: 'test2' },
     });
     fireEvent.change(screen.getByLabelText('SAP Company ID'), {
-      target: { value: '3' },
+      target: { value: 'test3' },
     });
     fireEvent.change(screen.getByLabelText('SAP User ID'), {
       target: { value: 'test4' },
@@ -88,7 +88,7 @@ describe('<SAPConfig />', () => {
       />,
     );
     fireEvent.change(screen.getByLabelText('SAP Company ID'), {
-      target: { value: '3' },
+      target: { value: 'test3' },
     });
     fireEvent.change(screen.getByLabelText('SAP User ID'), {
       target: { value: 'test4' },
@@ -111,7 +111,7 @@ describe('<SAPConfig />', () => {
     const expectedConfig = {
       active: false,
       sapsf_base_url: 'https://www.test.com',
-      sapsf_company_id: '3',
+      sapsf_company_id: 'test3',
       sapsf_user_id: 'test4',
       secret: 'test6',
       key: 'test5',
@@ -130,7 +130,7 @@ describe('<SAPConfig />', () => {
       />,
     );
     fireEvent.change(screen.getByLabelText('SAP Company ID'), {
-      target: { value: '3' },
+      target: { value: 'test3' },
     });
     fireEvent.change(screen.getByLabelText('SAP User ID'), {
       target: { value: 'test4' },

--- a/src/components/settings/SettingsLMSTab/tests/SAPConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/SAPConfig.test.jsx
@@ -153,7 +153,7 @@ describe('<SAPConfig />', () => {
     const expectedConfig = {
       active: false,
       sapsf_base_url: 'https://www.test.com',
-      sapsf_company_id: '3',
+      sapsf_company_id: 'test3',
       sapsf_user_id: 'test4',
       secret: 'test6',
       key: 'test5',

--- a/src/components/settings/SettingsLMSTab/utils.js
+++ b/src/components/settings/SettingsLMSTab/utils.js
@@ -4,6 +4,7 @@ export function buttonBool(config) {
   let returnVal = true;
   Object.entries(config).forEach(entry => {
     const [key, value] = entry;
+    // check whether or not the field is an optional value
     if ((key !== 'displayName' && key !== 'degreedFetchUrl') && !value) {
       returnVal = false;
     }

--- a/src/components/settings/SettingsLMSTab/utils.js
+++ b/src/components/settings/SettingsLMSTab/utils.js
@@ -2,8 +2,9 @@ import { logError } from '@edx/frontend-platform/logging';
 
 export function buttonBool(config) {
   let returnVal = true;
-  Object.values(config).forEach(value => {
-    if (!value) {
+  Object.entries(config).forEach(entry => {
+    const [key, value] = entry;
+    if ((key !== 'displayName' && key !== 'degreedFetchUrl') && !value) {
       returnVal = false;
     }
   });


### PR DESCRIPTION
# For all changes

- SAP config’s Company ID field needs to not validate numbers only and instead should allow strings
- All string fields need to have a char limit validation similar to display name’s with a 255 limit
- Moodle’s password field needs to be obscured like other password fields
- Degreed2 config forms need to include an optional token fetch base url with a tool tip stating that if one isn’t supplied then we will use the degreed base url provided
- Degreed2 backend should not require the config to have the optional token fetch base url 
- Toggle and Delete error message should read configuration instead of config, and remove “later”
- “Try Again” button should also be removed from error modals

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
