### PR TITLE
feat: replace subsidy with more descriptive labels for code/subs mgmt 

### DIFF
--- a/src/components/settings/SettingsAccessTab/data/utils.js
+++ b/src/components/settings/SettingsAccessTab/data/utils.js
@@ -1,0 +1,35 @@
+import { logError } from '@edx/frontend-platform/logging';
+import { SUPPORTED_SUBSIDY_TYPES } from '../../../../data/constants/subsidyRequests';
+
+/* eslint-disable import/prefer-default-export */
+
+/**
+ *
+ * @param {string} configuredRequestSubsidyType The configured request subsidy type (e.g., subscription license, code)
+ * @param {*} enterpriseSlug The slug for an enterprise customer
+ * @returns {object} Object containing a human-readable label of the configured request subsidy type and a path to the
+ *  appropriate subsidy tab route.
+ */
+export const getSubsidyTypeLabelAndRoute = (configuredRequestSubsidyType, enterpriseSlug) => {
+  let subsidyTypeLabelAndRoute;
+  if (configuredRequestSubsidyType === SUPPORTED_SUBSIDY_TYPES.license) {
+    subsidyTypeLabelAndRoute = {
+      label: 'subscription license',
+      route: {
+        path: `/${enterpriseSlug}/admin/subscriptions/manage-requests`,
+        label: 'Subscription Management',
+      },
+    };
+  } else if (configuredRequestSubsidyType === SUPPORTED_SUBSIDY_TYPES.coupon) {
+    subsidyTypeLabelAndRoute = {
+      label: 'code',
+      route: {
+        path: `/${enterpriseSlug}/admin/coupons/manage-requests`,
+        label: 'Code Management',
+      },
+    };
+  } else {
+    logError(`Invalid request subsidy type provided: ${configuredRequestSubsidyType}`);
+  }
+  return subsidyTypeLabelAndRoute;
+};

--- a/src/components/settings/SettingsAccessTab/data/utils.js
+++ b/src/components/settings/SettingsAccessTab/data/utils.js
@@ -6,7 +6,7 @@ import { SUPPORTED_SUBSIDY_TYPES } from '../../../../data/constants/subsidyReque
 /**
  *
  * @param {string} configuredRequestSubsidyType The configured request subsidy type (e.g., subscription license, code)
- * @param {*} enterpriseSlug The slug for an enterprise customer
+ * @param {string} enterpriseSlug The slug for an enterprise customer
  * @returns {object} Object containing a human-readable label of the configured request subsidy type and a path to the
  *  appropriate subsidy tab route.
  */

--- a/src/components/settings/SettingsAccessTab/tests/SettingsAccessTab.test.jsx
+++ b/src/components/settings/SettingsAccessTab/tests/SettingsAccessTab.test.jsx
@@ -3,6 +3,8 @@ import {
   render,
 } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+
 import SettingsAccessTab from '../index';
 import { SettingsContext } from '../../SettingsContext';
 import { SubsidyRequestsContext } from '../../../subsidy-requests';
