### PR TITLE
fix: invalidate cached subsidy request configuration after toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2725,27 +2725,42 @@
       }
     },
     "@edx/frontend-platform": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-1.11.0.tgz",
-      "integrity": "sha512-XtqKPWUvXzPJLlIEsoLMuac3TvTtAe1GY9MKu1QQsZDget1plDZqaf3ByRbuxOW8b2g2JVPvFx+Jm3FxTcrmIQ==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-1.15.6.tgz",
+      "integrity": "sha512-hvcJwRLy4JBdyBjHgu11nrqmMTWI901q6Ax83pf+yQpz68PpsJ0KdFjerxnkNJjU//XrWUuhSLesOPY2ntIjjg==",
       "requires": {
         "@cospired/i18n-iso-languages": "2.2.0",
-        "axios": "0.21.1",
-        "axios-cache-adapter": "^2.5.0",
+        "axios": "0.26.1",
+        "axios-cache-adapter": "2.7.3",
         "form-urlencoded": "4.1.4",
-        "glob": "7.1.7",
+        "glob": "7.2.0",
         "history": "4.10.1",
         "i18n-iso-countries": "4.3.1",
-        "jwt-decode": "2.2.0",
-        "localforage": "^1.9.0",
-        "localforage-memoryStorageDriver": "^0.9.2",
+        "jwt-decode": "3.1.2",
+        "localforage": "1.10.0",
+        "localforage-memoryStorageDriver": "0.9.2",
         "lodash.camelcase": "4.3.0",
         "lodash.memoize": "4.1.2",
         "lodash.merge": "4.6.2",
         "lodash.snakecase": "4.1.1",
-        "pubsub-js": "1.9.3",
+        "pubsub-js": "1.9.4",
         "react-intl": "2.9.0",
         "universal-cookie": "4.0.4"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "@edx/new-relic-source-map-webpack-plugin": {
@@ -5642,11 +5657,18 @@
       }
     },
     "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.8"
