### PR TITLE
fix: shrink header column in settings access tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@edx/frontend-enterprise-logistration": "1.1.2",
         "@edx/frontend-enterprise-utils": "^2.0.1",
         "@edx/frontend-platform": "1.15.6",
-        "@edx/paragon": "19.22.1",
+        "@edx/paragon": "19.23.1",
         "@fortawesome/fontawesome-svg-core": "1.2.35",
         "@fortawesome/free-brands-svg-icons": "5.15.3",
         "@fortawesome/free-regular-svg-icons": "5.15.3",
@@ -5583,9 +5583,9 @@
       }
     },
     "node_modules/@edx/paragon": {
-      "version": "19.22.1",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-19.22.1.tgz",
-      "integrity": "sha512-gENq+5bi8rqasqyEPHqy7mEUxLj2t+lO1jE0l7rW1zlPWoCgVkWZXDjo29kT5n9WV79hqG12/OQ1noJVYzRgVg==",
+      "version": "19.23.1",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-19.23.1.tgz",
+      "integrity": "sha512-94l0wHWGxQVOeBlJl+rjXjniCPPNWehPUQGknsYPdCSPwLA07B1s2ekWbAemXbCZvjacsGzK/AyQBXHX55lVug==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.36",
         "@fortawesome/react-fontawesome": "^0.1.18",
@@ -29565,9 +29565,9 @@
       }
     },
     "@edx/paragon": {
-      "version": "19.22.1",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-19.22.1.tgz",
-      "integrity": "sha512-gENq+5bi8rqasqyEPHqy7mEUxLj2t+lO1jE0l7rW1zlPWoCgVkWZXDjo29kT5n9WV79hqG12/OQ1noJVYzRgVg==",
+      "version": "19.23.1",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-19.23.1.tgz",
+      "integrity": "sha512-94l0wHWGxQVOeBlJl+rjXjniCPPNWehPUQGknsYPdCSPwLA07B1s2ekWbAemXbCZvjacsGzK/AyQBXHX55lVug==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.36",
         "@fortawesome/react-fontawesome": "^0.1.18",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@edx/frontend-enterprise-logistration": "1.1.2",
     "@edx/frontend-enterprise-utils": "^2.0.1",
     "@edx/frontend-platform": "1.15.6",
-    "@edx/paragon": "19.22.1",
+    "@edx/paragon": "19.23.1",
     "@fortawesome/fontawesome-svg-core": "1.2.35",
     "@fortawesome/free-brands-svg-icons": "5.15.3",
     "@fortawesome/free-regular-svg-icons": "5.15.3",

--- a/src/components/settings/SettingsAccessTab/index.jsx
+++ b/src/components/settings/SettingsAccessTab/index.jsx
@@ -64,8 +64,8 @@ const SettingsAccessTab = ({
           <h2>Enable browsing on-demand</h2>
         </Col>
       </Row>
-      <Row className="mb-4">
-        <Col>
+      <Row className="mb-4 justify-content-between">
+        <Col lg={8} xl={9}>
           <p>
             Allow learners without a subsidy to browse the catalog and request enrollment to courses.
             Browsing on demand will expire at the end of your latest purchase.


### PR DESCRIPTION
Column size adjustment so customers don't correlate the contact support button with turning B&R on.
Upgrade paragon to fix dropdown menu icon.

![Screen Shot 2022-05-23 at 9 35 18 AM](https://user-images.githubusercontent.com/17792243/169835477-0e3204ad-5879-4de9-ac37-67601cf2b3dd.png)
![Screen Shot 2022-05-23 at 9 56 23 AM](https://user-images.githubusercontent.com/17792243/169835678-a30cf4c8-2f81-4b49-ac75-8c61d42d88c4.png)
![Screen Shot 2022-05-23 at 9 56 33 AM](https://user-images.githubusercontent.com/17792243/169835681-569e69e7-21b1-4311-8a48-b83115ba7ecd.png)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots


