### PR TITLE
fix: pass enterprise customer uuid to backend when we create a new report configuration

### DIFF
--- a/src/components/ReportingConfig/ReportingConfigForm.jsx
+++ b/src/components/ReportingConfig/ReportingConfigForm.jsx
@@ -122,6 +122,7 @@ class ReportingConfigForm extends React.Component {
       }
     } else {
       // ...or create a new configuration
+      formData.append('enterprise_customer_id', this.props.enterpriseCustomerUuid);
       const err = await this.props.createConfig(formData);
       if (err) {
         this.setState({ submitState: SUBMIT_STATES.ERROR });
@@ -381,6 +382,7 @@ ReportingConfigForm.defaultProps = {
 };
 
 ReportingConfigForm.propTypes = {
+  enterpriseCustomerUuid: PropTypes.string.isRequired,
   config: PropTypes.shape({
     active: PropTypes.bool,
     dataType: PropTypes.string,

--- a/src/components/ReportingConfig/index.jsx
+++ b/src/components/ReportingConfig/index.jsx
@@ -167,6 +167,7 @@ class ReportingConfig extends React.Component {
                     deleteConfig={this.deleteConfig}
                     availableCatalogs={camelCaseObject(availableCatalogs)}
                     reportingConfigTypes={camelCaseObject(reportingConfigTypes)}
+                    enterpriseCustomerUuid={this.props.enterpriseId}
                   />
                 </Collapsible>
               </div>
@@ -180,6 +181,7 @@ class ReportingConfig extends React.Component {
               <div>
                 <ReportingConfigForm
                   createConfig={this.createConfig}
+                  enterpriseCustomerUuid={this.props.enterpriseId}
                   availableCatalogs={camelCaseObject(availableCatalogs)}
                   reportingConfigTypes={camelCaseObject(reportingConfigTypes)}
                 />


### PR DESCRIPTION


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
