### PR TITLE
chore: validating existing LMS configs on load in the settings page

### DIFF
--- a/src/components/settings/SettingsLMSTab/LMSConfigs/BlackboardConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/BlackboardConfig.jsx
@@ -192,16 +192,23 @@ const BlackboardConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => 
     switch (field) {
       case 'Blackboard Base URL':
         setBlackboardBaseUrl(input);
-        setUrlValid(urlValidation(input) || input.length === 0);
+        setUrlValid(urlValidation(input) || input?.length === 0);
         break;
       case 'Display Name':
         setDisplayName(input);
-        setNameValid(input.length <= 20);
+        setNameValid(input?.length <= 20);
         break;
       default:
         break;
     }
   };
+
+  useEffect(() => {
+    if (!isEmpty(existingData)) {
+      validateField('Blackboard Base URL', existingData.blackboardBaseUrl);
+      validateField('Display Name', existingData.displayName);
+    }
+  }, [existingData]);
 
   return (
     <span>

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/CanvasConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/CanvasConfig.jsx
@@ -173,16 +173,23 @@ const CanvasConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
     switch (field) {
       case 'Canvas Base URL':
         setCanvasBaseUrl(input);
-        setUrlValid(urlValidation(input) || input.length === 0);
+        setUrlValid(urlValidation(input) || input?.length === 0);
         break;
       case 'Display Name':
         setDisplayName(input);
-        setNameValid(input.length <= 20);
+        setNameValid(input?.length <= 20);
         break;
       default:
         break;
     }
   };
+
+  useEffect(() => {
+    if (!isEmpty(existingData)) {
+      validateField('Canvas Base URL', existingData.canvasBaseUrl);
+      validateField('Display Name', existingData.displayName);
+    }
+  }, [existingData]);
 
   return (
     <span>

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/CornerstoneConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/CornerstoneConfig.jsx
@@ -70,16 +70,23 @@ const CornerstoneConfig = ({ enterpriseCustomerUuid, onClick, existingData }) =>
     switch (field) {
       case 'Cornerstone Base URL':
         setCornerstoneBaseUrl(input);
-        setUrlValid(urlValidation(input) || input.length === 0);
+        setUrlValid(urlValidation(input) || input?.length === 0);
         break;
       case 'Display Name':
         setDisplayName(input);
-        setNameValid(input.length <= 20);
+        setNameValid(input?.length <= 20);
         break;
       default:
         break;
     }
   };
