### PR TITLE
fix: fix auto toggling subsidy requests everytime page is loaded

### DIFF
--- a/src/components/settings/SettingsAccessTab/SettingsAccessSubsidyRequestManagement.jsx
+++ b/src/components/settings/SettingsAccessTab/SettingsAccessSubsidyRequestManagement.jsx
@@ -14,6 +14,7 @@ const SettingsAccessSubsidyRequestManagement = ({
 }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState();
+  const [isInitiallyDisabled, setIsInitiallyDisabled] = useState(disabled);
 
   const subsidyRequestsEnabled = subsidyRequestConfiguration?.subsidyRequestsEnabled;
 
@@ -37,8 +38,10 @@ const SettingsAccessSubsidyRequestManagement = ({
   }, [disabled, subsidyRequestsEnabled]);
 
   useEffect(() => {
-    if (!disabled && !subsidyRequestsEnabled) {
+    // auto toggle to true if disabled becomes false
+    if (isInitiallyDisabled && !disabled) {
       toggleSubsidyRequests(true);
+      setIsInitiallyDisabled(false);
     }
   }, [disabled]);
 

--- a/src/components/settings/SettingsAccessTab/index.jsx
+++ b/src/components/settings/SettingsAccessTab/index.jsx
@@ -31,12 +31,11 @@ const SettingsAccessTab = ({
     customerAgreement: { subscriptions },
   } = useContext(SettingsContext);
 
-  const isEligibleForBrowseAndRequest = features.FEATURE_BROWSE_AND_REQUEST
+  const isEligibleForSubsidyRequests = features.FEATURE_BROWSE_AND_REQUEST
    && enableBrowseAndRequest && !!subsidyRequestConfiguration?.subsidyType;
 
-  const isBrowseAndRequestDisabled = !(enableUniversalLink || (
-    identityProvider && enableIntegratedCustomerLearnerPortalSearch
-  ));
+  const isLearnerPortalSearchEnabled = identityProvider && enableIntegratedCustomerLearnerPortalSearch;
+  const hasActiveAccessChannel = enableUniversalLink || isLearnerPortalSearchEnabled;
 
   const isUniversalLinkEnabled = features.SETTINGS_UNIVERSAL_LINK && enableLearnerPortal;
 
@@ -88,7 +87,7 @@ const SettingsAccessTab = ({
         />
       )}
 
-      {isEligibleForBrowseAndRequest && (
+      {isEligibleForSubsidyRequests && (
         <div className="mt-5">
           <h3>Manage course requests</h3>
           <p>
@@ -98,7 +97,7 @@ const SettingsAccessTab = ({
           <SettingsAccessSubsidyRequestManagement
             subsidyRequestConfiguration={subsidyRequestConfiguration}
             updateSubsidyRequestConfiguration={updateSubsidyRequestConfiguration}
-            disabled={isBrowseAndRequestDisabled}
+            disabled={!hasActiveAccessChannel}
           />
         </div>
       )}

--- a/src/components/settings/SettingsAccessTab/tests/SettingsAccessSubsidyRequestManagement.test.jsx
+++ b/src/components/settings/SettingsAccessTab/tests/SettingsAccessSubsidyRequestManagement.test.jsx
@@ -50,7 +50,7 @@ describe('<SettingsAccessSubsidyRequestManagement />', () => {
     });
   });
 
-  it('should update configuration if disabled = false and subsidy requests are not currently enabled ', async () => {
+  it('should update configuration if disabled becomes false and subsidy requests are not currently enabled', async () => {
     const mockUpdateSubsidyRequestConfiguration = jest.fn();
     const props = {
       subsidyRequestConfiguration: {
@@ -58,12 +58,21 @@ describe('<SettingsAccessSubsidyRequestManagement />', () => {
         subsidyType: SUPPORTED_SUBSIDY_TYPES.license,
       },
       updateSubsidyRequestConfiguration: mockUpdateSubsidyRequestConfiguration,
-      disabled: false,
+      disabled: true,
     };
 
-    render(
+    const { rerender } = render(
       <SettingsAccessSubsidyRequestManagement
         {...props}
+      />,
+    );
+
+    rerender(
+      <SettingsAccessSubsidyRequestManagement
+        {...{
+          ...props,
+          disabled: false,
+        }}
       />,
     );
 
@@ -71,25 +80,6 @@ describe('<SettingsAccessSubsidyRequestManagement />', () => {
       expect(mockUpdateSubsidyRequestConfiguration).toHaveBeenCalledWith(
         { isSubsidyRequestsEnabled: true },
       );
-    });
-  });
-
-  it('should not update configuration if disabled = false and subsidy requests is currently enabled ', async () => {
-    const mockUpdateSubsidyRequestConfiguration = jest.fn();
-    const props = {
-      ...basicProps,
-      updateSubsidyRequestConfiguration: mockUpdateSubsidyRequestConfiguration,
-      disabled: false,
-    };
-
-    render(
-      <SettingsAccessSubsidyRequestManagement
-        {...props}
-      />,
-    );
-
-    await waitFor(() => {
-      expect(mockUpdateSubsidyRequestConfiguration).toHaveBeenCalledTimes(0);
     });
   });
 


### PR DESCRIPTION
# For all changes

Right now admins have no way of turning off subsidy requests since it auto-toggles every time the setting page loads.
This fixes that by turning on subsidy requests automatically only if disabled becomes false (when an access channel gets turned on).

Removed unneeded subsidyRequestsEnabled check.

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
