### PR TITLE
fix: bug fixes

### DIFF
--- a/src/components/settings/SettingsLMSTab/ConfigError.jsx
+++ b/src/components/settings/SettingsLMSTab/ConfigError.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  AlertModal, ActionRow, Button, MailtoLink,
+  AlertModal, ActionRow, Button, Hyperlink,
 } from '@edx/paragon';
-import { HELP_CENTER_EMAIL } from '../data/constants';
+import { HELP_CENTER_LINK } from '../data/constants';
 
 const cardText400 = 'We were unable to process your request to submit a new LMS configuration. Please try submitting again or contact support for help.';
 const cardText500 = 'We were unable to process your request to submit a new LMS configuration. Please try submitting again later or contact support for help.';
@@ -22,7 +22,10 @@ const ConfigError = ({
     hasCloseButton
     footerNode={(
       <ActionRow>
-        <MailtoLink className="ml-auto my-2 mr-2" to={HELP_CENTER_EMAIL}>Contact Support</MailtoLink>
+        <ActionRow.Spacer />
+        <Button variant="primary">
+          <Hyperlink style={{ color: 'white' }} destination={HELP_CENTER_LINK} target="_blank">Contact Support</Hyperlink>
+        </Button>
         {code <= 499 && <Button variant="primary" onClick={submit}>Try Again</Button>}
       </ActionRow>
     )}

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/BlackboardConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/BlackboardConfig.jsx
@@ -160,8 +160,6 @@ const BlackboardConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => 
     event.preventDefault();
     // format config data for the backend
     const transformedConfig = snakeCaseDict(config);
-    // this will need to change based on save draft/submit
-    transformedConfig.active = false;
     transformedConfig.enterprise_customer = enterpriseCustomerUuid;
     let err;
     // If we have a config that already exists, or a config that was created when authorized, post
@@ -176,6 +174,7 @@ const BlackboardConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => 
     // Otherwise post a new config
     } else {
       try {
+        transformedConfig.active = false;
         await LmsApiService.postNewBlackboardConfig(transformedConfig);
       } catch (error) {
         err = handleErrors(error);

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/CanvasConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/CanvasConfig.jsx
@@ -99,7 +99,6 @@ const CanvasConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
     event.preventDefault();
     const transformedConfig = snakeCaseDict(config);
 
-    transformedConfig.active = false;
     transformedConfig.enterprise_customer = enterpriseCustomerUuid;
     let err;
     let fetchedConfigId;
@@ -115,6 +114,7 @@ const CanvasConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
     // If the config didn't previously exist, create it
     } else if (isEmpty(existingData)) {
       try {
+        transformedConfig.active = false;
         const response = await LmsApiService.postNewCanvasConfig(transformedConfig);
         fetchedConfigId = response.data.id;
       } catch (error) {
@@ -148,8 +148,6 @@ const CanvasConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
   const handleSubmit = async (event) => {
     event.preventDefault();
     const transformedConfig = snakeCaseDict(config);
-    // this will need to change based on save draft/submit
-    transformedConfig.active = false;
     transformedConfig.enterprise_customer = enterpriseCustomerUuid;
     let err;
 
@@ -161,6 +159,7 @@ const CanvasConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
       }
     } else {
       try {
+        transformedConfig.active = false;
         await LmsApiService.postNewCanvasConfig(transformedConfig);
       } catch (error) {
         err = handleErrors(error);

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/CornerstoneConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/CornerstoneConfig.jsx
@@ -42,8 +42,6 @@ const CornerstoneConfig = ({ enterpriseCustomerUuid, onClick, existingData }) =>
   const handleSubmit = async (event) => {
     event.preventDefault();
     const transformedConfig = snakeCaseDict(config);
-    // this will need to change based on save draft/submit
-    transformedConfig.active = false;
     transformedConfig.enterprise_customer = enterpriseCustomerUuid;
     let err;
 
@@ -55,6 +53,7 @@ const CornerstoneConfig = ({ enterpriseCustomerUuid, onClick, existingData }) =>
       }
     } else {
       try {
+        transformedConfig.active = false;
         await LmsApiService.postNewCornerstoneConfig(transformedConfig);
       } catch (error) {
         err = handleErrors(error);

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/Degreed2Config.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/Degreed2Config.jsx
@@ -45,8 +45,6 @@ const Degreed2Config = ({ enterpriseCustomerUuid, onClick, existingData }) => {
 
   const handleSubmit = async () => {
     const transformedConfig = snakeCaseDict(config);
-    // this will need to change based on save draft/submit
-    transformedConfig.active = false;
     transformedConfig.enterprise_customer = enterpriseCustomerUuid;
     let err;
 
@@ -58,6 +56,7 @@ const Degreed2Config = ({ enterpriseCustomerUuid, onClick, existingData }) => {
       }
     } else {
       try {
+        transformedConfig.active = false;
         await LmsApiService.postNewDegreed2Config(transformedConfig);
       } catch (error) {
         err = handleErrors(error);

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/DegreedConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/DegreedConfig.jsx
@@ -55,8 +55,6 @@ const DegreedConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
 
   const handleSubmit = async () => {
     const transformedConfig = snakeCaseDict(config);
-    // this will need to change based on save draft/submit
-    transformedConfig.active = false;
     transformedConfig.enterprise_customer = enterpriseCustomerUuid;
     let err;
 
@@ -68,6 +66,7 @@ const DegreedConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
       }
     } else {
       try {
+        transformedConfig.active = false;
         await LmsApiService.postNewDegreedConfig(transformedConfig);
       } catch (error) {
         err = handleErrors(error);

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/MoodleConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/MoodleConfig.jsx
@@ -63,8 +63,6 @@ const MoodleConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
   const handleSubmit = async (event) => {
     event.preventDefault();
     const transformedConfig = snakeCaseDict(config);
-    // this will need to change based on save draft/submit
-    transformedConfig.active = false;
     transformedConfig.enterprise_customer = enterpriseCustomerUuid;
     let err;
 
@@ -76,6 +74,7 @@ const MoodleConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
       }
     } else {
       try {
+        transformedConfig.active = false;
         await LmsApiService.postNewMoodleConfig(transformedConfig);
       } catch (error) {
         err = handleErrors(error);

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/SAPConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/SAPConfig.jsx
@@ -55,8 +55,6 @@ const SAPConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
   const handleSubmit = async (event) => {
     event.preventDefault();
     const transformedConfig = snakeCaseDict(config);
-    // this will need to change based on save draft/submit
-    transformedConfig.active = false;
     transformedConfig.enterprise_customer = enterpriseCustomerUuid;
     let err;
 
@@ -68,6 +66,7 @@ const SAPConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
       }
     } else {
       try {
+        transformedConfig.active = false;
         await LmsApiService.postNewSuccessFactorsConfig(transformedConfig);
       } catch (error) {
         err = handleErrors(error);

--- a/src/components/settings/SettingsLMSTab/tests/BlackboardConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/BlackboardConfig.test.jsx
@@ -114,7 +114,6 @@ describe('<BlackboardConfig />', () => {
 
     userEvent.click(screen.getByText('Submit'));
     const expectedConfig = {
-      active: false,
       blackboard_base_url: 'https://www.test.com',
       display_name: 'displayName',
       enterprise_customer: enterpriseId,

--- a/src/components/settings/SettingsLMSTab/tests/CanvasConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/CanvasConfig.test.jsx
@@ -135,7 +135,6 @@ describe('<CanvasConfig />', () => {
     await waitFor(() => screen.getByText('Submit'));
 
     const expectedConfig = {
-      active: false,
       canvas_base_url: 'https://www.test4.com',
       canvas_account_id: '3',
       client_id: 'test1',

--- a/src/components/settings/SettingsLMSTab/tests/CornerstoneConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/CornerstoneConfig.test.jsx
@@ -79,7 +79,6 @@ describe('<CornerstoneConfig />', () => {
     fireEvent.click(screen.getByText('Submit'));
 
     const expectedConfig = {
-      active: false,
       cornerstone_base_url: 'https://www.test1.com',
       display_name: 'displayName',
       enterprise_customer: enterpriseId,

--- a/src/components/settings/SettingsLMSTab/tests/Degreed2Config.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/Degreed2Config.test.jsx
@@ -92,7 +92,6 @@ describe('<DegreedConfig />', () => {
     fireEvent.click(screen.getByText('Submit'));
 
     const expectedConfig = {
-      active: false,
       degreed_base_url: 'https://test1.com',
       display_name: 'displayName',
       client_id: 'test1',

--- a/src/components/settings/SettingsLMSTab/tests/DegreedConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/DegreedConfig.test.jsx
@@ -113,7 +113,6 @@ describe('<DegreedConfig />', () => {
     fireEvent.click(screen.getByText('Submit'));
 
     const expectedConfig = {
-      active: false,
       degreed_base_url: 'https://test1.com',
       degreed_company_id: 'test3',
       degreed_user_id: 'test5',

--- a/src/components/settings/SettingsLMSTab/tests/MoodleConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/MoodleConfig.test.jsx
@@ -91,7 +91,6 @@ describe('<MoodleConfig />', () => {
     fireEvent.click(screen.getByText('Submit'));
 
     const expectedConfig = {
-      active: false,
       moodle_base_url: 'https://www.test1.com',
       service_short_name: 'test2',
       display_name: 'displayName',

--- a/src/components/settings/SettingsLMSTab/tests/SAPConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/SAPConfig.test.jsx
@@ -109,7 +109,6 @@ describe('<SAPConfig />', () => {
     fireEvent.click(screen.getByText('Submit'));
 
     const expectedConfig = {
-      active: false,
       sapsf_base_url: 'https://www.test.com',
       sapsf_company_id: '3',
       sapsf_user_id: 'test4',

--- a/src/components/settings/data/constants.js
+++ b/src/components/settings/data/constants.js
@@ -10,7 +10,6 @@ const SSO_TAB_LABEL = 'SAML';
 
 export const HELP_CENTER_LINK = 'https://business-support.edx.org/hc/en-us/categories/360000368453-Integrations';
 export const HELP_CENTER_SAML_LINK = 'https://business-support.edx.org/hc/en-us/articles/360005421073-5-Implementing-Single-Sign-on-SSO-with-edX';
-export const HELP_CENTER_EMAIL = 'customersuccess@edx.org';
 export const SUCCESS_LABEL = 'success';
 export const TOGGLE_SUCCESS_LABEL = 'toggle success';
 export const DELETE_SUCCESS_LABEL = 'delete success';

--- a/src/data/services/LmsApiService.js
+++ b/src/data/services/LmsApiService.js
@@ -168,7 +168,7 @@ class LmsApiService {
   }
 
   static deleteCanvasConfig(configId) {
-    return LmsApiService.apiClient().delete(`${LmsApiService.lmsIntegrationUrl}/Canvas/configuration/${configId}/`);
+    return LmsApiService.apiClient().delete(`${LmsApiService.lmsIntegrationUrl}/canvas/configuration/${configId}/`);
   }
 
   static fetchBlackboardGlobalConfig() {


### PR DESCRIPTION
# For all changes

- Error modal’s contact support buttons (for both modals related to existing config kebab menu usage and config form usage) should link to   and open in a new tab
- The url used for deleting Canvas configs needs to be fixed /Canvas/ => /canvas/
- For all channels, config forms should only set the config to inactive when creating a new config    
- currently `active=false` is being appended to all payloads 
# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
