### PR TITLE
feat: add Learner Credit Management tab and page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10145,12 +10145,19 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001283",
-      "license": "CC-BY-4.0",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "version": "1.0.30001346",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001346.tgz",
+      "integrity": "sha512-q6ibZUO2t88QCIPayP/euuDREq+aMAxFE5S70PkrLh0iTDj/zEhgvJRKC2+CvXY6EWc6oQwUR48lL5vCW6jiXQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -10944,21 +10951,6 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
-    },
-    "node_modules/core-js-compat/node_modules/caniuse-lite": {
-      "version": "1.0.30001322",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        }
-      ],
-      "license": "CC-BY-4.0"
     },
     "node_modules/core-js-compat/node_modules/electron-to-chromium": {
       "version": "1.4.102",
@@ -32728,7 +32720,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001283"
+      "version": "1.0.30001346",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001346.tgz",
+      "integrity": "sha512-q6ibZUO2t88QCIPayP/euuDREq+aMAxFE5S70PkrLh0iTDj/zEhgvJRKC2+CvXY6EWc6oQwUR48lL5vCW6jiXQ=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -33233,10 +33227,6 @@
             "node-releases": "^2.0.2",
             "picocolors": "^1.0.0"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001322",
-          "dev": true
         },
         "electron-to-chromium": {
           "version": "1.4.102",

--- a/src/components/EnterpriseApp/index.jsx
+++ b/src/components/EnterpriseApp/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Switch, Route, Redirect } from 'react-router-dom';
 import { breakpoints, MediaQuery } from '@edx/paragon';
+import { getConfig } from '@edx/frontend-platform/config';
 
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import AdminPage from '../../containers/AdminPage';
@@ -25,6 +26,7 @@ import FeatureAnnouncementBanner from '../FeatureAnnouncementBanner';
 import BulkEnrollmentResultsDownloadPage from '../BulkEnrollmentResultsDownloadPage';
 import BrowseAndRequestTour from '../ProductTours/BrowseAndRequestTour';
 import SubsidyRequestsContextProvider from '../subsidy-requests';
