### PR TITLE
fix: fixing config info entry bug

### DIFF
--- a/src/components/settings/SettingsSSOTab/steps/SSOConfigConfigureStep.jsx
+++ b/src/components/settings/SettingsSSOTab/steps/SSOConfigConfigureStep.jsx
@@ -18,25 +18,33 @@ const SSOConfigConfigureStep = ({
   setRefreshBool,
   refreshBool,
   setFormUpdated,
+  setConfigNextButtonDisabled,
 }) => {
-  const configData = new FormData();
   const [nameValid, setNameValid] = React.useState(true);
   const [lengthValid, setLengthValid] = React.useState(true);
+
+  const addConfigVal = (key, value) => {
+    setConfigValues((configValues) => ({
+      ...configValues,
+      [key]: value,
+    }));
+  };
 
   const validateField = (field, input) => {
     switch (field) {
       case 'seconds':
-        configData.set('max_session_length', input);
+        addConfigVal('max_session_length', input);
         setLengthValid(input <= 1210000);
+        setConfigNextButtonDisabled(!(input <= 1210000));
         break;
       case 'name':
-        configData.set('display_name', input);
+        addConfigVal('display_name', input);
         setNameValid(input?.length <= 20);
+        setConfigNextButtonDisabled(!(input?.length <= 20));
         break;
       default:
         break;
     }
-    setConfigValues(configData);
     setFormUpdated(true);
   };
 
@@ -61,7 +69,7 @@ const SSOConfigConfigureStep = ({
         <Hyperlink destination={HELP_CENTER_SAML_LINK} target="_blank">
           Help Center
         </Hyperlink>{' '}
-        article
+        article.
       </p>
       <ModalDialog
         onClose={closeExitModal}
@@ -168,8 +176,7 @@ const SSOConfigConfigureStep = ({
           <Form.Control
             type="text"
             onChange={(e) => {
-              configData.set('attr_user_permanent_id', e.target.value);
-              setConfigValues(configData);
+              addConfigVal('attr_user_permanent_id', e.target.value);
               setFormUpdated(true);
             }}
             maxLength={128}
@@ -184,9 +191,8 @@ const SSOConfigConfigureStep = ({
           <Form.Control
             type="text"
             onChange={(e) => {
-              configData.set('attr_full_name', e.target.value);
+              addConfigVal('attr_full_name', e.target.value);
               setFormUpdated(true);
-              setConfigValues(configData);
             }}
             maxLength={255}
             floatingLabel="Full Name Attribute"
@@ -200,8 +206,7 @@ const SSOConfigConfigureStep = ({
           <Form.Control
             type="text"
             onChange={(e) => {
-              configData.set('attr_first_name', e.target.value);
-              setConfigValues(configData);
+              addConfigVal('attr_first_name', e.target.value);
               setFormUpdated(true);
             }}
             maxLength={128}
@@ -216,8 +221,7 @@ const SSOConfigConfigureStep = ({
           <Form.Control
             type="text"
             onChange={(e) => {
-              configData.set('attr_last_name', e.target.value);
-              setConfigValues(configData);
+              addConfigVal('attr_last_name', e.target.value);
               setFormUpdated(true);
             }}
             maxLength={128}
@@ -233,8 +237,7 @@ const SSOConfigConfigureStep = ({
           <Form.Control
             type="text"
             onChange={(e) => {
-              configData.set('attr_email', e.target.value);
-              setConfigValues(configData);
+              addConfigVal('attr_email', e.target.value);
               setFormUpdated(true);
             }}
             maxLength={128}
@@ -243,18 +246,6 @@ const SSOConfigConfigureStep = ({
           />
           <Form.Text>
             URN of SAML attribute containing the user&apos;s email address[es]. Leave blank for default.
-          </Form.Text>
-        </Form.Group>
-
-        <Form.Group>
-          <Form.Control
-            type="text"
-            readOnly
-            floatingLabel="SAML Configuration"
-            defaultValue={(connectError ? errorData.samlConfig : existingConfigData?.saml_configuration)}
-          />
-          <Form.Text>
-            We use the default SAML certificate for all configurations.
           </Form.Text>
         </Form.Group>
       </div>
@@ -295,6 +286,7 @@ SSOConfigConfigureStep.propTypes = {
   setRefreshBool: PropTypes.func.isRequired,
   refreshBool: PropTypes.bool.isRequired,
   setFormUpdated: PropTypes.func.isRequired,
+  setConfigNextButtonDisabled: PropTypes.func.isRequired,
 };
 
 export default SSOConfigConfigureStep;

--- a/src/components/settings/SettingsSSOTab/steps/SSOConfigConfigureStep.jsx
+++ b/src/components/settings/SettingsSSOTab/steps/SSOConfigConfigureStep.jsx
@@ -31,16 +31,19 @@ const SSOConfigConfigureStep = ({
   };
 
   const validateField = (field, input) => {
+    let inputValid;
     switch (field) {
       case 'seconds':
+        inputValid = (input <= 1210000);
         addConfigVal('max_session_length', input);
-        setLengthValid(input <= 1210000);
-        setConfigNextButtonDisabled(!(input <= 1210000));
+        setLengthValid(inputValid);
+        setConfigNextButtonDisabled(!inputValid);
         break;
       case 'name':
+        inputValid = (input?.length <= 20);
         addConfigVal('display_name', input);
-        setNameValid(input?.length <= 20);
-        setConfigNextButtonDisabled(!(input?.length <= 20));
+        setNameValid(inputValid);
+        setConfigNextButtonDisabled(!inputValid);
         break;
       default:
         break;

--- a/src/components/settings/SettingsSSOTab/steps/SSOConfigConfigureStep.test.jsx
+++ b/src/components/settings/SettingsSSOTab/steps/SSOConfigConfigureStep.test.jsx
@@ -23,6 +23,7 @@ describe('SSO Config Configure step', () => {
         <SSOConfigContextProvider initialState={INITIAL_SSO_STATE}>
           <SSOConfigConfigureStep
             showExitModal={false}
+            configValues={null}
             setConfigValues={jest.fn()}
             connectError={false}
             setProviderConfig={jest.fn()}
@@ -31,6 +32,7 @@ describe('SSO Config Configure step', () => {
             setRefreshBool={jest.fn()}
             refreshBool={false}
             setFormUpdated={jest.fn()}
+            setConfigNextButtonDisabled={jest.fn()}
           />
         </SSOConfigContextProvider>
       </Provider>,
@@ -42,15 +44,16 @@ describe('SSO Config Configure step', () => {
     screen.getByLabelText('First Name Attribute');
     screen.getByLabelText('Last Name Attribute');
     screen.getByLabelText('Email Address Attribute');
-    screen.getByLabelText('SAML Configuration');
   });
-  test('updating fields fires setFormUpdated', () => {
+  test('updating fields fires setFormUpdated', async () => {
     const mockSetFormUpdated = jest.fn();
+    const configValues = null;
     render(
       <Provider store={store}>
         <SSOConfigContextProvider initialState={INITIAL_SSO_STATE}>
           <SSOConfigConfigureStep
             showExitModal={false}
+            configValues={configValues}
             setProviderConfig={jest.fn()}
             saveOnQuit={jest.fn()}
             closeExitModal={jest.fn()}
@@ -59,12 +62,14 @@ describe('SSO Config Configure step', () => {
             setConfigValues={jest.fn()}
             connectError={false}
             setFormUpdated={mockSetFormUpdated}
+            setConfigNextButtonDisabled={jest.fn()}
           />
         </SSOConfigContextProvider>
       </Provider>,
     );
+    expect(configValues).toBeNull();
     userEvent.type(screen.getByLabelText('SSO Configuration Name'), 'f');
-    userEvent.type(screen.getByLabelText('Maximum Session Length (seconds)'), 'f');
+    userEvent.type(screen.getByLabelText('Maximum Session Length (seconds)'), '1');
     userEvent.type(screen.getByLabelText('User ID Attribute'), 'f');
     userEvent.type(screen.getByLabelText('Full Name Attribute'), 'f');
     userEvent.type(screen.getByLabelText('First Name Attribute'), 'f');
@@ -73,11 +78,13 @@ describe('SSO Config Configure step', () => {
     expect(mockSetFormUpdated).toHaveBeenCalledTimes(7);
   });
   test('page form validation', () => {
+    const mockSetConfigNextButtonDisabled = jest.fn();
     render(
       <Provider store={store}>
         <SSOConfigContextProvider initialState={INITIAL_SSO_STATE}>
           <SSOConfigConfigureStep
             showExitModal={false}
+            configValues={null}
             setProviderConfig={jest.fn()}
             saveOnQuit={jest.fn()}
             closeExitModal={jest.fn()}
@@ -86,6 +93,7 @@ describe('SSO Config Configure step', () => {
             setConfigValues={jest.fn()}
             connectError={false}
             setFormUpdated={jest.fn()}
+            setConfigNextButtonDisabled={mockSetConfigNextButtonDisabled}
           />
         </SSOConfigContextProvider>
       </Provider>,
@@ -94,6 +102,7 @@ describe('SSO Config Configure step', () => {
     userEvent.type(screen.getByLabelText('Maximum Session Length (seconds)'), '2000000');
     expect(screen.queryByText(INVALID_NAME));
     expect(screen.queryByText(INVALID_LENGTH));
+    expect(mockSetConfigNextButtonDisabled).toHaveBeenCalled();
   });
   test('error with default values', () => {
     render(
@@ -101,6 +110,7 @@ describe('SSO Config Configure step', () => {
         <SSOConfigContextProvider initialState={INITIAL_SSO_STATE}>
           <SSOConfigConfigureStep
             connectError
+            configValues={null}
             setConfigValues={jest.fn()}
             setFormUpdated={jest.fn()}
             showExitModal={false}
@@ -109,6 +119,7 @@ describe('SSO Config Configure step', () => {
             closeExitModal={jest.fn()}
             setRefreshBool={jest.fn()}
             refreshBool={false}
+            setConfigNextButtonDisabled={jest.fn()}
           />
         </SSOConfigContextProvider>
       </Provider>,

--- a/src/components/settings/SettingsSSOTab/tests/NewSSOConfigForm.test.jsx
+++ b/src/components/settings/SettingsSSOTab/tests/NewSSOConfigForm.test.jsx
@@ -196,6 +196,7 @@ describe('SAML Config Tab', () => {
       ),
     ).toBeInTheDocument();
     userEvent.type(screen.getByText('Maximum Session Length (seconds)'), 'haha hehe');
+    expect(screen.getByText('Next')).toBeDisabled();
     userEvent.click(screen.getByText('Cancel'));
     await expect(screen.queryByText('Do you want to save your work?')).toBeInTheDocument();
     userEvent.click(screen.getByText('Exit without saving'));
@@ -241,6 +242,7 @@ describe('SAML Config Tab', () => {
       ),
     ).toBeInTheDocument();
     userEvent.type(screen.getByText('Maximum Session Length (seconds)'), 'haha hehe');
+    expect(screen.getByText('Next')).toBeDisabled();
     userEvent.click(screen.getByText('Cancel'));
     await expect(screen.queryByText('Do you want to save your work?')).toBeInTheDocument();
     userEvent.click(screen.getByText('Save'));
@@ -264,7 +266,7 @@ describe('SAML Config Tab', () => {
     ).toBeInTheDocument();
     userEvent.type(screen.getByText('Maximum Session Length (seconds)'), '2');
     userEvent.click(screen.getByText('Next'));
-    await waitFor(() => expect(mockSetProviderConfig).toHaveBeenCalled());
+    await expect(mockUpdateProviderConfig).toHaveBeenCalled();
   });
   test('idp completed check for url entry', async () => {
     // Setup

--- a/src/components/settings/data/constants.js
+++ b/src/components/settings/data/constants.js
@@ -25,7 +25,7 @@ export const SAP_TYPE = 'SAP';
 
 export const INVALID_LINK = 'Link must be properly formatted and start with http or https';
 export const INVALID_NAME = 'Display name must be unique and cannot be over 20 characters';
-export const INVALID_LENGTH = 'Max length cannot be over 2 weeks (1210000 seconds)';
+export const INVALID_LENGTH = 'Max length must be a number, but cannot be over 2 weeks (1210000 seconds)';
 
 /**
  * Used as tab values and in router params


### PR DESCRIPTION
Fixing dual entry for SSO bug, along with fixing a bug that still allows for advancement tot he next page after incorrectly entering fields. 
https://2u-internal.atlassian.net/browse/ENT-5904

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