+
+  useEffect(() => {
+    if (!isEmpty(existingData)) {
+      validateField('Cornerstone Base URL', existingData.cornerstoneBaseUrl);
+      validateField('Display Name', existingData.displayName);
+    }
+  }, [existingData]);
 
   return (
     <span>

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/Degreed2Config.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/Degreed2Config.jsx
@@ -78,20 +78,28 @@ const Degreed2Config = ({ enterpriseCustomerUuid, onClick, existingData }) => {
     switch (field) {
       case 'Degreed Token Fetch Base Url':
         setDegreedFetchUrl(input);
-        setFetchUrlValid(urlValidation(input) || input.length === 0);
+        setFetchUrlValid(urlValidation(input) || input?.length === 0);
         break;
       case 'Degreed Base URL':
         setDegreedBaseUrl(input);
-        setUrlValid(urlValidation(input) || input.length === 0);
+        setUrlValid(urlValidation(input) || input?.length === 0);
         break;
       case 'Display Name':
         setDisplayName(input);
-        setNameValid(input.length <= 20);
+        setNameValid(input?.length <= 20);
         break;
       default:
         break;
     }
   };
+
+  useEffect(() => {
+    if (!isEmpty(existingData)) {
+      validateField('Degreed Base URL', existingData.degreedBaseUrl);
+      validateField('Display Name', existingData.displayName);
+      validateField('Degreed Token Fetch Base Url', existingData.degreedFetchUrl);
+    }
+  }, [existingData]);
 
   return (
     <span>
@@ -124,7 +132,6 @@ const Degreed2Config = ({ enterpriseCustomerUuid, onClick, existingData }) => {
             maxLength={255}
             onChange={(e) => {
               setEdited(true);
-              validateField('API Client ID', e.target.value);
               setClientId(e.target.value);
             }}
             floatingLabel="API Client ID"
@@ -138,7 +145,6 @@ const Degreed2Config = ({ enterpriseCustomerUuid, onClick, existingData }) => {
             maxLength={255}
             onChange={(e) => {
               setEdited(true);
-              validateField('API Client Secret', e.target.value);
               setClientSecret(e.target.value);
             }}
             floatingLabel="API Client Secret"

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/DegreedConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/DegreedConfig.jsx
@@ -83,16 +83,23 @@ const DegreedConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
     switch (field) {
       case 'Degreed Base URL':
         setDegreedBaseUrl(input);
-        setUrlValid(urlValidation(input) || input.length === 0);
+        setUrlValid(urlValidation(input) || input?.length === 0);
         break;
       case 'Display Name':
         setDisplayName(input);
-        setNameValid(input.length <= 20);
+        setNameValid(input?.length <= 20);
         break;
       default:
         break;
     }
   };
+
+  useEffect(() => {
+    if (!isEmpty(existingData)) {
+      validateField('Degreed Base URL', existingData.degreedBaseUrl);
+      validateField('Display Name', existingData.displayName);
+    }
+  }, [existingData]);
 
   return (
     <span>

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/MoodleConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/MoodleConfig.jsx
@@ -91,16 +91,23 @@ const MoodleConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
     switch (field) {
       case 'Moodle Base URL':
         setMoodleBaseUrl(input);
-        setUrlValid(urlValidation(input) || input.length === 0);
+        setUrlValid(urlValidation(input) || input?.length === 0);
         break;
       case 'Display Name':
         setDisplayName(input);
-        setNameValid(input.length <= 20);
+        setNameValid(input?.length <= 20);
         break;
       default:
         break;
     }
   };
+
+  useEffect(() => {
+    if (!isEmpty(existingData)) {
+      validateField('Moodle Base URL', existingData.moodleBaseUrl);
+      validateField('Display Name', existingData.displayName);
+    }
+  }, [existingData]);
 
   return (
     <span>

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/SAPConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/SAPConfig.jsx
@@ -82,16 +82,23 @@ const SAPConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
     switch (field) {
       case 'SAP Base URL':
         setSapsfBaseUrl(input);
-        setUrlValid(urlValidation(input) || input.length === 0);
+        setUrlValid(urlValidation(input) || input?.length === 0);
         break;
       case 'Display Name':
         setDisplayName(input);
-        setNameValid(input.length <= 20);
+        setNameValid(input?.length <= 20);
         break;
       default:
         break;
     }
   };
+
+  useEffect(() => {
+    if (!isEmpty(existingData)) {
+      validateField('SAP Base URL', existingData.sapsfBaseUrl);
+      validateField('Display Name', existingData.displayName);
+    }
+  }, [existingData]);
 
   return (
     <span>

--- a/src/components/settings/SettingsLMSTab/tests/BlackboardConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/BlackboardConfig.test.jsx
@@ -42,6 +42,11 @@ const existingConfigDataNoAuth = {
   displayName: 'foobar',
   blackboardBaseUrl: 'https://foobarish.com',
 };
+// Existing invalid data that will be validated on load
+const invalidExistingData = {
+  displayName: 'fooooooooobaaaaaaaaar',
+  blackboardBaseUrl: 'bad_url :^(',
+};
 
 afterEach(() => {
   jest.clearAllMocks();
@@ -246,5 +251,27 @@ describe('<BlackboardConfig />', () => {
     expect(mockUpdateConfigApi).not.toHaveBeenCalled();
     expect(window.open).toHaveBeenCalled();
     expect(mockFetchSingleConfig).toHaveBeenCalledWith(1);
+  });
+  test('validates poorly formatted existing data on load', () => {
+    render(
+      <BlackboardConfig
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={invalidExistingData}
+      />,
+    );
+    expect(screen.getByText(INVALID_LINK)).toBeInTheDocument();
+    expect(screen.getByText(INVALID_NAME)).toBeInTheDocument();
+  });
+  test('validates properly formatted existing data on load', () => {
+    render(
+      <BlackboardConfig
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={existingConfigDataNoAuth}
+      />,
+    );
+    expect(screen.queryByText(INVALID_LINK)).not.toBeInTheDocument();
+    expect(screen.queryByText(INVALID_NAME)).not.toBeInTheDocument();
   });
 });

--- a/src/components/settings/SettingsLMSTab/tests/CanvasConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/CanvasConfig.test.jsx
@@ -34,6 +34,11 @@ const existingConfigData = {
   id: 1,
   displayName: 'foobarss',
 };
+// Existing invalid data that will be validated on load
+const invalidExistingData = {
+  displayName: 'fooooooooobaaaaaaaaar',
+  canvasBaseUrl: 'bad_url :^(',
+};
 // Existing config data that has not been authorized
 const existingConfigDataNoAuth = {
   id: 1,
@@ -280,5 +285,27 @@ describe('<CanvasConfig />', () => {
     expect(mockUpdateConfigApi).not.toHaveBeenCalled();
     expect(window.open).toHaveBeenCalled();
     expect(mockFetchSingleConfig).toHaveBeenCalledWith(1);
+  });
+  test('validates poorly formatted existing data on load', () => {
+    render(
+      <CanvasConfig
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={invalidExistingData}
+      />,
+    );
+    expect(screen.getByText(INVALID_LINK)).toBeInTheDocument();
+    expect(screen.getByText(INVALID_NAME)).toBeInTheDocument();
+  });
+  test('validates properly formatted existing data on load', () => {
+    render(
+      <CanvasConfig
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={existingConfigDataNoAuth}
+      />,
+    );
+    expect(screen.queryByText(INVALID_LINK)).not.toBeInTheDocument();
+    expect(screen.queryByText(INVALID_NAME)).not.toBeInTheDocument();
   });
 });

--- a/src/components/settings/SettingsLMSTab/tests/CornerstoneConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/CornerstoneConfig.test.jsx
@@ -14,8 +14,15 @@ const enterpriseId = 'test-enterprise-id';
 
 const mockOnClick = jest.fn();
 const noExistingData = {};
+// Existing invalid data that will be validated on load
+const invalidExistingData = {
+  displayName: 'fooooooooobaaaaaaaaar',
+  cornerstoneBaseUrl: 'bad_url :^(',
+};
 const existingConfigData = {
   id: 1,
+  cornerstoneBaseUrl: 'https://foobar.com',
+  displayName: 'test display name',
 };
 
 afterEach(() => {
@@ -129,5 +136,27 @@ describe('<CornerstoneConfig />', () => {
       enterprise_customer: enterpriseId,
     };
     expect(LmsApiService.postNewCornerstoneConfig).toHaveBeenCalledWith(expectedConfig);
+  });
+  test('validates poorly formatted existing data on load', () => {
+    render(
+      <CornerstoneConfig
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={invalidExistingData}
+      />,
+    );
+    expect(screen.getByText(INVALID_LINK)).toBeInTheDocument();
+    expect(screen.getByText(INVALID_NAME)).toBeInTheDocument();
+  });
+  test('validates properly formatted existing data on load', () => {
+    render(
+      <CornerstoneConfig
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={existingConfigData}
+      />,
+    );
+    expect(screen.queryByText(INVALID_LINK)).not.toBeInTheDocument();
+    expect(screen.queryByText(INVALID_NAME)).not.toBeInTheDocument();
   });
 });

--- a/src/components/settings/SettingsLMSTab/tests/Degreed2Config.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/Degreed2Config.test.jsx
@@ -15,14 +15,23 @@ const mockOnClick = jest.fn();
 const noExistingData = {};
 const existingConfigData = {
   id: 1,
+  displayName: 'test ayylmao',
+  degreedBaseUrl: 'https://foobar.com',
+  degreedFetchUrl: 'https://foobar.com',
+};
+// Existing invalid data that will be validated on load
+const invalidExistingData = {
+  displayName: 'fooooooooobaaaaaaaaar',
+  degreedBaseUrl: 'bad_url :^(',
+  degreedFetchUrl: '',
 };
 
 afterEach(() => {
   jest.clearAllMocks();
 });
 
-describe('<DegreedConfig />', () => {
-  test('renders Degreed Config Form', () => {
+describe('<Degreed2Config />', () => {
+  test('renders Degreed2 Config Form', () => {
     render(
       <Degreed2Config
         enterpriseCustomerUuid={enterpriseId}
@@ -163,5 +172,27 @@ describe('<DegreedConfig />', () => {
       enterprise_customer: enterpriseId,
     };
     expect(LmsApiService.postNewDegreed2Config).toHaveBeenCalledWith(expectedConfig);
+  });
+  test('validates poorly formatted existing data on load', () => {
+    render(
+      <Degreed2Config
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={invalidExistingData}
+      />,
+    );
+    expect(screen.getByText(INVALID_LINK)).toBeInTheDocument();
+    expect(screen.getByText(INVALID_NAME)).toBeInTheDocument();
+  });
+  test('validates properly formatted existing data on load', () => {
+    render(
+      <Degreed2Config
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={existingConfigData}
+      />,
+    );
+    expect(screen.queryByText(INVALID_LINK)).not.toBeInTheDocument();
+    expect(screen.queryByText(INVALID_NAME)).not.toBeInTheDocument();
   });
 });

--- a/src/components/settings/SettingsLMSTab/tests/DegreedConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/DegreedConfig.test.jsx
@@ -15,6 +15,13 @@ const mockOnClick = jest.fn();
 const noExistingData = {};
 const existingConfigData = {
   id: 1,
+  displayName: 'test ayylmao',
+  degreedBaseUrl: 'https://foobar.com',
+};
+// Existing invalid data that will be validated on load
+const invalidExistingData = {
+  displayName: 'fooooooooobaaaaaaaaar',
+  degreedBaseUrl: 'bad_url :^(',
 };
 
 afterEach(() => {
@@ -188,5 +195,27 @@ describe('<DegreedConfig />', () => {
       enterprise_customer: enterpriseId,
     };
     expect(LmsApiService.postNewDegreedConfig).toHaveBeenCalledWith(expectedConfig);
+  });
+  test('validates poorly formatted existing data on load', () => {
+    render(
+      <DegreedConfig
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={invalidExistingData}
+      />,
+    );
+    expect(screen.getByText(INVALID_LINK)).toBeInTheDocument();
+    expect(screen.getByText(INVALID_NAME)).toBeInTheDocument();
+  });
+  test('validates properly formatted existing data on load', () => {
+    render(
+      <DegreedConfig
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={existingConfigData}
+      />,
+    );
+    expect(screen.queryByText(INVALID_LINK)).not.toBeInTheDocument();
+    expect(screen.queryByText(INVALID_NAME)).not.toBeInTheDocument();
   });
 });

--- a/src/components/settings/SettingsLMSTab/tests/MoodleConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/MoodleConfig.test.jsx
@@ -15,6 +15,13 @@ const mockOnClick = jest.fn();
 const noExistingData = {};
 const existingConfigData = {
   id: 1,
+  moodleBaseUrl: 'https://foobarish.com',
+  displayName: 'foobar',
+};
+// Existing invalid data that will be validated on load
+const invalidExistingData = {
+  displayName: 'fooooooooobaaaaaaaaar',
+  moodleBaseUrl: 'bad_url :^(',
 };
 
 afterEach(() => {
@@ -151,5 +158,27 @@ describe('<MoodleConfig />', () => {
       enterprise_customer: enterpriseId,
     };
     expect(LmsApiService.postNewMoodleConfig).toHaveBeenCalledWith(expectedConfig);
+  });
+  test('validates poorly formatted existing data on load', () => {
+    render(
+      <MoodleConfig
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={invalidExistingData}
+      />,
+    );
+    expect(screen.getByText(INVALID_LINK)).toBeInTheDocument();
+    expect(screen.getByText(INVALID_NAME)).toBeInTheDocument();
+  });
+  test('validates properly formatted existing data on load', () => {
+    render(
+      <MoodleConfig
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={existingConfigData}
+      />,
+    );
+    expect(screen.queryByText(INVALID_LINK)).not.toBeInTheDocument();
+    expect(screen.queryByText(INVALID_NAME)).not.toBeInTheDocument();
   });
 });

--- a/src/components/settings/SettingsLMSTab/tests/SAPConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/SAPConfig.test.jsx
@@ -15,6 +15,13 @@ const mockOnClick = jest.fn();
 const noExistingData = {};
 const existingConfigData = {
   id: 1,
+  displayName: 'foobar',
+  sapsfBaseUrl: 'https://foobarish.com',
+};
+// Existing invalid data that will be validated on load
+const invalidExistingData = {
+  displayName: 'fooooooooobaaaaaaaaar',
+  sapsfBaseUrl: 'bad_url :^(',
 };
 
 afterEach(() => {
@@ -182,5 +189,27 @@ describe('<SAPConfig />', () => {
       user_type: 'admin',
     };
     expect(LmsApiService.postNewSuccessFactorsConfig).toHaveBeenCalledWith(expectedConfig);
+  });
+  test('validates poorly formatted existing data on load', () => {
+    render(
+      <SAPConfig
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={invalidExistingData}
+      />,
+    );
+    expect(screen.getByText(INVALID_LINK)).toBeInTheDocument();
+    expect(screen.getByText(INVALID_NAME)).toBeInTheDocument();
+  });
+  test('validates properly formatted existing data on load', () => {
+    render(
+      <SAPConfig
+        enterpriseCustomerUuid={enterpriseId}
+        onClick={mockOnClick}
+        existingData={existingConfigData}
+      />,
+    );
+    expect(screen.queryByText(INVALID_LINK)).not.toBeInTheDocument();
+    expect(screen.queryByText(INVALID_NAME)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# Description
- LMS config settings page now validates existing configs when editing on load

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