+import LearnerCreditManagement from '../learner-credit-management';
 
 class EnterpriseApp extends React.Component {
   constructor(props) {
@@ -193,55 +195,54 @@ class EnterpriseApp extends React.Component {
                       />,
                     ]}
                     {features.REPORTING_CONFIGURATIONS && (
-                    <Route
-                      key="reporting-config"
-                      exact
-                      path={`${baseUrl}/admin/reporting`}
-                      render={routeProps => (this.props.enterpriseId
-                        ? <ReportingConfig {...routeProps} enterpriseId={this.props.enterpriseId} />
-                        : <LoadingMessage className="overview" />
-                      )}
-                    />
+                      <Route
+                        key="reporting-config"
+                        exact
+                        path={`${baseUrl}/admin/reporting`}
+                        render={routeProps => (this.props.enterpriseId
+                          ? <ReportingConfig {...routeProps} enterpriseId={this.props.enterpriseId} />
+                          : <LoadingMessage className="overview" />
+                        )}
+                      />
                     )}
                     {enableSubscriptionManagementScreen && (
-                    <Route
-                      key="subscription-management"
-                      path={`${baseUrl}/admin/${ROUTE_NAMES.subscriptionManagement}`}
-                      render={routeProps => <SubscriptionManagementPage {...routeProps} />}
-                    />
+                      <Route
+                        key="subscription-management"
+                        path={`${baseUrl}/admin/${ROUTE_NAMES.subscriptionManagement}`}
+                        render={routeProps => <SubscriptionManagementPage {...routeProps} />}
+                      />
                     )}
                     {features.ANALYTICS && enableAnalyticsScreen && (
-                    <Route
-                      key="analytics"
-                      exact
-                      path={`${baseUrl}/admin/analytics`}
-                      render={routeProps => (
-                        <AnalyticsPage
-                          {...routeProps}
-                        />
-                      )}
-                    />
+                      <Route
+                        key="analytics"
+                        exact
+                        path={`${baseUrl}/admin/analytics`}
+                        render={routeProps => (
+                          <AnalyticsPage
+                            {...routeProps}
+                          />
+                        )}
+                      />
                     )}
                     {features.SAML_CONFIGURATION && enableSamlConfigurationScreen && (
-                    <Route
-                      key="saml-configuration"
-                      exact
-                      path={`${baseUrl}/admin/samlconfiguration`}
-                      render={routeProps => (
-                        <SamlProviderConfiguration
-                          {...routeProps}
-                        />
-                      )}
-                    />
+                      <Route
+                        key="saml-configuration"
+                        exact
+                        path={`${baseUrl}/admin/samlconfiguration`}
+                        render={routeProps => (
+                          <SamlProviderConfiguration
+                            {...routeProps}
+                          />
+                        )}
+                      />
                     )}
-                    {features.EXTERNAL_LMS_CONFIGURATION && enableLmsConfigurationsScreen
-                    && (
-                    <Route
-                      key="lms-integrations"
-                      exact
-                      path={`${baseUrl}/admin/lmsintegrations`}
-                      render={routeProps => <LmsConfigurations {...routeProps} />}
-                    />
+                    {features.EXTERNAL_LMS_CONFIGURATION && enableLmsConfigurationsScreen && (
+                      <Route
+                        key="lms-integrations"
+                        exact
+                        path={`${baseUrl}/admin/lmsintegrations`}
+                        render={routeProps => <LmsConfigurations {...routeProps} />}
+                      />
                     )}
                     <Route
                       exact
@@ -252,6 +253,13 @@ class EnterpriseApp extends React.Component {
                       <Route
                         path={`${baseUrl}/admin/${ROUTE_NAMES.settings}`}
                         component={SettingsPage}
+                      />
+                    )}
+                    {getConfig().FEATURE_LEARNER_CREDIT_MANAGEMENT && (
+                      <Route
+                        exact
+                        path={`${baseUrl}/admin/learner-credit`}
+                        component={LearnerCreditManagement}
                       />
                     )}
                     <Route path="" component={NotFoundPage} />

--- a/src/components/Sidebar/IconLink.jsx
+++ b/src/components/Sidebar/IconLink.jsx
@@ -2,7 +2,6 @@ import React, { useLayoutEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { NavLink } from 'react-router-dom';
 import classNames from 'classnames';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Bubble } from '@edx/paragon';
 
 const BUBBLE_MARGIN_LEFT = 5;
@@ -20,8 +19,8 @@ const BaseNavLink = ({
   const [notificationBubbleMarginLeft, setNotificationBubbleMarginLeft] = useState(0);
 
   useLayoutEffect(() => {
-    const iconRect = iconRef.current?.getBoundingClientRect();
-    const titleRect = titleRef.current?.getBoundingClientRect();
+    const iconRect = iconRef.current?.getBoundingClientRect?.();
+    const titleRect = titleRef.current?.getBoundingClientRect?.();
 
     if (isExpanded && iconRect && titleRect) {
       setNotificationBubbleMarginLeft(iconRect.width + titleRect.width + BUBBLE_MARGIN_LEFT);
@@ -31,16 +30,23 @@ const BaseNavLink = ({
     if (iconRect) {
       setNotificationBubbleMarginLeft(iconRect.width + BUBBLE_MARGIN_LEFT);
     }
-  }, [iconRef, titleRef, isExpanded]);
+  }, [isExpanded]);
+
+  const IconElement = React.cloneElement(icon, {
+    className: classNames(
+      icon.props.className,
+      { 'mr-2': isExpanded },
+    ),
+  });
 
   return (
     <NavLink
-      className="nav-link text-left rounded-0"
+      className="nav-link text-left rounded-0 d-flex align-items-center"
       {...rest}
     >
-      <div className="position-relative">
-        <span ref={iconRef}>
-          <FontAwesomeIcon icon={icon} className={classNames({ 'mr-2': isExpanded })} />
+      <div className="position-relative d-flex align-items-center">
+        <span ref={iconRef} className="d-flex align-items-center">
+          {IconElement}
         </span>
         {!isExpanded && <span className="sr-only">{title}</span>}
         {isExpanded && <span ref={titleRef}>{title}</span>}
@@ -65,7 +71,7 @@ const BaseNavLink = ({
 
 const commonPropTypes = {
   title: PropTypes.string.isRequired,
-  icon: PropTypes.shape().isRequired,
+  icon: PropTypes.node.isRequired,
   isExpanded: PropTypes.bool,
   notification: PropTypes.bool,
 };

--- a/src/components/Sidebar/IconLink.test.jsx
+++ b/src/components/Sidebar/IconLink.test.jsx
@@ -3,6 +3,7 @@ import {
 } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUniversity } from '@fortawesome/free-solid-svg-icons';
 import { MemoryRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
@@ -27,7 +28,7 @@ describe('<IconLink />', () => {
     const defaultProps = {
       title: 'Internal Route',
       to: 'admin/test',
-      icon: faUniversity,
+      icon: <FontAwesomeIcon icon={faUniversity} />,
     };
     render(<IconLinkWrapper {...defaultProps} />);
     expect(screen.getByText('Internal Route').closest('a')).toHaveAttribute('href', '/admin/test');
@@ -37,7 +38,7 @@ describe('<IconLink />', () => {
     const defaultProps = {
       title: 'External Route',
       to: 'http://helpcenter.edx.org/us',
-      icon: faUniversity,
+      icon: <FontAwesomeIcon icon={faUniversity} />,
       external: true,
     };
 

--- a/src/components/Sidebar/_Sidebar.scss
+++ b/src/components/Sidebar/_Sidebar.scss
@@ -9,7 +9,17 @@
     width: auto;
 
     &.has-shadow {
-      box-shadow: 6px 0 10px -6px rgba(0, 0, 0, 0.25);
+      @include pgn-box-shadow(1, 'right');
+    }
+  }
+
+  &:not(.expanded) {
+    .nav-link {
+      // TODO: using a hardcoded pixel value isn't ideal, but it's a temporary fix while we have
+      // both Font Awesome and Paragon icons in the sidebar navigation, each having slightly different
+      // styles and DOM structures, making styling difficult. 44px is the height of each nav link when
+      // the sidebar is expanded, so this forces it to be the same height when not expanded as well.
+      height: 44px;
     }
   }
 

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -2,9 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { faFile, faIdCard, faLifeRing } from '@fortawesome/free-regular-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faCreditCard, faTags, faChartLine, faChartBar, faUniversity, faCog,
 } from '@fortawesome/free-solid-svg-icons';
+import { Icon } from '@edx/paragon';
+import { MoneyOutline } from '@edx/paragon/icons';
+import { getConfig } from '@edx/frontend-platform/config';
 
 import IconLink from './IconLink';
 
@@ -70,58 +74,64 @@ class Sidebar extends React.Component {
       {
         title: 'Learner Progress Report',
         to: `${baseUrl}/admin/learners`,
-        icon: faChartLine,
-      },
-      {
-        title: 'Code Management',
-        to: `${baseUrl}/admin/coupons`,
-        icon: faTags,
-        hidden: !features.CODE_MANAGEMENT || !enableCodeManagementScreen,
-        notification: !!subsidyRequestsCounts.couponCodes,
-      },
-      {
-        title: 'Reporting Configurations',
-        to: `${baseUrl}/admin/reporting`,
-        icon: faFile,
-        hidden: !features.REPORTING_CONFIGURATIONS || !enableReportingConfigScreen,
-      },
-      {
-        title: 'Subscription Management',
-        to: `${baseUrl}/admin/subscriptions`,
-        icon: faCreditCard,
-        hidden: !enableSubscriptionManagementScreen,
-        notification: !!subsidyRequestsCounts.subscriptionLicenses,
+        icon: <span><FontAwesomeIcon icon={faChartLine} fixedWidth /></span>,
       },
       {
         title: 'Analytics',
         to: `${baseUrl}/admin/analytics`,
-        icon: faChartBar,
+        icon: <FontAwesomeIcon icon={faChartBar} fixedWidth />,
         hidden: !features.ANALYTICS || !enableAnalyticsScreen,
+      },
+      {
+        title: 'Code Management',
+        to: `${baseUrl}/admin/coupons`,
+        icon: <FontAwesomeIcon icon={faTags} fixedWidth />,
+        hidden: !features.CODE_MANAGEMENT || !enableCodeManagementScreen,
+        notification: !!subsidyRequestsCounts.couponCodes,
+      },
+      {
+        title: 'Subscription Management',
+        to: `${baseUrl}/admin/subscriptions`,
+        icon: <FontAwesomeIcon icon={faCreditCard} fixedWidth />,
+        hidden: !enableSubscriptionManagementScreen,
+        notification: !!subsidyRequestsCounts.subscriptionLicenses,
+      },
+      {
+        title: 'Learner Credit Management',
+        to: `${baseUrl}/admin/learner-credit`,
+        icon: <Icon src={MoneyOutline} className="d-inline-block" />,
+        hidden: !getConfig().FEATURE_LEARNER_CREDIT_MANAGEMENT,
+      },
+      {
+        title: 'Reporting Configurations',
+        to: `${baseUrl}/admin/reporting`,
+        icon: <FontAwesomeIcon icon={faFile} fixedWidth />,
+        hidden: !features.REPORTING_CONFIGURATIONS || !enableReportingConfigScreen,
       },
       {
         title: 'SAML Configuration',
         to: `${baseUrl}/admin/samlconfiguration`,
-        icon: faIdCard,
+        icon: <FontAwesomeIcon icon={faIdCard} fixedWidth />,
         hidden: !features.SAML_CONFIGURATION || !enableSamlConfigurationScreen,
       },
       {
         title: 'LMS Integration Configuration',
         to: `${baseUrl}/admin/lmsintegrations`,
-        icon: faUniversity,
+        icon: <FontAwesomeIcon icon={faUniversity} fixedWidth />,
         hidden: !features.EXTERNAL_LMS_CONFIGURATION || !enableLmsConfigurationsScreen,
       },
       {
         title: 'Settings',
         id: TOUR_TARGETS.SETTINGS_SIDEBAR,
         to: `${baseUrl}/admin/${ROUTE_NAMES.settings}/`,
-        icon: faCog,
+        icon: <FontAwesomeIcon icon={faCog} fixedWidth />,
         hidden: !shouldShowSettingsLink,
       },
       // NOTE: keep "Support" link the last nav item
       {
         title: 'Support',
         to: configuration.ENTERPRISE_SUPPORT_URL,
-        icon: faLifeRing,
+        icon: <FontAwesomeIcon icon={faLifeRing} fixedWidth />,
         hidden: !features.SUPPORT,
         external: true,
       },

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -74,7 +74,7 @@ class Sidebar extends React.Component {
       {
         title: 'Learner Progress Report',
         to: `${baseUrl}/admin/learners`,
-        icon: <span><FontAwesomeIcon icon={faChartLine} fixedWidth /></span>,
+        icon: <FontAwesomeIcon icon={faChartLine} fixedWidth />,
       },
       {
         title: 'Analytics',

--- a/src/components/learner-credit-management/LearnerCreditManagement.jsx
+++ b/src/components/learner-credit-management/LearnerCreditManagement.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Helmet from 'react-helmet';
+
+import Hero from '../Hero';
+
+const LearnerCreditManagement = () => (
+  <>
+    <Helmet>
+      <title>Learner Credit Management</title>
+    </Helmet>
+    <Hero title="Learner Credit Management" />
+  </>
+);
+
+export default LearnerCreditManagement;

--- a/src/components/learner-credit-management/index.js
+++ b/src/components/learner-credit-management/index.js
@@ -1,0 +1,3 @@
+import LearnerCreditManagement from './LearnerCreditManagement';
+
+export default LearnerCreditManagement;

--- a/src/containers/Sidebar/Sidebar.test.jsx
+++ b/src/containers/Sidebar/Sidebar.test.jsx
@@ -6,6 +6,7 @@ import renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
+import { AppContext } from '@edx/frontend-platform/react';
 import {
   render, screen,
 } from '@testing-library/react';
@@ -43,21 +44,29 @@ const initialSubsidyRequestsContextValue = {
   },
 };
 
+const initialAppContextValue = {
+  configuration: {},
+};
+
 const SidebarWrapper = ({
-  // eslint-disable-next-line react/prop-types
+  /* eslint-disable react/prop-types */
   subsidyRequestsContextValue = initialSubsidyRequestsContextValue,
+  appContextValue = initialAppContextValue,
+  /* eslint-enable react/prop-types */
   ...props
 }) => (
-  <MemoryRouter>
-    <Provider store={props.store}>
-      <SubsidyRequestsContext.Provider value={subsidyRequestsContextValue}>
-        <Sidebar
-          baseUrl="/test-enterprise-slug"
-          {...props}
-        />
-      </SubsidyRequestsContext.Provider>
-    </Provider>
-  </MemoryRouter>
+  <AppContext.Provider value={appContextValue}>
+    <MemoryRouter>
+      <Provider store={props.store}>
+        <SubsidyRequestsContext.Provider value={subsidyRequestsContextValue}>
+          <Sidebar
+            baseUrl="/test-enterprise-slug"
+            {...props}
+          />
+        </SubsidyRequestsContext.Provider>
+      </Provider>
+    </MemoryRouter>
+  </AppContext.Provider>
 );
 
 SidebarWrapper.defaultProps = {

--- a/src/containers/Sidebar/Sidebar.test.jsx
+++ b/src/containers/Sidebar/Sidebar.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
 import configureMockStore from 'redux-mock-store';
@@ -6,7 +7,6 @@ import renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { AppContext } from '@edx/frontend-platform/react';
 import {
   render, screen,
 } from '@testing-library/react';
@@ -44,29 +44,20 @@ const initialSubsidyRequestsContextValue = {
   },
 };
 
-const initialAppContextValue = {
-  configuration: {},
-};
-
 const SidebarWrapper = ({
-  /* eslint-disable react/prop-types */
   subsidyRequestsContextValue = initialSubsidyRequestsContextValue,
-  appContextValue = initialAppContextValue,
-  /* eslint-enable react/prop-types */
   ...props
 }) => (
-  <AppContext.Provider value={appContextValue}>
-    <MemoryRouter>
-      <Provider store={props.store}>
-        <SubsidyRequestsContext.Provider value={subsidyRequestsContextValue}>
-          <Sidebar
-            baseUrl="/test-enterprise-slug"
-            {...props}
-          />
-        </SubsidyRequestsContext.Provider>
-      </Provider>
-    </MemoryRouter>
-  </AppContext.Provider>
+  <MemoryRouter>
+    <Provider store={props.store}>
+      <SubsidyRequestsContext.Provider value={subsidyRequestsContextValue}>
+        <Sidebar
+          baseUrl="/test-enterprise-slug"
+          {...props}
+        />
+      </SubsidyRequestsContext.Provider>
+    </Provider>
+  </MemoryRouter>
 );
 
 SidebarWrapper.defaultProps = {

--- a/src/containers/Sidebar/__snapshots__/Sidebar.test.jsx.snap
+++ b/src/containers/Sidebar/__snapshots__/Sidebar.test.jsx.snap
@@ -31,27 +31,23 @@ exports[`<Sidebar /> renders correctly 1`] = `
             <span
               className="d-flex align-items-center"
             >
-              <span
-                className=""
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-chart-line fa-w-16 fa-fw "
+                data-icon="chart-line"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-hidden="true"
-                  className="svg-inline--fa fa-chart-line fa-w-16 fa-fw "
-                  data-icon="chart-line"
-                  data-prefix="fas"
-                  focusable="false"
-                  role="img"
+                <path
+                  d="M496 384H64V80c0-8.84-7.16-16-16-16H16C7.16 64 0 71.16 0 80v336c0 17.67 14.33 32 32 32h464c8.84 0 16-7.16 16-16v-32c0-8.84-7.16-16-16-16zM464 96H345.94c-21.38 0-32.09 25.85-16.97 40.97l32.4 32.4L288 242.75l-73.37-73.37c-12.5-12.5-32.76-12.5-45.25 0l-68.69 68.69c-6.25 6.25-6.25 16.38 0 22.63l22.62 22.62c6.25 6.25 16.38 6.25 22.63 0L192 237.25l73.37 73.37c12.5 12.5 32.76 12.5 45.25 0l96-96 32.4 32.4c15.12 15.12 40.97 4.41 40.97-16.97V112c.01-8.84-7.15-16-15.99-16z"
+                  fill="currentColor"
                   style={Object {}}
-                  viewBox="0 0 512 512"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M496 384H64V80c0-8.84-7.16-16-16-16H16C7.16 64 0 71.16 0 80v336c0 17.67 14.33 32 32 32h464c8.84 0 16-7.16 16-16v-32c0-8.84-7.16-16-16-16zM464 96H345.94c-21.38 0-32.09 25.85-16.97 40.97l32.4 32.4L288 242.75l-73.37-73.37c-12.5-12.5-32.76-12.5-45.25 0l-68.69 68.69c-6.25 6.25-6.25 16.38 0 22.63l22.62 22.62c6.25 6.25 16.38 6.25 22.63 0L192 237.25l73.37 73.37c12.5 12.5 32.76 12.5 45.25 0l96-96 32.4 32.4c15.12 15.12 40.97 4.41 40.97-16.97V112c.01-8.84-7.15-16-15.99-16z"
-                    fill="currentColor"
-                    style={Object {}}
-                  />
-                </svg>
-              </span>
+                />
+              </svg>
             </span>
             <span
               className="sr-only"
@@ -179,27 +175,23 @@ exports[`<Sidebar /> renders correctly when code management is hidden 1`] = `
             <span
               className="d-flex align-items-center"
             >
-              <span
-                className=""
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-chart-line fa-w-16 fa-fw "
+                data-icon="chart-line"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-hidden="true"
-                  className="svg-inline--fa fa-chart-line fa-w-16 fa-fw "
-                  data-icon="chart-line"
-                  data-prefix="fas"
-                  focusable="false"
-                  role="img"
+                <path
+                  d="M496 384H64V80c0-8.84-7.16-16-16-16H16C7.16 64 0 71.16 0 80v336c0 17.67 14.33 32 32 32h464c8.84 0 16-7.16 16-16v-32c0-8.84-7.16-16-16-16zM464 96H345.94c-21.38 0-32.09 25.85-16.97 40.97l32.4 32.4L288 242.75l-73.37-73.37c-12.5-12.5-32.76-12.5-45.25 0l-68.69 68.69c-6.25 6.25-6.25 16.38 0 22.63l22.62 22.62c6.25 6.25 16.38 6.25 22.63 0L192 237.25l73.37 73.37c12.5 12.5 32.76 12.5 45.25 0l96-96 32.4 32.4c15.12 15.12 40.97 4.41 40.97-16.97V112c.01-8.84-7.15-16-15.99-16z"
+                  fill="currentColor"
                   style={Object {}}
-                  viewBox="0 0 512 512"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M496 384H64V80c0-8.84-7.16-16-16-16H16C7.16 64 0 71.16 0 80v336c0 17.67 14.33 32 32 32h464c8.84 0 16-7.16 16-16v-32c0-8.84-7.16-16-16-16zM464 96H345.94c-21.38 0-32.09 25.85-16.97 40.97l32.4 32.4L288 242.75l-73.37-73.37c-12.5-12.5-32.76-12.5-45.25 0l-68.69 68.69c-6.25 6.25-6.25 16.38 0 22.63l22.62 22.62c6.25 6.25 16.38 6.25 22.63 0L192 237.25l73.37 73.37c12.5 12.5 32.76 12.5 45.25 0l96-96 32.4 32.4c15.12 15.12 40.97 4.41 40.97-16.97V112c.01-8.84-7.15-16-15.99-16z"
-                    fill="currentColor"
-                    style={Object {}}
-                  />
-                </svg>
-              </span>
+                />
+              </svg>
             </span>
             <span
               className="sr-only"
@@ -245,27 +237,23 @@ exports[`<Sidebar /> renders correctly when expanded 1`] = `
             <span
               className="d-flex align-items-center"
             >
-              <span
-                className="mr-2"
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-chart-line fa-w-16 fa-fw mr-2"
+                data-icon="chart-line"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-hidden="true"
-                  className="svg-inline--fa fa-chart-line fa-w-16 fa-fw "
-                  data-icon="chart-line"
-                  data-prefix="fas"
-                  focusable="false"
-                  role="img"
+                <path
+                  d="M496 384H64V80c0-8.84-7.16-16-16-16H16C7.16 64 0 71.16 0 80v336c0 17.67 14.33 32 32 32h464c8.84 0 16-7.16 16-16v-32c0-8.84-7.16-16-16-16zM464 96H345.94c-21.38 0-32.09 25.85-16.97 40.97l32.4 32.4L288 242.75l-73.37-73.37c-12.5-12.5-32.76-12.5-45.25 0l-68.69 68.69c-6.25 6.25-6.25 16.38 0 22.63l22.62 22.62c6.25 6.25 16.38 6.25 22.63 0L192 237.25l73.37 73.37c12.5 12.5 32.76 12.5 45.25 0l96-96 32.4 32.4c15.12 15.12 40.97 4.41 40.97-16.97V112c.01-8.84-7.15-16-15.99-16z"
+                  fill="currentColor"
                   style={Object {}}
-                  viewBox="0 0 512 512"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M496 384H64V80c0-8.84-7.16-16-16-16H16C7.16 64 0 71.16 0 80v336c0 17.67 14.33 32 32 32h464c8.84 0 16-7.16 16-16v-32c0-8.84-7.16-16-16-16zM464 96H345.94c-21.38 0-32.09 25.85-16.97 40.97l32.4 32.4L288 242.75l-73.37-73.37c-12.5-12.5-32.76-12.5-45.25 0l-68.69 68.69c-6.25 6.25-6.25 16.38 0 22.63l22.62 22.62c6.25 6.25 16.38 6.25 22.63 0L192 237.25l73.37 73.37c12.5 12.5 32.76 12.5 45.25 0l96-96 32.4 32.4c15.12 15.12 40.97 4.41 40.97-16.97V112c.01-8.84-7.15-16-15.99-16z"
-                    fill="currentColor"
-                    style={Object {}}
-                  />
-                </svg>
-              </span>
+                />
+              </svg>
             </span>
             <span>
               Learner Progress Report
@@ -387,27 +375,23 @@ exports[`<Sidebar /> renders correctly when expanded by toggle 1`] = `
             <span
               className="d-flex align-items-center"
             >
-              <span
-                className="mr-2"
+              <svg
+                aria-hidden="true"
+                className="svg-inline--fa fa-chart-line fa-w-16 fa-fw mr-2"
+                data-icon="chart-line"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style={Object {}}
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-hidden="true"
-                  className="svg-inline--fa fa-chart-line fa-w-16 fa-fw "
-                  data-icon="chart-line"
-                  data-prefix="fas"
-                  focusable="false"
-                  role="img"
+                <path
+                  d="M496 384H64V80c0-8.84-7.16-16-16-16H16C7.16 64 0 71.16 0 80v336c0 17.67 14.33 32 32 32h464c8.84 0 16-7.16 16-16v-32c0-8.84-7.16-16-16-16zM464 96H345.94c-21.38 0-32.09 25.85-16.97 40.97l32.4 32.4L288 242.75l-73.37-73.37c-12.5-12.5-32.76-12.5-45.25 0l-68.69 68.69c-6.25 6.25-6.25 16.38 0 22.63l22.62 22.62c6.25 6.25 16.38 6.25 22.63 0L192 237.25l73.37 73.37c12.5 12.5 32.76 12.5 45.25 0l96-96 32.4 32.4c15.12 15.12 40.97 4.41 40.97-16.97V112c.01-8.84-7.15-16-15.99-16z"
+                  fill="currentColor"
                   style={Object {}}
-                  viewBox="0 0 512 512"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M496 384H64V80c0-8.84-7.16-16-16-16H16C7.16 64 0 71.16 0 80v336c0 17.67 14.33 32 32 32h464c8.84 0 16-7.16 16-16v-32c0-8.84-7.16-16-16-16zM464 96H345.94c-21.38 0-32.09 25.85-16.97 40.97l32.4 32.4L288 242.75l-73.37-73.37c-12.5-12.5-32.76-12.5-45.25 0l-68.69 68.69c-6.25 6.25-6.25 16.38 0 22.63l22.62 22.62c6.25 6.25 16.38 6.25 22.63 0L192 237.25l73.37 73.37c12.5 12.5 32.76 12.5 45.25 0l96-96 32.4 32.4c15.12 15.12 40.97 4.41 40.97-16.97V112c.01-8.84-7.15-16-15.99-16z"
-                    fill="currentColor"
-                    style={Object {}}
-                  />
-                </svg>
-              </span>
+                />
+              </svg>
             </span>
             <span>
               Learner Progress Report

--- a/src/containers/Sidebar/__snapshots__/Sidebar.test.jsx.snap
+++ b/src/containers/Sidebar/__snapshots__/Sidebar.test.jsx.snap
@@ -21,31 +21,37 @@ exports[`<Sidebar /> renders correctly 1`] = `
       >
         <a
           aria-current={null}
-          className="nav-link text-left rounded-0"
+          className="nav-link text-left rounded-0 d-flex align-items-center"
           href="/test-enterprise-slug/admin/learners"
           onClick={[Function]}
         >
           <div
-            className="position-relative"
+            className="position-relative d-flex align-items-center"
           >
-            <span>
-              <svg
-                aria-hidden="true"
-                className="svg-inline--fa fa-chart-line fa-w-16 "
-                data-icon="chart-line"
-                data-prefix="fas"
-                focusable="false"
-                role="img"
-                style={Object {}}
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <span
+              className="d-flex align-items-center"
+            >
+              <span
+                className=""
               >
-                <path
-                  d="M496 384H64V80c0-8.84-7.16-16-16-16H16C7.16 64 0 71.16 0 80v336c0 17.67 14.33 32 32 32h464c8.84 0 16-7.16 16-16v-32c0-8.84-7.16-16-16-16zM464 96H345.94c-21.38 0-32.09 25.85-16.97 40.97l32.4 32.4L288 242.75l-73.37-73.37c-12.5-12.5-32.76-12.5-45.25 0l-68.69 68.69c-6.25 6.25-6.25 16.38 0 22.63l22.62 22.62c6.25 6.25 16.38 6.25 22.63 0L192 237.25l73.37 73.37c12.5 12.5 32.76 12.5 45.25 0l96-96 32.4 32.4c15.12 15.12 40.97 4.41 40.97-16.97V112c.01-8.84-7.15-16-15.99-16z"
-                  fill="currentColor"
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-chart-line fa-w-16 fa-fw "
+                  data-icon="chart-line"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
                   style={Object {}}
-                />
-              </svg>
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M496 384H64V80c0-8.84-7.16-16-16-16H16C7.16 64 0 71.16 0 80v336c0 17.67 14.33 32 32 32h464c8.84 0 16-7.16 16-16v-32c0-8.84-7.16-16-16-16zM464 96H345.94c-21.38 0-32.09 25.85-16.97 40.97l32.4 32.4L288 242.75l-73.37-73.37c-12.5-12.5-32.76-12.5-45.25 0l-68.69 68.69c-6.25 6.25-6.25 16.38 0 22.63l22.62 22.62c6.25 6.25 16.38 6.25 22.63 0L192 237.25l73.37 73.37c12.5 12.5 32.76 12.5 45.25 0l96-96 32.4 32.4c15.12 15.12 40.97 4.41 40.97-16.97V112c.01-8.84-7.15-16-15.99-16z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </span>
             </span>
             <span
               className="sr-only"
@@ -60,17 +66,19 @@ exports[`<Sidebar /> renders correctly 1`] = `
       >
         <a
           aria-current={null}
-          className="nav-link text-left rounded-0"
+          className="nav-link text-left rounded-0 d-flex align-items-center"
           href="/test-enterprise-slug/admin/coupons"
           onClick={[Function]}
         >
           <div
-            className="position-relative"
+            className="position-relative d-flex align-items-center"
           >
-            <span>
+            <span
+              className="d-flex align-items-center"
+            >
               <svg
                 aria-hidden="true"
-                className="svg-inline--fa fa-tags fa-w-20 "
+                className="svg-inline--fa fa-tags fa-w-20 fa-fw "
                 data-icon="tags"
                 data-prefix="fas"
                 focusable="false"
@@ -99,17 +107,19 @@ exports[`<Sidebar /> renders correctly 1`] = `
       >
         <a
           aria-current={null}
-          className="nav-link text-left rounded-0"
+          className="nav-link text-left rounded-0 d-flex align-items-center"
           href="/test-enterprise-slug/admin/subscriptions"
           onClick={[Function]}
         >
           <div
-            className="position-relative"
+            className="position-relative d-flex align-items-center"
           >
-            <span>
+            <span
+              className="d-flex align-items-center"
+            >
               <svg
                 aria-hidden="true"
-                className="svg-inline--fa fa-credit-card fa-w-18 "
+                className="svg-inline--fa fa-credit-card fa-w-18 fa-fw "
                 data-icon="credit-card"
                 data-prefix="fas"
                 focusable="false"
@@ -159,31 +169,37 @@ exports[`<Sidebar /> renders correctly when code management is hidden 1`] = `
       >
         <a
           aria-current={null}
-          className="nav-link text-left rounded-0"
+          className="nav-link text-left rounded-0 d-flex align-items-center"
           href="/test-enterprise-slug/admin/learners"
           onClick={[Function]}
         >
           <div
-            className="position-relative"
+            className="position-relative d-flex align-items-center"
           >
-            <span>
-              <svg
-                aria-hidden="true"
-                className="svg-inline--fa fa-chart-line fa-w-16 "
-                data-icon="chart-line"
-                data-prefix="fas"
-                focusable="false"
-                role="img"
-                style={Object {}}
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <span
+              className="d-flex align-items-center"
+            >
+              <span
+                className=""
               >
-                <path
-                  d="M496 384H64V80c0-8.84-7.16-16-16-16H16C7.16 64 0 71.16 0 80v336c0 17.67 14.33 32 32 32h464c8.84 0 16-7.16 16-16v-32c0-8.84-7.16-16-16-16zM464 96H345.94c-21.38 0-32.09 25.85-16.97 40.97l32.4 32.4L288 242.75l-73.37-73.37c-12.5-12.5-32.76-12.5-45.25 0l-68.69 68.69c-6.25 6.25-6.25 16.38 0 22.63l22.62 22.62c6.25 6.25 16.38 6.25 22.63 0L192 237.25l73.37 73.37c12.5 12.5 32.76 12.5 45.25 0l96-96 32.4 32.4c15.12 15.12 40.97 4.41 40.97-16.97V112c.01-8.84-7.15-16-15.99-16z"
-                  fill="currentColor"
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-chart-line fa-w-16 fa-fw "
+                  data-icon="chart-line"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
                   style={Object {}}
-                />
-              </svg>
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M496 384H64V80c0-8.84-7.16-16-16-16H16C7.16 64 0 71.16 0 80v336c0 17.67 14.33 32 32 32h464c8.84 0 16-7.16 16-16v-32c0-8.84-7.16-16-16-16zM464 96H345.94c-21.38 0-32.09 25.85-16.97 40.97l32.4 32.4L288 242.75l-73.37-73.37c-12.5-12.5-32.76-12.5-45.25 0l-68.69 68.69c-6.25 6.25-6.25 16.38 0 22.63l22.62 22.62c6.25 6.25 16.38 6.25 22.63 0L192 237.25l73.37 73.37c12.5 12.5 32.76 12.5 45.25 0l96-96 32.4 32.4c15.12 15.12 40.97 4.41 40.97-16.97V112c.01-8.84-7.15-16-15.99-16z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </span>
             </span>
             <span
               className="sr-only"
@@ -219,31 +235,37 @@ exports[`<Sidebar /> renders correctly when expanded 1`] = `
       >
         <a
           aria-current={null}
-          className="nav-link text-left rounded-0"
+          className="nav-link text-left rounded-0 d-flex align-items-center"
           href="/test-enterprise-slug/admin/learners"
           onClick={[Function]}
         >
           <div
-            className="position-relative"
+            className="position-relative d-flex align-items-center"
           >
-            <span>
-              <svg
-                aria-hidden="true"
-                className="svg-inline--fa fa-chart-line fa-w-16 mr-2"
-                data-icon="chart-line"
-                data-prefix="fas"
-                focusable="false"
-                role="img"
-                style={Object {}}
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <span
+              className="d-flex align-items-center"
+            >
+              <span
+                className="mr-2"
               >
-                <path
-                  d="M496 384H64V80c0-8.84-7.16-16-16-16H16C7.16 64 0 71.16 0 80v336c0 17.67 14.33 32 32 32h464c8.84 0 16-7.16 16-16v-32c0-8.84-7.16-16-16-16zM464 96H345.94c-21.38 0-32.09 25.85-16.97 40.97l32.4 32.4L288 242.75l-73.37-73.37c-12.5-12.5-32.76-12.5-45.25 0l-68.69 68.69c-6.25 6.25-6.25 16.38 0 22.63l22.62 22.62c6.25 6.25 16.38 6.25 22.63 0L192 237.25l73.37 73.37c12.5 12.5 32.76 12.5 45.25 0l96-96 32.4 32.4c15.12 15.12 40.97 4.41 40.97-16.97V112c.01-8.84-7.15-16-15.99-16z"
-                  fill="currentColor"
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-chart-line fa-w-16 fa-fw "
+                  data-icon="chart-line"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
                   style={Object {}}
-                />
-              </svg>
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M496 384H64V80c0-8.84-7.16-16-16-16H16C7.16 64 0 71.16 0 80v336c0 17.67 14.33 32 32 32h464c8.84 0 16-7.16 16-16v-32c0-8.84-7.16-16-16-16zM464 96H345.94c-21.38 0-32.09 25.85-16.97 40.97l32.4 32.4L288 242.75l-73.37-73.37c-12.5-12.5-32.76-12.5-45.25 0l-68.69 68.69c-6.25 6.25-6.25 16.38 0 22.63l22.62 22.62c6.25 6.25 16.38 6.25 22.63 0L192 237.25l73.37 73.37c12.5 12.5 32.76 12.5 45.25 0l96-96 32.4 32.4c15.12 15.12 40.97 4.41 40.97-16.97V112c.01-8.84-7.15-16-15.99-16z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </span>
             </span>
             <span>
               Learner Progress Report
@@ -256,17 +278,19 @@ exports[`<Sidebar /> renders correctly when expanded 1`] = `
       >
         <a
           aria-current={null}
-          className="nav-link text-left rounded-0"
+          className="nav-link text-left rounded-0 d-flex align-items-center"
           href="/test-enterprise-slug/admin/coupons"
           onClick={[Function]}
         >
           <div
-            className="position-relative"
+            className="position-relative d-flex align-items-center"
           >
-            <span>
+            <span
+              className="d-flex align-items-center"
+            >
               <svg
                 aria-hidden="true"
-                className="svg-inline--fa fa-tags fa-w-20 mr-2"
+                className="svg-inline--fa fa-tags fa-w-20 fa-fw mr-2"
                 data-icon="tags"
                 data-prefix="fas"
                 focusable="false"
@@ -293,17 +317,19 @@ exports[`<Sidebar /> renders correctly when expanded 1`] = `
       >
         <a
           aria-current={null}
-          className="nav-link text-left rounded-0"
+          className="nav-link text-left rounded-0 d-flex align-items-center"
           href="/test-enterprise-slug/admin/subscriptions"
           onClick={[Function]}
         >
           <div
-            className="position-relative"
+            className="position-relative d-flex align-items-center"
           >
-            <span>
+            <span
+              className="d-flex align-items-center"
+            >
               <svg
                 aria-hidden="true"
-                className="svg-inline--fa fa-credit-card fa-w-18 mr-2"
+                className="svg-inline--fa fa-credit-card fa-w-18 fa-fw mr-2"
                 data-icon="credit-card"
                 data-prefix="fas"
                 focusable="false"
@@ -351,31 +377,37 @@ exports[`<Sidebar /> renders correctly when expanded by toggle 1`] = `
       >
         <a
           aria-current={null}
-          className="nav-link text-left rounded-0"
+          className="nav-link text-left rounded-0 d-flex align-items-center"
           href="/test-enterprise-slug/admin/learners"
           onClick={[Function]}
         >
           <div
-            className="position-relative"
+            className="position-relative d-flex align-items-center"
           >
-            <span>
-              <svg
-                aria-hidden="true"
-                className="svg-inline--fa fa-chart-line fa-w-16 mr-2"
-                data-icon="chart-line"
-                data-prefix="fas"
-                focusable="false"
-                role="img"
-                style={Object {}}
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <span
+              className="d-flex align-items-center"
+            >
+              <span
+                className="mr-2"
               >
-                <path
-                  d="M496 384H64V80c0-8.84-7.16-16-16-16H16C7.16 64 0 71.16 0 80v336c0 17.67 14.33 32 32 32h464c8.84 0 16-7.16 16-16v-32c0-8.84-7.16-16-16-16zM464 96H345.94c-21.38 0-32.09 25.85-16.97 40.97l32.4 32.4L288 242.75l-73.37-73.37c-12.5-12.5-32.76-12.5-45.25 0l-68.69 68.69c-6.25 6.25-6.25 16.38 0 22.63l22.62 22.62c6.25 6.25 16.38 6.25 22.63 0L192 237.25l73.37 73.37c12.5 12.5 32.76 12.5 45.25 0l96-96 32.4 32.4c15.12 15.12 40.97 4.41 40.97-16.97V112c.01-8.84-7.15-16-15.99-16z"
-                  fill="currentColor"
+                <svg
+                  aria-hidden="true"
+                  className="svg-inline--fa fa-chart-line fa-w-16 fa-fw "
+                  data-icon="chart-line"
+                  data-prefix="fas"
+                  focusable="false"
+                  role="img"
                   style={Object {}}
-                />
-              </svg>
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M496 384H64V80c0-8.84-7.16-16-16-16H16C7.16 64 0 71.16 0 80v336c0 17.67 14.33 32 32 32h464c8.84 0 16-7.16 16-16v-32c0-8.84-7.16-16-16-16zM464 96H345.94c-21.38 0-32.09 25.85-16.97 40.97l32.4 32.4L288 242.75l-73.37-73.37c-12.5-12.5-32.76-12.5-45.25 0l-68.69 68.69c-6.25 6.25-6.25 16.38 0 22.63l22.62 22.62c6.25 6.25 16.38 6.25 22.63 0L192 237.25l73.37 73.37c12.5 12.5 32.76 12.5 45.25 0l96-96 32.4 32.4c15.12 15.12 40.97 4.41 40.97-16.97V112c.01-8.84-7.15-16-15.99-16z"
+                    fill="currentColor"
+                    style={Object {}}
+                  />
+                </svg>
+              </span>
             </span>
             <span>
               Learner Progress Report
@@ -388,17 +420,19 @@ exports[`<Sidebar /> renders correctly when expanded by toggle 1`] = `
       >
         <a
           aria-current={null}
-          className="nav-link text-left rounded-0"
+          className="nav-link text-left rounded-0 d-flex align-items-center"
           href="/test-enterprise-slug/admin/coupons"
           onClick={[Function]}
         >
           <div
-            className="position-relative"
+            className="position-relative d-flex align-items-center"
           >
-            <span>
+            <span
+              className="d-flex align-items-center"
+            >
               <svg
                 aria-hidden="true"
-                className="svg-inline--fa fa-tags fa-w-20 mr-2"
+                className="svg-inline--fa fa-tags fa-w-20 fa-fw mr-2"
                 data-icon="tags"
                 data-prefix="fas"
                 focusable="false"
@@ -425,17 +459,19 @@ exports[`<Sidebar /> renders correctly when expanded by toggle 1`] = `
       >
         <a
           aria-current={null}
-          className="nav-link text-left rounded-0"
+          className="nav-link text-left rounded-0 d-flex align-items-center"
           href="/test-enterprise-slug/admin/subscriptions"
           onClick={[Function]}
         >
           <div
-            className="position-relative"
+            className="position-relative d-flex align-items-center"
           >
-            <span>
+            <span
+              className="d-flex align-items-center"
+            >
               <svg
                 aria-hidden="true"
-                className="svg-inline--fa fa-credit-card fa-w-18 mr-2"
+                className="svg-inline--fa fa-credit-card fa-w-18 fa-fw mr-2"
                 data-icon="credit-card"
                 data-prefix="fas"
                 focusable="false"


### PR DESCRIPTION
# Description

Adds a "Learner Credit Management" tab to the sidebar navigation that links to a new shell page with the hero/title. It is behind the `FEATURE_LEARNER_CREDIT_MANAGEMENT` feature flag.

Also ran `npx browserslist --update-db` which updated package-lock.json.

<img width="1509" alt="image" src="https://user-images.githubusercontent.com/2828721/171925144-ead2917f-9b1c-46c1-8657-affe9bc52c28.png">

<img width="734" alt="image" src="https://user-images.githubusercontent.com/2828721/171938999-b404c741-6f81-49c8-a429-b8d4517bc399.png">

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
