### PR TITLE
feat: allow enterprise to select subsidy type for bnr

### DIFF
--- a/src/components/ConfirmationModal/ConfirmationModal.test.jsx
+++ b/src/components/ConfirmationModal/ConfirmationModal.test.jsx
@@ -1,0 +1,35 @@
+import {
+  render, screen,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/extend-expect';
+
+import ConfirmationModal from './index';
+
+describe('<ConfirmationModal />', () => {
+  const basicProps = {
+    isOpen: true,
+    onConfirm: jest.fn(),
+    onClose: jest.fn(),
+    body: 'Content',
+  };
+
+  it('should call onConfirm when confirm button is clicked', () => {
+    const mockHandleConfirm = jest.fn();
+    render(<ConfirmationModal {...basicProps} onConfirm={mockHandleConfirm} />);
+    userEvent.click(screen.getByText('Confirm'));
+    expect(mockHandleConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onClose when modal is closed', () => {
+    const mockHandleClose = jest.fn();
+    render(<ConfirmationModal {...basicProps} onClose={mockHandleClose} />);
+    userEvent.click(screen.getByText('Cancel'));
+    expect(mockHandleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should show error alert if confirmButtonState = error', () => {
+    render(<ConfirmationModal {...basicProps} confirmButtonState="errored" />);
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+});

--- a/src/components/ConfirmationModal/index.jsx
+++ b/src/components/ConfirmationModal/index.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  ModalDialog, ActionRow, Button, StatefulButton, Alert,
+} from '@edx/paragon';
+import { Info } from '@edx/paragon/icons';
+
+export const DEFAULT_TITLE = 'Are you sure?';
+export const CONFIRM_BUTTON_STATES = {
+  default: 'default',
+  pending: 'pending',
+  errored: 'errored',
+};
+
+const ConfirmationModal = ({
+  isOpen,
+  disabled,
+  confirmButtonLabels,
+  confirmButtonState,
+  onConfirm,
+  onClose,
+  title,
+  body,
+  confirmText,
+  cancelText,
+  ...rest
+}) => (
+  <ModalDialog
+    title="Confirmation Modal"
+    variant="default"
+    isOpen={isOpen}
+    onClose={onClose}
+    {...rest}
+  >
+    <ModalDialog.Header>
+      <ModalDialog.Title>
+        {title}
+      </ModalDialog.Title>
+      {confirmButtonState === CONFIRM_BUTTON_STATES.errored && (
+        <Alert
+          icon={Info}
+          variant="danger"
+        >
+          <Alert.Heading>
+            Something went wrong
+          </Alert.Heading>
+          Please try again.
+        </Alert>
+      )}
+    </ModalDialog.Header>
+    <ModalDialog.Body>
+      {body}
+    </ModalDialog.Body>
+    <ModalDialog.Footer>
+      <ActionRow>
+        <Button onClick={onClose} variant="outline-primary">
+          {cancelText}
+        </Button>
+        <StatefulButton
+          labels={confirmButtonLabels}
+          state={confirmButtonState}
+          variant="primary"
+          disabled={disabled}
+          onClick={onConfirm}
+        />
+      </ActionRow>
+    </ModalDialog.Footer>
+  </ModalDialog>
+);
+
+ConfirmationModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool,
+  confirmButtonLabels: PropTypes.shape({
+    default: PropTypes.string,
+    pending: PropTypes.string,
+    errored: PropTypes.string,
+  }),
+  confirmButtonState: PropTypes.oneOf(Object.values(CONFIRM_BUTTON_STATES)),
+  onConfirm: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+  title: PropTypes.node,
+  body: PropTypes.node.isRequired,
+  confirmText: PropTypes.string,
+  cancelText: PropTypes.string,
+};
+
+ConfirmationModal.defaultProps = {
+  disabled: false,
+  confirmButtonLabels: {
+    [CONFIRM_BUTTON_STATES.default]: 'Confirm',
+    [CONFIRM_BUTTON_STATES.pending]: 'Loading...',
+    [CONFIRM_BUTTON_STATES.errored]: 'Try again',
+  },
+  confirmButtonState: CONFIRM_BUTTON_STATES.default,
+  title: DEFAULT_TITLE,
+  confirmText: 'Confirm',
+  cancelText: 'Cancel',
+};
+
+export default ConfirmationModal;

--- a/src/components/EnterpriseApp/EnterpriseApp.test.jsx
+++ b/src/components/EnterpriseApp/EnterpriseApp.test.jsx
@@ -1,0 +1,67 @@
+import {
+  render, screen,
+} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
+
+import EnterpriseApp from './index';
+import { features } from '../../config';
+
+features.SETTINGS_PAGE = true;
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  __esModule: true,
+  // eslint-disable-next-line react/prop-types
+  Route: (props) => <span>{props.path}</span>,
+  Switch: (props) => props.children,
+  Redirect: () => 'redirect',
+}));
+
+jest.mock('../ProductTours/BrowseAndRequestTour', () => ({
+  __esModule: true,
+  default: () => 'BNR Product Tour',
+}));
+
+jest.mock('../../containers/Sidebar', () => ({
+  __esModule: true,
+  default: () => 'Side bar',
+}));
+
+describe('<EnterpriseApp />', () => {
+  const basicProps = {
+    match: {
+      url: '',
+      params: {
+        enterpriseSlug: 'foo',
+      },
+    },
+    location: {
+      pathname: '/',
+    },
+    history: {
+      replace: jest.fn(),
+    },
+    fetchPortalConfiguration: jest.fn(),
+    toggleSidebarToggle: jest.fn(),
+    loading: false,
+    enableLearnerPortal: true,
+  };
+
+  beforeEach(() => {
+    getAuthenticatedUser.mockReturnValue({
+      username: 'edx',
+      roles: ['enterprise_learner:*'],
+    });
+  });
+
+  it('should show settings page if there is at least one visible tab', () => {
+    render(<EnterpriseApp {...basicProps} />);
+    expect(screen.getByText('/admin/settings'));
+  });
+
+  it('should hide settings page if there are no visible tabs', () => {
+    render(<EnterpriseApp {...basicProps} enableLearnerPortal={false} />);
+    expect(screen.queryByText('/admin/settings')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/EnterpriseApp/index.jsx
+++ b/src/components/EnterpriseApp/index.jsx
@@ -94,6 +94,7 @@ class EnterpriseApp extends React.Component {
       enableSubscriptionManagementScreen,
       enableAnalyticsScreen,
       enableSamlConfigurationScreen,
+      enableLearnerPortal,
       enableLmsConfigurationsScreen,
       enterpriseId,
       loading,
@@ -109,6 +110,14 @@ class EnterpriseApp extends React.Component {
     // checking for undefined tells if if the user's info is hydrated
     const isUserLoadedAndInactive = isActive !== undefined && !isActive;
     const isUserMissingJWTRoles = !roles?.length;
+
+    // Hide Settings page if there are no visible tabs
+    const shouldShowSettingsPage = (
+      features.SETTINGS_PAGE && (
+        enableLearnerPortal || features.FEATURE_SSO_SETTINGS_TAB
+       || (features.EXTERNAL_LMS_CONFIGURATION && features.SETTINGS_PAGE_LMS_TAB && enableLmsConfigurationsScreen)
+      )
+    );
 
     if (error) {
       return this.renderError(error);
@@ -241,7 +250,7 @@ class EnterpriseApp extends React.Component {
                       path={`${baseUrl}/admin/bulk-enrollment-results/:bulkEnrollmentJobId`}
                       component={BulkEnrollmentResultsDownloadPage}
                     />
-                    {features.SETTINGS_PAGE && (
+                    {shouldShowSettingsPage && (
                       <Route
                         path={`${baseUrl}/admin/${ROUTE_NAMES.settings}`}
                         component={SettingsPage}
@@ -268,6 +277,7 @@ EnterpriseApp.defaultProps = {
   enableSubscriptionManagementScreen: false,
   enableSamlConfigurationScreen: false,
   enableAnalyticsScreen: false,
+  enableLearnerPortal: false,
   enableLmsConfigurationsScreen: false,
   loading: true,
 };
@@ -294,6 +304,7 @@ EnterpriseApp.propTypes = {
   enableSubscriptionManagementScreen: PropTypes.bool,
   enableSamlConfigurationScreen: PropTypes.bool,
   enableAnalyticsScreen: PropTypes.bool,
+  enableLearnerPortal: PropTypes.bool,
   enableLmsConfigurationsScreen: PropTypes.bool,
   error: PropTypes.instanceOf(Error),
   loading: PropTypes.bool,

--- a/src/components/ProductTours/BrowseAndRequestTour.jsx
+++ b/src/components/ProductTours/BrowseAndRequestTour.jsx
@@ -18,8 +18,7 @@ const cookies = new Cookies();
 
 const BrowseAndRequestTour = ({ enterpriseSlug, enableBrowseAndRequest }) => {
   const { subsidyRequestConfiguration } = useContext(SubsidyRequestsContext);
-  const isEligibleForFeature = !!subsidyRequestConfiguration?.subsidyType;
-  const isFeatureEnabled = features.FEATURE_BROWSE_AND_REQUEST && enableBrowseAndRequest;
+  const isFeatureEnabledForEnterprise = features.FEATURE_BROWSE_AND_REQUEST && enableBrowseAndRequest;
 
   const history = useHistory();
   const inSettingsPage = history.location.pathname.includes(ROUTE_NAMES.settings);
@@ -28,7 +27,7 @@ const BrowseAndRequestTour = ({ enterpriseSlug, enableBrowseAndRequest }) => {
 
   // Only show tour if feature is enabled, the enterprise is eligible for the feature,
   // hide cookie is undefined or false, not in settings page, and subsidy requests are not already enabled
-  const showTour = isFeatureEnabled && isEligibleForFeature
+  const showTour = isFeatureEnabledForEnterprise
     && !dismissedTourCookie && !inSettingsPage && !subsidyRequestConfiguration?.subsidyRequestsEnabled;
 
   if (!showTour) {
@@ -65,7 +64,7 @@ const BrowseAndRequestTour = ({ enterpriseSlug, enableBrowseAndRequest }) => {
     checkpoints: [
       {
         placement: 'right',
-        body: 'We’ve recently added a new feature that enables learners to browse for courses and request access. '
+        body: "We've recently added a new feature that enables learners to browse for courses and request access. "
           + 'Continue to the settings page to learn more and configure access.',
         target: `#${TOUR_TARGETS.SETTINGS_SIDEBAR}`,
         title: 'New Feature',

--- a/src/components/ProductTours/tests/BrowseAndRequestTour.test.jsx
+++ b/src/components/ProductTours/tests/BrowseAndRequestTour.test.jsx
@@ -78,11 +78,6 @@ describe('<BrowseAndRequestTour/>', () => {
     expect(screen.queryByText('New Feature')).toBeTruthy();
   });
 
-  it('is not shown if enterprise is not eligible for browse and request', () => {
-    render(<TourWithContext subsidyType={null} />);
-    expect(screen.queryByText('New Feature')).toBeFalsy();
-  });
-
   it('is not shown if enterprise already has subsidy requests turned on', () => {
     render(<TourWithContext subsidyRequestsEnabled />);
     expect(screen.queryByText('New Feature')).toBeFalsy();

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -52,10 +52,19 @@ class Sidebar extends React.Component {
       enableSubscriptionManagementScreen,
       enableSamlConfigurationScreen,
       enableAnalyticsScreen,
+      enableLearnerPortal,
       enableLmsConfigurationsScreen,
     } = this.props;
 
     const { subsidyRequestsCounts } = this.context;
+
+    // Hide Settings link if there are no visible tabs
+    const shouldShowSettingsLink = (
+      features.SETTINGS_PAGE && (
+        enableLearnerPortal || features.FEATURE_SSO_SETTINGS_TAB
+       || (features.EXTERNAL_LMS_CONFIGURATION && features.SETTINGS_PAGE_LMS_TAB && enableLmsConfigurationsScreen)
+      )
+    );
 
     return [
       {
@@ -106,7 +115,7 @@ class Sidebar extends React.Component {
         id: TOUR_TARGETS.SETTINGS_SIDEBAR,
         to: `${baseUrl}/admin/${ROUTE_NAMES.settings}/`,
         icon: faCog,
-        hidden: !features.SETTINGS_PAGE,
+        hidden: !shouldShowSettingsLink,
       },
       // NOTE: keep "Support" link the last nav item
       {
@@ -200,6 +209,7 @@ Sidebar.defaultProps = {
   enableSubscriptionManagementScreen: false,
   enableSamlConfigurationScreen: false,
   enableAnalyticsScreen: false,
+  enableLearnerPortal: false,
   enableLmsConfigurationsScreen: false,
   onWidthChange: () => {},
   isMobile: false,
@@ -216,6 +226,7 @@ Sidebar.propTypes = {
   enableSubscriptionManagementScreen: PropTypes.bool,
   enableAnalyticsScreen: PropTypes.bool,
   enableSamlConfigurationScreen: PropTypes.bool,
+  enableLearnerPortal: PropTypes.bool,
   enableLmsConfigurationsScreen: PropTypes.bool,
   onWidthChange: PropTypes.func,
   isMobile: PropTypes.bool,

--- a/src/components/settings/SettingsAccessTab/SettingsAccessConfiguredSubsidyType.jsx
+++ b/src/components/settings/SettingsAccessTab/SettingsAccessConfiguredSubsidyType.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { CheckCircle } from '@edx/paragon/icons';
+import {
+  OverlayTrigger,
+  Tooltip,
+} from '@edx/paragon';
+import PropTypes from 'prop-types';
+import { SUBSIDY_TYPE_LABELS } from '../data/constants';
+
+const SettingsAccessConfiguredSubsidyType = ({
+  subsidyType,
+}) => (
+  <>
+    <p>Learners will browse and request courses from the associated catalog.</p>
+    <div>
+      <OverlayTrigger
+        trigger={['hover', 'focus']}
+        placement="right"
+        overlay={(
+          <Tooltip id="configured-subsidy-type-tooltip">
+            Contact support to change your selection
+          </Tooltip>
+          )}
+      >
+        <div className="d-inline">
+          <CheckCircle className="text-success-500 mr-1" />
+          <span>{SUBSIDY_TYPE_LABELS[subsidyType]}</span>
+        </div>
+      </OverlayTrigger>
+    </div>
+  </>
+);
+
+SettingsAccessConfiguredSubsidyType.propTypes = {
+  subsidyType: PropTypes.string.isRequired,
+};
+
+export default SettingsAccessConfiguredSubsidyType;

--- a/src/components/settings/SettingsAccessTab/SettingsAccessSubsidyTypeSelection.jsx
+++ b/src/components/settings/SettingsAccessTab/SettingsAccessSubsidyTypeSelection.jsx
@@ -1,0 +1,109 @@
+import React, { useCallback, useState, useMemo } from 'react';
+import {
+  Form,
+} from '@edx/paragon';
+import PropTypes from 'prop-types';
+import { SUPPORTED_SUBSIDY_TYPES } from '../../../data/constants/subsidyRequests';
+import ConfirmationModal, { CONFIRM_BUTTON_STATES } from '../../ConfirmationModal';
+import { SUBSIDY_TYPE_LABELS } from '../data/constants';
+
+const SettingsAccessSubsidyTypeSelection = ({
+  subsidyRequestConfiguration,
+  updateSubsidyRequestConfiguration,
+  subsidyTypes,
+}) => {
+  const [selectedSubsidyType, setSelectedSubsidyType] = useState(subsidyRequestConfiguration?.subsidyType);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState();
+
+  const confirmModalButtonState = useMemo(() => {
+    if (error) {
+      return CONFIRM_BUTTON_STATES.errored;
+    }
+
+    if (isLoading) {
+      return CONFIRM_BUTTON_STATES.pending;
+    }
+
+    return CONFIRM_BUTTON_STATES.default;
+  }, [error, isLoading]);
+
+  const handleSelection = useCallback((value) => {
+    if (value !== selectedSubsidyType) {
+      setIsModalOpen(true);
+    }
+  }, [selectedSubsidyType]);
+
+  const handleConfirm = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      await updateSubsidyRequestConfiguration({
+        subsidyType: selectedSubsidyType,
+      });
+      setIsModalOpen(false);
+    } catch (err) {
+      setError(err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [selectedSubsidyType, updateSubsidyRequestConfiguration]);
+
+  return (
+    <>
+      <p>
+        Select a subsidy type to distribute.
+        Learners will browse and request courses from the associated catalog.
+      </p>
+      <Form.RadioSet
+        name="subsidy-type-selection"
+        onChange={(e) => setSelectedSubsidyType(e.target.value)}
+        value={selectedSubsidyType}
+        isInline
+      >
+        {subsidyTypes.map(
+          subsidyType => (
+            <Form.Radio
+              key={`subsidy-type-selection-${subsidyType}`}
+              className="mr-3"
+              value={subsidyType}
+              onClick={(ev) => handleSelection(ev.target.value)}
+            >
+              {SUBSIDY_TYPE_LABELS[subsidyType]}
+            </Form.Radio>
+          ),
+        )}
+      </Form.RadioSet>
+      <ConfirmationModal
+        isOpen={isModalOpen}
+        confirmButtonLabels={
+          {
+            [CONFIRM_BUTTON_STATES.default]: 'Confirm selection',
+            [CONFIRM_BUTTON_STATES.pending]: 'Updating subsidy type...',
+            [CONFIRM_BUTTON_STATES.errored]: 'Try again',
+          }
+        }
+        confirmButtonState={confirmModalButtonState}
+        onConfirm={handleConfirm}
+        onClose={() => {
+          setSelectedSubsidyType(subsidyRequestConfiguration?.subsidyType);
+          setIsModalOpen(false);
+        }}
+        body={
+          `Setting your selection to "${SUBSIDY_TYPE_LABELS[selectedSubsidyType]}" is permanent,
+           and can only be changed through customer support.`
+        }
+      />
+    </>
+  );
+};
+
+SettingsAccessSubsidyTypeSelection.propTypes = {
+  subsidyRequestConfiguration: PropTypes.shape({
+    subsidyType: PropTypes.oneOf(Object.values(SUPPORTED_SUBSIDY_TYPES)),
+  }).isRequired,
+  subsidyTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
+  updateSubsidyRequestConfiguration: PropTypes.func.isRequired,
+};
+
+export default SettingsAccessSubsidyTypeSelection;

--- a/src/components/settings/SettingsAccessTab/tests/SettingsAccessConfiguredSubsidyType.test.jsx
+++ b/src/components/settings/SettingsAccessTab/tests/SettingsAccessConfiguredSubsidyType.test.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import {
+  screen,
+  render,
+} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import SettingsAccessConfiguredSubsidyType from '../SettingsAccessConfiguredSubsidyType';
+import { SUPPORTED_SUBSIDY_TYPES } from '../../../../data/constants/subsidyRequests';
+import { SUBSIDY_TYPE_LABELS } from '../../data/constants';
+
+describe('<SettingsAccessConfiguredSubsidyType />', () => {
+  it('renders correctly', () => {
+    const subsidyType = SUPPORTED_SUBSIDY_TYPES.license;
+    render(<SettingsAccessConfiguredSubsidyType subsidyType={subsidyType} />);
+    expect(screen.getByText(SUBSIDY_TYPE_LABELS[subsidyType])).toBeInTheDocument();
+  });
+});

--- a/src/components/settings/SettingsAccessTab/tests/SettingsAccessSubsidyTypeSelection.test.jsx
+++ b/src/components/settings/SettingsAccessTab/tests/SettingsAccessSubsidyTypeSelection.test.jsx
@@ -1,0 +1,74 @@
+import {
+  screen,
+  render,
+  waitFor,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import { SUPPORTED_SUBSIDY_TYPES } from '../../../../data/constants/subsidyRequests';
+import SettingsAccessSubsidyTypeSelection from '../SettingsAccessSubsidyTypeSelection';
+import { SUBSIDY_TYPE_LABELS } from '../../data/constants';
+
+describe('<SettingsAccessSubsidyTypeSelection />', () => {
+  const basicProps = {
+    subsidyRequestConfiguration: {
+      subsidyType: null,
+    },
+    updateSubsidyRequestConfiguration: jest.fn(),
+    subsidyTypes: Object.values(SUPPORTED_SUBSIDY_TYPES),
+  };
+
+  it('should open confirmation modal when subsidy type is selected', () => {
+    render(<SettingsAccessSubsidyTypeSelection {...basicProps} />);
+    userEvent.click(screen.getByLabelText(SUBSIDY_TYPE_LABELS[SUPPORTED_SUBSIDY_TYPES.license]));
+    expect(screen.getByText('Confirm selection')).toBeInTheDocument();
+  });
+
+  it('should close confirmation modal when cancel is clicked', () => {
+    render(<SettingsAccessSubsidyTypeSelection {...basicProps} />);
+    userEvent.click(screen.getByLabelText(SUBSIDY_TYPE_LABELS[SUPPORTED_SUBSIDY_TYPES.license]));
+    expect(screen.getByText('Confirm selection')).toBeInTheDocument();
+    userEvent.click(screen.getByText('Cancel'));
+    expect(screen.queryByText('Confirm selection')).not.toBeInTheDocument();
+  });
+
+  it('should call updateSubsidyRequestConfiguration when selection is confirmed', async () => {
+    const mockUpdateSubsidyRequestConfiguration = jest.fn();
+    render(
+      <SettingsAccessSubsidyTypeSelection
+        {...basicProps}
+        updateSubsidyRequestConfiguration={mockUpdateSubsidyRequestConfiguration}
+      />,
+    );
+    userEvent.click(screen.getByLabelText(SUBSIDY_TYPE_LABELS[SUPPORTED_SUBSIDY_TYPES.license]));
+    userEvent.click(screen.getByText('Confirm selection'));
+    await waitFor(() => {
+      expect(mockUpdateSubsidyRequestConfiguration).toHaveBeenCalledWith({
+        subsidyType: SUPPORTED_SUBSIDY_TYPES.license,
+      });
+    });
+  });
+
+  it('should handle errors', async () => {
+    const mockUpdateSubsidyRequestConfiguration = jest.fn();
+    mockUpdateSubsidyRequestConfiguration.mockRejectedValue('error');
+
+    render(
+      <SettingsAccessSubsidyTypeSelection
+        {...basicProps}
+        updateSubsidyRequestConfiguration={mockUpdateSubsidyRequestConfiguration}
+      />,
+    );
+
+    userEvent.click(screen.getByLabelText(SUBSIDY_TYPE_LABELS[SUPPORTED_SUBSIDY_TYPES.license]));
+    userEvent.click(screen.getByText('Confirm selection'));
+    await waitFor(() => {
+      expect(mockUpdateSubsidyRequestConfiguration).toHaveBeenCalledWith({
+        subsidyType: SUPPORTED_SUBSIDY_TYPES.license,
+      });
+    });
+
+    expect(screen.getByText('Try again')).toBeInTheDocument();
+  });
+});

--- a/src/components/settings/SettingsContext.jsx
+++ b/src/components/settings/SettingsContext.jsx
@@ -6,6 +6,7 @@ import { camelCaseObject } from '@edx/frontend-platform';
 import { useCustomerAgreementData } from './data/hooks';
 import { fetchCouponOrders } from '../../data/actions/coupons';
 import LoadingMessage from '../LoadingMessage';
+import { SUPPORTED_SUBSIDY_TYPES } from '../../data/constants/subsidyRequests';
 
 export const SettingsContext = createContext({});
 
@@ -25,11 +26,24 @@ function SettingsContextProvider({
     fetchCoupons();
   }, []);
 
+  const enterpriseSubsidyTypes = useMemo(() => {
+    const subsidyTypes = [];
+    if (couponsData.results.length > 0) {
+      subsidyTypes.push(SUPPORTED_SUBSIDY_TYPES.coupon);
+    }
+
+    if (customerAgreement.subscriptions.length > 0) {
+      subsidyTypes.push(SUPPORTED_SUBSIDY_TYPES.license);
+    }
+    return subsidyTypes;
+  }, [customerAgreement, couponsData]);
+
   const context = useMemo(() => ({
     enterpriseId,
     customerAgreement,
     couponsData,
-  }), [customerAgreement, couponsData]);
+    enterpriseSubsidyTypes,
+  }), [customerAgreement, couponsData, enterpriseSubsidyTypes]);
 
   if (loadingCustomerAgreement || loadingCoupons) {
     return <LoadingMessage className="settings mt-3" />;

--- a/src/components/settings/SettingsTabs.jsx
+++ b/src/components/settings/SettingsTabs.jsx
@@ -66,17 +66,19 @@ const SettingsTabs = ({
         activeKey={tab}
         onSelect={handleTabChange}
       >
-        <Tab eventKey={SETTINGS_TABS_VALUES.access} title={SETTINGS_TAB_LABELS.access}>
-          <SettingsAccessTab
-            enterpriseId={enterpriseId}
-            enableIntegratedCustomerLearnerPortalSearch={enableIntegratedCustomerLearnerPortalSearch}
-            identityProvider={identityProvider}
-            enableBrowseAndRequest={enableBrowseAndRequest}
-            enableLearnerPortal={enableLearnerPortal}
-            enableUniversalLink={enableUniversalLink}
-            updatePortalConfiguration={updatePortalConfiguration}
-          />
-        </Tab>
+        {enableLearnerPortal && (
+          <Tab eventKey={SETTINGS_TABS_VALUES.access} title={SETTINGS_TAB_LABELS.access}>
+            <SettingsAccessTab
+              enterpriseId={enterpriseId}
+              enableIntegratedCustomerLearnerPortalSearch={enableIntegratedCustomerLearnerPortalSearch}
+              identityProvider={identityProvider}
+              enableBrowseAndRequest={enableBrowseAndRequest}
+              enableLearnerPortal={enableLearnerPortal}
+              enableUniversalLink={enableUniversalLink}
+              updatePortalConfiguration={updatePortalConfiguration}
+            />
+          </Tab>
+        )}
 
         {FEATURE_SSO_SETTINGS_TAB && (
           <Tab eventKey={SETTINGS_TABS_VALUES.sso} title={SETTINGS_TAB_LABELS.sso}>

--- a/src/components/settings/data/constants.js
+++ b/src/components/settings/data/constants.js
@@ -1,4 +1,5 @@
 import { configuration } from '../../../config';
+import { SUPPORTED_SUBSIDY_TYPES } from '../../../data/constants/subsidyRequests';
 
 const ACCESS_TAB = 'access';
 const LMS_TAB = 'lms';
@@ -67,3 +68,8 @@ export const BLACKBOARD_OAUTH_REDIRECT_URL = `${configuration.LMS_BASE_URL}/blac
 export const CANVAS_OAUTH_REDIRECT_URL = `${configuration.LMS_BASE_URL}/canvas/oauth-complete`;
 export const LMS_CONFIG_OAUTH_POLLING_TIMEOUT = 60000;
 export const LMS_CONFIG_OAUTH_POLLING_INTERVAL = 1000;
+
+export const SUBSIDY_TYPE_LABELS = {
+  [SUPPORTED_SUBSIDY_TYPES.coupon]: 'Codes',
+  [SUPPORTED_SUBSIDY_TYPES.license]: 'Licenses',
+};

--- a/src/components/settings/tests/SettingsContext.test.jsx
+++ b/src/components/settings/tests/SettingsContext.test.jsx
@@ -30,7 +30,7 @@ const initialState = {
 const SettingsContextProviderWrapper = (props) => (
   <Provider store={mockStore(props.state)}>
     <SettingsContextProvider>
-      {props.children}
+      children
     </SettingsContextProvider>
   </Provider>
 );
@@ -41,35 +41,40 @@ describe('<SettingsContextProvider/>', () => {
       type: 'fetch coupons',
     });
     hooks.useCustomerAgreementData.mockReturnValue({
-      customerAgreement: {},
+      customerAgreement: {
+        subscriptions: [{ uuid: 'subscription-uuid' }],
+      },
     });
   });
 
   it('should fetch coupons and render children', () => {
     render(
-      <SettingsContextProviderWrapper state={initialState}>
-        children
-      </SettingsContextProviderWrapper>,
+      <SettingsContextProviderWrapper state={initialState} />,
     );
     expect(couponActions.fetchCouponOrders).toHaveBeenCalled();
     expect(screen.getByText('children'));
   });
 
   it('should render <LoadingMessage /> if loading coupons', () => {
-    render(<SettingsContextProviderWrapper state={{
-      ...initialState,
-      coupons: {
-        loading: true,
-      },
-    }}
-    />);
+    render(
+      <SettingsContextProviderWrapper
+        state={{
+          ...initialState,
+          coupons: {
+            loading: true,
+          },
+        }}
+      />,
+    );
     expect(couponActions.fetchCouponOrders).toHaveBeenCalled();
     expect(screen.getByText('Loading...'));
   });
 
   it('should render <LoadingMessage /> if loading customer agreement', () => {
     hooks.useCustomerAgreementData.mockReturnValue({
-      customerAgreement: undefined,
+      customerAgreement: {
+        subscriptions: [],
+      },
       loadingCustomerAgreement: true,
     });
     render(<SettingsContextProviderWrapper state={initialState} />);

--- a/src/components/settings/tests/SettingsTabs.test.jsx
+++ b/src/components/settings/tests/SettingsTabs.test.jsx
@@ -39,7 +39,7 @@ const initialStore = {
   portalConfiguration: {
     enterpriseId,
     enterpriseSlug: 'sluggy',
-    enableLearnerPortal: false,
+    enableLearnerPortal: true,
     enableLmsConfigurationsScreen: true,
     enableBrowseAndRequest: false,
     enableIntegratedCustomerLearnerPortalSearch: true,

--- a/src/components/subsidy-requests/data/hooks.js
+++ b/src/components/subsidy-requests/data/hooks.js
@@ -28,8 +28,8 @@ export const useSubsidyRequestConfiguration = (enterpriseUUID) => {
       const hasCoupons = couponsData.data.results.length > 0;
       const hasSubscriptions = subscriptionsData.data.results.length > 0;
 
-      // If the customer has two subsidy types, they are not eligible for Browse & Request in the MVP
-      // A subsidy type of null on the customer configuration indicates that the customer is not eligible
+      // A subsidy type of null on the customer configuration indicates that the customer will have to select a subsidy
+      // type before enabling requests
       let subsidyType = null;
 
       if (!(hasCoupons && hasSubscriptions)) {

--- a/src/containers/EnterpriseApp/index.jsx
+++ b/src/containers/EnterpriseApp/index.jsx
@@ -17,6 +17,7 @@ const mapStateToProps = (state) => {
     enableSubscriptionManagementScreen: state.portalConfiguration.enableSubscriptionManagementScreen, // eslint-disable-line max-len
     enableSamlConfigurationScreen: state.portalConfiguration.enableSamlConfigurationScreen,
     enableAnalyticsScreen: state.portalConfiguration.enableAnalyticsScreen,
+    enableLearnerPortal: state.portalConfiguration.enableLearnerPortal,
     enableLmsConfigurationsScreen: state.portalConfiguration.enableLmsConfigurationsScreen,
     enterpriseId: state.portalConfiguration.enterpriseId,
     enterpriseName: state.portalConfiguration.enterpriseName,

--- a/src/containers/Sidebar/Sidebar.test.jsx
+++ b/src/containers/Sidebar/Sidebar.test.jsx
@@ -256,6 +256,34 @@ describe('<Sidebar />', () => {
     expect(subscriptionManagementLink).toBeInTheDocument();
   });
 
+  it('renders settings link if the settings page has visible tabs.', () => {
+    const store = mockStore({
+      ...initialState,
+      portalConfiguration: {
+        enableLearnerPortal: true,
+      },
+    });
+
+    features.SETTINGS_PAGE = true;
+
+    render(<SidebarWrapper store={store} />);
+    expect(screen.getByRole('link', { name: 'Settings' })).toBeInTheDocument();
+  });
+
+  it('hides settings link if the settings page has no visible tabs.', () => {
+    const store = mockStore({
+      ...initialState,
+      portalConfiguration: {
+        enableLearnerPortal: false,
+      },
+    });
+
+    features.SETTINGS_PAGE = true;
+
+    render(<SidebarWrapper store={store} />);
+    expect(screen.queryByRole('link', { name: 'Settings' })).not.toBeInTheDocument();
+  });
+
   describe('notifications', () => {
     it('displays notification bubble when there are outstanding license requests', () => {
       const contextValue = { subsidyRequestsCounts: { subscriptionLicenses: 2 } };

--- a/src/containers/Sidebar/index.jsx
+++ b/src/containers/Sidebar/index.jsx
@@ -15,6 +15,7 @@ const mapStateToProps = state => ({
   enableReportingConfigScreen: state.portalConfiguration.enableReportingConfigScreen,
   enableSubscriptionManagementScreen: state.portalConfiguration.enableSubscriptionManagementScreen,
   enableSamlConfigurationScreen: state.portalConfiguration.enableSamlConfigurationScreen,
+  enableLearnerPortal: state.portalConfiguration.enableLearnerPortal,
   enableLmsConfigurationsScreen: state.portalConfiguration.enableLmsConfigurationsScreen,
   enableAnalyticsScreen: state.portalConfiguration.enableAnalyticsScreen,
 });


### PR DESCRIPTION
https://openedx.atlassian.net/browse/ENT-5730

- Allow enterprises to configure subsidy type for browse and request **once**
- Hide settings page if there are no visible tabs

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots

![Screen Shot 2022-04-19 at 10 04 48 AM](https://user-images.githubusercontent.com/17792243/164036230-f5044c9d-9711-4262-b7cd-8279b8dba3ea.png)
![Screen Shot 2022-04-19 at 10 04 54 AM](https://user-images.githubusercontent.com/17792243/164036231-9b89379e-f60c-4b0e-b859-70fc09d3793f.png)
![Screen Shot 2022-04-19 at 10 51 49 AM](https://user-images.githubusercontent.com/17792243/164036233-51a12e3b-21ae-4b0f-8f66-d14cffbbfdb6.png)
![Screen Shot 2022-04-19 at 10 52 04 AM](https://user-images.githubusercontent.com/17792243/164036235-76b0b9e0-59e9-4115-bd66-be59b87f99bb.png)