@@ -87,7 +89,7 @@ const SettingsAccessTabWrapper = ({
 
 describe('<SettingsAccessTab />', () => {
   it('should render <SettingsAccessSSOManagement/> if sso is configured', () => {
-    render(<SettingsAccessTabWrapper props={{ identityProvider: 'idp' }} />);
+    renderWithRouter(<SettingsAccessTabWrapper props={{ identityProvider: 'idp' }} />);
     expect(screen.getByText('SettingsAccessSSOManagement'));
     expect(screen.queryByText('SettingsAccessLinkManagement')).not.toBeInTheDocument();
     expect(screen.queryByText('SettingsAccessSubsidyRequestManagement')).not.toBeInTheDocument();
@@ -95,7 +97,7 @@ describe('<SettingsAccessTab />', () => {
 
   it('should render <SettingsAccessLinkManagement/> if universal link feature flag is enabled and learner portal is enabled', () => {
     config.features.SETTINGS_UNIVERSAL_LINK = 'true';
-    render(<SettingsAccessTabWrapper props={{ enableLearnerPortal: true }} />);
+    renderWithRouter(<SettingsAccessTabWrapper props={{ enableLearnerPortal: true }} />);
     expect(screen.queryByText('SettingsAccessSSOManagement')).not.toBeInTheDocument();
     expect(screen.getByText('SettingsAccessLinkManagement'));
     expect(screen.queryByText('SettingsAccessSubsidyRequestManagement')).not.toBeInTheDocument();
@@ -103,7 +105,7 @@ describe('<SettingsAccessTab />', () => {
 
   it('should render <SettingsAccessSubsidyRequestManagement/> if browse and request is enabled', () => {
     config.features.FEATURE_BROWSE_AND_REQUEST = 'true';
-    render(<SettingsAccessTabWrapper />);
+    renderWithRouter(<SettingsAccessTabWrapper />);
     expect(screen.queryByText('SettingsAccessSSOManagement')).not.toBeInTheDocument();
     expect(screen.queryByText('SettingsAccessLinkManagement')).not.toBeInTheDocument();
     expect(screen.getByText('SettingsAccessSubsidyRequestManagement'));
@@ -111,7 +113,7 @@ describe('<SettingsAccessTab />', () => {
 
   it('should disable <SettingsAccessSubsidyRequestManagement/> if neither universal link or sso are configured', () => {
     config.features.FEATURE_BROWSE_AND_REQUEST = 'true';
-    render(
+    renderWithRouter(
       <SettingsAccessTabWrapper
         props={{ enableUniversalLink: false, identityProvider: null }}
       />,
@@ -130,7 +132,7 @@ describe('<SettingsAccessTab />', () => {
         subsidyType: SUPPORTED_SUBSIDY_TYPES.coupon,
       },
     };
-    render(
+    renderWithRouter(
       <SettingsAccessTabWrapper
         subsidyRequestConfigurationContextValue={subsidyRequestConfigurationContextValue}
         props={{ enableUniversalLink: false, identityProvider: null }}
@@ -148,7 +150,7 @@ describe('<SettingsAccessTab />', () => {
       },
       updateSubsidyRequestConfiguration: jest.fn(),
     };
-    render(
+    renderWithRouter(
       <SettingsAccessTabWrapper
         subsidyRequestConfigurationContextValue={subsidyRequestConfigurationContextValue}
         props={{ enableUniversalLink: false, identityProvider: null }}
@@ -166,7 +168,7 @@ describe('<SettingsAccessTab />', () => {
       },
       updateSubsidyRequestConfiguration: jest.fn(),
     };
-    render(
+    renderWithRouter(
       <SettingsAccessTabWrapper
         subsidyRequestConfigurationContextValue={subsidyRequestConfigurationContextValue}
         props={{ enableUniversalLink: false, identityProvider: null }}
@@ -184,7 +186,7 @@ describe('<SettingsAccessTab />', () => {
       },
       updateSubsidyRequestConfiguration: jest.fn(),
     };
-    render(
+    renderWithRouter(
       <SettingsAccessTabWrapper
         subsidyRequestConfigurationContextValue={subsidyRequestConfigurationContextValue}
         props={{ enableUniversalLink: false, identityProvider: null }}
@@ -194,7 +196,7 @@ describe('<SettingsAccessTab />', () => {
   });
 
   it('should render <SettingsAccessSubsidyTypeSelection/> if enterprise has multiple subsidy types and subsidy type is not configured', () => {
-    render(
+    renderWithRouter(
       <SettingsAccessTabWrapper
         settingsContextValue={
           {
@@ -220,7 +222,7 @@ describe('<SettingsAccessTab />', () => {
   });
 
   it('should render <SettingsAccessConfiguredSubsidyType/> if subsidy type is configured', () => {
-    render(
+    renderWithRouter(
       <SettingsAccessTabWrapper
         settingsContextValue={
           {

--- a/src/components/settings/SettingsAccessTab/tests/SettingsAccessTab.test.jsx
+++ b/src/components/settings/SettingsAccessTab/tests/SettingsAccessTab.test.jsx
@@ -1,7 +1,4 @@
-import {
-  screen,
-  render,
-} from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { renderWithRouter } from '@edx/frontend-enterprise-utils';
 

--- a/src/components/settings/SettingsTabs.jsx
+++ b/src/components/settings/SettingsTabs.jsx
@@ -69,6 +69,7 @@ const SettingsTabs = ({
           <Tab eventKey={SETTINGS_TABS_VALUES.access} title={SETTINGS_TAB_LABELS.access}>
             <SettingsAccessTab
               enterpriseId={enterpriseId}
+              enterpriseSlug={enterpriseSlug}
               enableIntegratedCustomerLearnerPortalSearch={enableIntegratedCustomerLearnerPortalSearch}
               identityProvider={identityProvider}
               enableLearnerPortal={enableLearnerPortal}


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-5851

Replaces"subsidy" with "code"/"subscription license" and links to the appropriate "Manage Requests" route based on the configured request subsidy type.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
