### PR TITLE
WIP feat: Add no available license/code banner to the settings page

### DIFF
--- a/src/components/settings/SettingsAccessTab/index.jsx
+++ b/src/components/settings/SettingsAccessTab/index.jsx
@@ -4,10 +4,13 @@ import PropTypes from 'prop-types';
 
 import { features } from '../../../config';
 import ContactCustomerSupportButton from '../../ContactCustomerSupportButton';
+import { NoAvailableCodesBanner, NoAvailableLicensesBanner } from '../../subsidy-request-management-alerts';
 import SettingsAccessLinkManagement from './SettingsAccessLinkManagement';
 import SettingsAccessSSOManagement from './SettingsAccessSSOManagement';
 import SettingsAccessSubsidyRequestManagement from './SettingsAccessSubsidyRequestManagement';
 import { SubsidyRequestConfigurationContext } from '../../subsidy-request-configuration';
+import { SUPPORTED_SUBSIDY_TYPES } from '../../../data/constants/subsidyRequests';
+import { SettingsContext } from '../SettingsContext';
 
 const SettingsAccessTab = ({
   enterpriseId,
@@ -23,6 +26,11 @@ const SettingsAccessTab = ({
     updateSubsidyRequestConfiguration,
   } = useContext(SubsidyRequestConfigurationContext);
 
+  const {
+    couponsData: { results: coupons },
+    customerAgreement: { subscriptions },
+  } = useContext(SettingsContext);
+
   const isEligibleForBrowseAndRequest = features.FEATURE_BROWSE_AND_REQUEST
    && enableBrowseAndRequest && !!subsidyRequestConfiguration?.subsidyType;
 
@@ -34,6 +42,12 @@ const SettingsAccessTab = ({
 
   return (
     <div className="settings-access-tab mt-4">
+      {subsidyRequestConfiguration?.subsidyType === SUPPORTED_SUBSIDY_TYPES.coupon
+       && subsidyRequestConfiguration?.subsidyRequestsEnabled
+        && <NoAvailableCodesBanner coupons={coupons} /> }
+      {subsidyRequestConfiguration?.subsidyType === SUPPORTED_SUBSIDY_TYPES.license
+       && subsidyRequestConfiguration?.subsidyRequestsEnabled
+        && <NoAvailableLicensesBanner subscriptions={subscriptions} /> }
       <Row>
         <Col>
           <h2>Enable browsing on-demand</h2>


### PR DESCRIPTION
https://openedx.atlassian.net/browse/ENT-5655

When B&R is enabled for a customer configuration, show a danger banner _on the settings page_ if no subsidies of the configured type are available:
<img width="1443" alt="image" src="https://user-images.githubusercontent.com/2307986/164498302-c980e89c-d96f-46f5-8fad-570214764bcf.png">


# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [x] Ensure to have UX team confirm screenshots
