### PR TITLE
feat: ENT-5689 | turn on subsidyRequest functionality when toggle bec…

### DIFF
--- a/src/components/settings/SettingsAccessTab/SettingsAccessSubsidyRequestManagement.jsx
+++ b/src/components/settings/SettingsAccessTab/SettingsAccessSubsidyRequestManagement.jsx
@@ -36,6 +36,12 @@ const SettingsAccessSubsidyRequestManagement = ({
     }
   }, [disabled, subsidyRequestsEnabled]);
 
+  useEffect(() => {
+    if (!disabled) {
+      toggleSubsidyRequests(true);
+    }
+  }, [disabled]);
+
   const handleFormSwitchChange = useCallback(async (e) => {
     const formSwitchValue = e.target.checked;
     await toggleSubsidyRequests(formSwitchValue);

--- a/src/components/settings/SettingsAccessTab/SettingsAccessSubsidyRequestManagement.jsx
+++ b/src/components/settings/SettingsAccessTab/SettingsAccessSubsidyRequestManagement.jsx
@@ -37,7 +37,7 @@ const SettingsAccessSubsidyRequestManagement = ({
   }, [disabled, subsidyRequestsEnabled]);
 
   useEffect(() => {
-    if (!disabled) {
+    if (!disabled && !subsidyRequestsEnabled) {
       toggleSubsidyRequests(true);
     }
   }, [disabled]);

--- a/src/components/settings/SettingsAccessTab/tests/SettingsAccessSubsidyRequestManagement.test.jsx
+++ b/src/components/settings/SettingsAccessTab/tests/SettingsAccessSubsidyRequestManagement.test.jsx
@@ -74,30 +74,6 @@ describe('<SettingsAccessSubsidyRequestManagement />', () => {
     });
   });
 
-  it('should update configuration if disabled = false and subsidy requests are not currently enabled ', async () => {
-    const mockUpdateSubsidyRequestConfiguration = jest.fn();
-    const props = {
-      subsidyRequestConfiguration: {
-        subsidyRequestsEnabled: false,
-        subsidyType: SUPPORTED_SUBSIDY_TYPES.license,
-      },
-      updateSubsidyRequestConfiguration: mockUpdateSubsidyRequestConfiguration,
-      disabled: false,
-    };
-
-    render(
-      <SettingsAccessSubsidyRequestManagement
-        {...props}
-      />,
-    );
-
-    await waitFor(() => {
-      expect(mockUpdateSubsidyRequestConfiguration).toHaveBeenCalledWith(
-        { isSubsidyRequestsEnabled: true },
-      );
-    });
-  });
-
   it('should not update configuration if disabled = false and subsidy requests is currently enabled ', async () => {
     const mockUpdateSubsidyRequestConfiguration = jest.fn();
     const props = {

--- a/src/components/settings/SettingsAccessTab/tests/SettingsAccessSubsidyRequestManagement.test.jsx
+++ b/src/components/settings/SettingsAccessTab/tests/SettingsAccessSubsidyRequestManagement.test.jsx
@@ -50,6 +50,27 @@ describe('<SettingsAccessSubsidyRequestManagement />', () => {
     });
   });
 
+  it('should update configuration if disable = false and subsidy requests are not currently enabled ', async () => {
+    const mockUpdateSubsidyRequestConfiguration = jest.fn();
+    const props = {
+      ...basicProps,
+      updateSubsidyRequestConfiguration: mockUpdateSubsidyRequestConfiguration,
+      disabled: false,
+    };
+
+    render(
+      <SettingsAccessSubsidyRequestManagement
+        {...props}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockUpdateSubsidyRequestConfiguration).toHaveBeenCalledWith(
+        { isSubsidyRequestsEnabled: true },
+      );
+    });
+  });
+
   it('should update configuration if disable = true and subsidy requests are currently enabled ', async () => {
     const mockUpdateSubsidyRequestConfiguration = jest.fn();
     const props = {

--- a/src/components/settings/SettingsAccessTab/tests/SettingsAccessSubsidyRequestManagement.test.jsx
+++ b/src/components/settings/SettingsAccessTab/tests/SettingsAccessSubsidyRequestManagement.test.jsx
@@ -50,7 +50,7 @@ describe('<SettingsAccessSubsidyRequestManagement />', () => {
     });
   });
 
-  it('should update configuration if disable = false and subsidy requests are not currently enabled ', async () => {
+  it('should update configuration if disabled = false and subsidy requests are not currently enabled ', async () => {
     const mockUpdateSubsidyRequestConfiguration = jest.fn();
     const props = {
       ...basicProps,
@@ -71,7 +71,7 @@ describe('<SettingsAccessSubsidyRequestManagement />', () => {
     });
   });
 
-  it('should update configuration if disable = true and subsidy requests are currently enabled ', async () => {
+  it('should update configuration if disabled = true and subsidy requests are currently enabled ', async () => {
     const mockUpdateSubsidyRequestConfiguration = jest.fn();
     const props = {
       ...basicProps,

--- a/src/components/settings/SettingsAccessTab/tests/SettingsAccessSubsidyRequestManagement.test.jsx
+++ b/src/components/settings/SettingsAccessTab/tests/SettingsAccessSubsidyRequestManagement.test.jsx
@@ -74,6 +74,49 @@ describe('<SettingsAccessSubsidyRequestManagement />', () => {
     });
   });
 
+  it('should update configuration if disabled = false and subsidy requests are not currently enabled ', async () => {
+    const mockUpdateSubsidyRequestConfiguration = jest.fn();
+    const props = {
+      subsidyRequestConfiguration: {
+        subsidyRequestsEnabled: false,
+        subsidyType: SUPPORTED_SUBSIDY_TYPES.license,
+      },
+      updateSubsidyRequestConfiguration: mockUpdateSubsidyRequestConfiguration,
+      disabled: false,
+    };
+
+    render(
+      <SettingsAccessSubsidyRequestManagement
+        {...props}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockUpdateSubsidyRequestConfiguration).toHaveBeenCalledWith(
+        { isSubsidyRequestsEnabled: true },
+      );
+    });
+  });
+
+  it('should not update configuration if disabled = false and subsidy requests is currently enabled ', async () => {
+    const mockUpdateSubsidyRequestConfiguration = jest.fn();
+    const props = {
+      ...basicProps,
+      updateSubsidyRequestConfiguration: mockUpdateSubsidyRequestConfiguration,
+      disabled: false,
+    };
+
+    render(
+      <SettingsAccessSubsidyRequestManagement
+        {...props}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockUpdateSubsidyRequestConfiguration).toHaveBeenCalledTimes(0);
+    });
+  });
+
   it('should update configuration if disabled = true and subsidy requests are currently enabled ', async () => {
     const mockUpdateSubsidyRequestConfiguration = jest.fn();
     const props = {

--- a/src/components/settings/SettingsAccessTab/tests/SettingsAccessSubsidyRequestManagement.test.jsx
+++ b/src/components/settings/SettingsAccessTab/tests/SettingsAccessSubsidyRequestManagement.test.jsx
@@ -53,7 +53,10 @@ describe('<SettingsAccessSubsidyRequestManagement />', () => {
   it('should update configuration if disabled = false and subsidy requests are not currently enabled ', async () => {
     const mockUpdateSubsidyRequestConfiguration = jest.fn();
     const props = {
-      ...basicProps,
+      subsidyRequestConfiguration: {
+        subsidyRequestsEnabled: false,
+        subsidyType: SUPPORTED_SUBSIDY_TYPES.license,
+      },
       updateSubsidyRequestConfiguration: mockUpdateSubsidyRequestConfiguration,
       disabled: false,
     };


### PR DESCRIPTION
…omes clickable

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