+      },
+      "dependencies": {
+        "follow-redirects": {
+          "version": "1.14.9",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+          "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+        }
       }
     },
     "axios-cache-adapter": {
@@ -9946,7 +9968,8 @@
     "follow-redirects": {
       "version": "1.14.5",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
+      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
+      "dev": true
     },
     "font-awesome": {
       "version": "4.7.0",
@@ -10406,6 +10429,7 @@
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -13272,9 +13296,9 @@
       "dev": true
     },
     "jwt-decode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
-      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "keyv": {
       "version": "3.0.0",
@@ -15518,9 +15542,9 @@
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "pubsub-js": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/pubsub-js/-/pubsub-js-1.9.3.tgz",
-      "integrity": "sha512-FhYYlPNOywTh7zN38u5AlG67emA47w6JZd7YgdQU1w8gQbZhhIGxVM0AQosdaINHb2ALb+fhfnVyBJAt4D4IzA=="
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/pubsub-js/-/pubsub-js-1.9.4.tgz",
+      "integrity": "sha512-hJYpaDvPH4w8ZX/0Fdf9ma1AwRgU353GfbaVfPjfJQf1KxZ2iHaHl3fAUw1qlJIR5dr4F3RzjGaWohYUEyoh7A=="
     },
     "pump": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@edx/frontend-enterprise-catalog-search": "2.5.0",
     "@edx/frontend-enterprise-logistration": "1.1.2",
     "@edx/frontend-enterprise-utils": "1.3.0",
-    "@edx/frontend-platform": "1.11.0",
+    "@edx/frontend-platform": "1.15.6",
     "@edx/paragon": "19.13.6",
     "@fortawesome/fontawesome-svg-core": "1.2.35",
     "@fortawesome/free-brands-svg-icons": "5.15.3",

--- a/src/components/SubsidyRequestManagementTable/tests/CourseTitleCell.test.jsx
+++ b/src/components/SubsidyRequestManagementTable/tests/CourseTitleCell.test.jsx
@@ -34,7 +34,7 @@ const defaultProps = {
 };
 
 describe('CourseTitleCell', () => {
-  test('renders', () => {
+  test('renders', async () => {
     const mockCourseDetails = { shortDescription: 'Test short description' };
     const mockPromiseResolve = Promise.resolve({ data: mockCourseDetails });
     DiscoveryApiService.fetchCourseDetails.mockReturnValue(mockPromiseResolve);
@@ -46,10 +46,10 @@ describe('CourseTitleCell', () => {
     renderWithRouter(Component);
     userEvent.click(screen.getByText(defaultProps.row.original.courseTitle));
     expect(screen.getByText('Loading course details...'));
-    waitFor(() => {
+    await waitFor(() => {
       screen.getByText(mockCourseDetails.shortDescription);
       screen.getByText('Learn more about this course');
-      screen.getByLabelText('in a new tab');
+      screen.getByText('in a new tab');
     });
   });
 });

--- a/src/components/subsidy-request-configuration/SubsidyRequestConfigurationContextProvider.jsx
+++ b/src/components/subsidy-request-configuration/SubsidyRequestConfigurationContextProvider.jsx
@@ -43,7 +43,7 @@ const SubsidyRequestConfigurationContextProviderWrapper = ({ enableBrowseAndRequ
       subsidyRequestsEnabled: false,
       subsidyType: null,
     },
-    isLoading: false,
+    updateSubsidyRequestConfiguration: () => {},
   }), []);
 
   return (

--- a/src/components/subsidy-request-configuration/data/tests/hooks.test.js
+++ b/src/components/subsidy-request-configuration/data/tests/hooks.test.js
@@ -52,7 +52,9 @@ describe('useSubsidyRequestConfiguration', () => {
 
     await waitForNextUpdate();
 
-    expect(EnterpriseAccessApiService.getSubsidyRequestConfiguration).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
+    expect(EnterpriseAccessApiService.getSubsidyRequestConfiguration).toHaveBeenCalledWith(
+      { clearCacheEntry: false, enterpriseId: TEST_ENTERPRISE_UUID },
+    );
 
     expect(result.current.subsidyRequestConfiguration).toEqual(
       camelCaseObject(TEST_CONFIGURATION_RESPONSE.data),
@@ -67,7 +69,9 @@ describe('useSubsidyRequestConfiguration', () => {
 
     await waitForNextUpdate();
 
-    expect(EnterpriseAccessApiService.getSubsidyRequestConfiguration).toHaveBeenCalledWith(TEST_ENTERPRISE_UUID);
+    expect(EnterpriseAccessApiService.getSubsidyRequestConfiguration).toHaveBeenCalledWith(
+      { clearCacheEntry: false, enterpriseId: TEST_ENTERPRISE_UUID },
+    );
     expect(result.current.subsidyRequestConfiguration).toEqual(
       camelCaseObject(TEST_CONFIGURATION_RESPONSE.data),
     );
@@ -183,16 +187,20 @@ describe('useSubsidyRequestConfiguration', () => {
 
   describe('updateSubsidyRequestConfiguration', () => {
     it('should update a configuration correctly', async () => {
-      EnterpriseAccessApiService.getSubsidyRequestConfiguration.mockResolvedValue(
+      EnterpriseAccessApiService.getSubsidyRequestConfiguration.mockResolvedValueOnce(
         createSubsidyRequestConfigurationResponse({
           subsidyRequestsEnabled: false,
         }),
-      );
-      EnterpriseAccessApiService.updateSubsidyRequestConfiguration.mockResolvedValue(
+      ).mockResolvedValueOnce(createSubsidyRequestConfigurationResponse({
+        subsidyRequestsEnabled: true,
+      }));
+
+      EnterpriseAccessApiService.updateSubsidyRequestConfiguration.mockResolvedValueOnce(
         createSubsidyRequestConfigurationResponse({
           subsidyRequestsEnabled: true,
         }),
       );
+
       const { result } = renderHook(() => useSubsidyRequestConfiguration(TEST_ENTERPRISE_UUID));
 
       await waitFor(() => {
@@ -205,7 +213,13 @@ describe('useSubsidyRequestConfiguration', () => {
         isSubsidyRequestsEnabled: true,
       }));
 
-      expect(result.current.subsidyRequestConfiguration.subsidyRequestsEnabled).toEqual(true);
+      await waitFor(() => {
+        expect(result.current.subsidyRequestConfiguration.subsidyRequestsEnabled).toEqual(true);
+      });
+
+      expect(EnterpriseAccessApiService.getSubsidyRequestConfiguration).toHaveBeenCalledWith(
+        { clearCacheEntry: true, enterpriseId: TEST_ENTERPRISE_UUID },
+      );
     });
 
     it('should handle errors', async () => {

--- a/src/data/services/EnterpriseAccessApiService.js
+++ b/src/data/services/EnterpriseAccessApiService.js
@@ -7,11 +7,11 @@ class EnterpriseAccessApiService {
 
   static apiClient = getAuthenticatedHttpClient;
 
-  static getSubsidyRequestConfiguration(enterpriseId) {
+  static getSubsidyRequestConfiguration({ enterpriseId, clearCacheEntry = false }) {
     const url = `${EnterpriseAccessApiService.baseUrl}/customer-configurations/${enterpriseId}/`;
     return EnterpriseAccessApiService.apiClient({
       useCache: configuration.USE_API_CACHE,
-    }).get(url);
+    }).get(url, { clearCacheEntry });
   }
 
   static createSubsidyRequestConfiguration({

--- a/src/data/services/tests/EnterpriseAccessApiService.test.js
+++ b/src/data/services/tests/EnterpriseAccessApiService.test.js
@@ -96,9 +96,10 @@ describe('EnterpriseAccessApiService', () => {
   });
 
   test('getSubsidyRequestConfiguration calls enterprise-access to fetch subsidy request configuration', () => {
-    EnterpriseAccessApiService.getSubsidyRequestConfiguration(mockEnterpriseUUID);
+    EnterpriseAccessApiService.getSubsidyRequestConfiguration({ enterpriseId: mockEnterpriseUUID });
     expect(axios.get).toBeCalledWith(
           `${enterpriseAccessBaseUrl}/api/v1/customer-configurations/${mockEnterpriseUUID}/`,
+          { clearCacheEntry: false },
     );
   });
 


### PR DESCRIPTION
- invalidate cache after updating subsidy request configuration
- relies on fix in https://github.com/openedx/frontend-platform/pull/311
- fix test that was using waitFor without await

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
