### PR TITLE
feat: hide settings tab based only on feature flag

### DIFF
--- a/src/components/EnterpriseApp/index.jsx
+++ b/src/components/EnterpriseApp/index.jsx
@@ -241,11 +241,11 @@ class EnterpriseApp extends React.Component {
                       path={`${baseUrl}/admin/bulk-enrollment-results/:bulkEnrollmentJobId`}
                       component={BulkEnrollmentResultsDownloadPage}
                     />
-                    {features.SETTINGS_PAGE && features.EXTERNAL_LMS_CONFIGURATION && enableLmsConfigurationsScreen && (
-                    <Route
-                      path={`${baseUrl}/admin/${ROUTE_NAMES.settings}`}
-                      component={SettingsPage}
-                    />
+                    {features.SETTINGS_PAGE && (
+                      <Route
+                        path={`${baseUrl}/admin/${ROUTE_NAMES.settings}`}
+                        component={SettingsPage}
+                      />
                     )}
                     <Route path="" component={NotFoundPage} />
                   </Switch>

--- a/src/components/settings/SettingsTabs.jsx
+++ b/src/components/settings/SettingsTabs.jsx
@@ -30,12 +30,13 @@ const SettingsTabs = ({
   enableBrowseAndRequest,
   enableIntegratedCustomerLearnerPortalSearch,
   enableLearnerPortal,
+  enableLmsConfigurationsScreen,
   enableSamlConfigurationScreen,
   enableUniversalLink,
   identityProvider,
   updatePortalConfiguration,
 }) => {
-  const { FEATURE_SSO_SETTINGS_TAB } = features;
+  const { FEATURE_SSO_SETTINGS_TAB, EXTERNAL_LMS_CONFIGURATION } = features;
 
   const tab = useCurrentSettingsTab();
 
@@ -76,19 +77,23 @@ const SettingsTabs = ({
             updatePortalConfiguration={updatePortalConfiguration}
           />
         </Tab>
-        { FEATURE_SSO_SETTINGS_TAB && (
-        <Tab eventKey={SETTINGS_TABS_VALUES.sso} title={SETTINGS_TAB_LABELS.sso}>
-          <SettingsSSOTab enterpriseId={enterpriseId} />
-        </Tab>
+
+        {FEATURE_SSO_SETTINGS_TAB && (
+          <Tab eventKey={SETTINGS_TABS_VALUES.sso} title={SETTINGS_TAB_LABELS.sso}>
+            <SettingsSSOTab enterpriseId={enterpriseId} />
+          </Tab>
         )}
-        <Tab eventKey={SETTINGS_TABS_VALUES.lms} title={SETTINGS_TAB_LABELS.lms}>
-          <SettingsLMSTab
-            enterpriseId={enterpriseId}
-            enterpriseSlug={enterpriseSlug}
-            enableSamlConfigurationScreen={enableSamlConfigurationScreen}
-            identityProvider={identityProvider}
-          />
-        </Tab>
+
+        {EXTERNAL_LMS_CONFIGURATION && enableLmsConfigurationsScreen && (
+          <Tab eventKey={SETTINGS_TABS_VALUES.lms} title={SETTINGS_TAB_LABELS.lms}>
+            <SettingsLMSTab
+              enterpriseId={enterpriseId}
+              enterpriseSlug={enterpriseSlug}
+              enableSamlConfigurationScreen={enableSamlConfigurationScreen}
+              identityProvider={identityProvider}
+            />
+          </Tab>
+        )}
       </Tabs>
     </Container>
   );
@@ -101,6 +106,7 @@ const mapStateToProps = state => {
     enableBrowseAndRequest,
     enableIntegratedCustomerLearnerPortalSearch,
     enableLearnerPortal,
+    enableLmsConfigurationsScreen,
     enableSamlConfigurationScreen,
     enableUniversalLink,
     identityProvider,
@@ -112,6 +118,7 @@ const mapStateToProps = state => {
     enableBrowseAndRequest,
     enableIntegratedCustomerLearnerPortalSearch,
     enableLearnerPortal,
+    enableLmsConfigurationsScreen,
     enableSamlConfigurationScreen,
     enableUniversalLink,
     identityProvider,
@@ -128,6 +135,7 @@ SettingsTabs.propTypes = {
   enableBrowseAndRequest: PropTypes.bool.isRequired,
   enableIntegratedCustomerLearnerPortalSearch: PropTypes.bool.isRequired,
   enableLearnerPortal: PropTypes.bool.isRequired,
+  enableLmsConfigurationsScreen: PropTypes.bool.isRequired,
   enableSamlConfigurationScreen: PropTypes.bool.isRequired,
   enableUniversalLink: PropTypes.bool.isRequired,
   identityProvider: PropTypes.string,


### PR DESCRIPTION
- We need to show the settings page for bnr, shuffled the logic to show settings page but hide tabs based on feature flags

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
