### PR TITLE
fix: use config uuid for canvas oauth state

### DIFF
--- a/src/components/settings/SettingsLMSTab/LMSConfigs/CanvasConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/CanvasConfig.jsx
@@ -135,7 +135,7 @@ const CanvasConfig = ({ enterpriseCustomerUuid, onClick, existingData }) => {
       setOauthPollingTimeout(LMS_CONFIG_OAUTH_POLLING_TIMEOUT);
 
       const oauthUrl = `${canvasBaseUrl}/login/oauth2/auth?client_id=${clientId}&`
-      + `state=${enterpriseCustomerUuid}&response_type=code&`
+      + `state=${fetchedConfigId}&response_type=code&`
       + `redirect_uri=${CANVAS_OAUTH_REDIRECT_URL}`;
 
       // Open the oauth window for the user


### PR DESCRIPTION
## Description

- we no longer using enterprise uuid so we can disambiguate which config is used in the case the customer has more than 1 configured

## Description

- [ENT-5610](https://2u-internal.atlassian.net/browse/ENT-5610)

