### PR TITLE
fix: adding base error handling

### DIFF
--- a/src/components/settings/SettingsSSOTab/NewSSOConfigForm.jsx
+++ b/src/components/settings/SettingsSSOTab/NewSSOConfigForm.jsx
@@ -1,8 +1,9 @@
 import React, { useContext } from 'react';
-import { Alert } from '@edx/paragon';
+import { Alert, Hyperlink } from '@edx/paragon';
 import { WarningFilled } from '@edx/paragon/icons';
 import { SSOConfigContext } from './SSOConfigContext';
 import SSOStepper from './SSOStepper';
+import { HELP_CENTER_SAML_LINK } from '../data/constants';
 
 const NewSSOConfigForm = () => {
   const { ssoState: { currentError } } = useContext(SSOConfigContext);
@@ -14,9 +15,24 @@ const NewSSOConfigForm = () => {
       </span>
       <SSOStepper />
       {currentError && (
-      <Alert variant="warning" icon={WarningFilled}>
-        <p className="my-3" style={{ wordBreak: 'break-all' }}>
-          There has been an error {currentError}
+      <Alert
+        variant="warning"
+        stacked
+        dismissible
+        icon={WarningFilled}
+        actions={[
+          <Hyperlink
+            destination={HELP_CENTER_SAML_LINK}
+            className="btn btn-sm btn-primary"
+            target="_blank"
+          >
+            Help Center
+          </Hyperlink>,
+        ]}
+      >
+        <Alert.Heading>Something went wrong.</Alert.Heading>
+        <p className="my-3">
+          Our system experienced an error. If this persists, please consult our help center.
         </p>
       </Alert>
       )}

--- a/src/components/settings/SettingsSSOTab/tests/NewSSOConfigForm.test.jsx
+++ b/src/components/settings/SettingsSSOTab/tests/NewSSOConfigForm.test.jsx
@@ -118,6 +118,7 @@ describe('SAML Config Tab', () => {
     await expect(screen.queryByText('Do you want to save your work?')).toBeInTheDocument();
     userEvent.click(screen.getByText('Save'));
     await expect(handleErrors).toHaveBeenCalled();
+    expect(screen.queryByText('Our system experienced an error.'));
   });
   test('canceling configure step without making changes', async () => {
     const mockUpdateProviderConfig = jest.spyOn(LmsApiService, 'updateProviderConfig');
@@ -160,6 +161,7 @@ describe('SAML Config Tab', () => {
     userEvent.type(screen.getByText('Maximum Session Length (seconds)'), '2');
     userEvent.click(screen.getByText('Next'));
     await expect(handleErrors).toHaveBeenCalled();
+    expect(screen.queryByText('Our system experienced an error.'));
   });
   test('canceling without saving configure form', async () => {
     const mockUpdateProviderConfig = jest.spyOn(LmsApiService, 'updateProviderConfig');


### PR DESCRIPTION
# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change
![Screen Shot 2022-06-03 at 12 34 08 PM](https://user-images.githubusercontent.com/31229189/172193025-d7eebe2d-5003-44c4-8415-63320e71563e.png)
- [x] Ensure to attach screenshots
- [x] Ensure to have UX team confirm screenshots


