### PR TITLE
FC-0001: Replace usages enterprise_catalog Enterprise API V1

### DIFF
--- a/src/components/ReportingConfig/index.jsx
+++ b/src/components/ReportingConfig/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Collapsible, Icon } from '@edx/paragon';
 import { camelCaseObject } from '@edx/frontend-platform';
+import EnterpriseCatalogApiService from '../../data/services/EnterpriseCatalogApiService';
 import LMSApiService from '../../data/services/LmsApiService';
 import ReportingConfigForm from './ReportingConfigForm';
 import { snakeCaseFormData } from '../../utils';
@@ -26,7 +27,7 @@ class ReportingConfig extends React.Component {
   componentDidMount() {
     Promise.allSettled([
       LMSApiService.fetchReportingConfigs(this.props.enterpriseId),
-      LMSApiService.fetchEnterpriseCustomerCatalogs(this.props.enterpriseId),
+      EnterpriseCatalogApiService.fetchEnterpriseCustomerCatalogs(this.props.enterpriseId),
       LMSApiService.fetchReportingConfigTypes(this.props.enterpriseId),
     ])
       .then((responses) => {

--- a/src/data/services/EnterpriseCatalogApiService.js
+++ b/src/data/services/EnterpriseCatalogApiService.js
@@ -7,6 +7,8 @@ class EnterpriseCatalogApiService {
 
   static apiClient = getAuthenticatedHttpClient;
 
+  static enterpriseCustomerCatalogsUrl = `${EnterpriseCatalogApiService.baseUrl}/enterprise-catalogs/`;
+
   static fetchApplicableCatalogs({ enterpriseId, courseRunIds }) {
     // This API call will *only* obtain the enterprise's catalogs whose
     // catalog queries return/contain the specified courseRunIds.
@@ -22,6 +24,10 @@ class EnterpriseCatalogApiService {
         useCache: configuration.USE_API_CACHE,
       },
     ).get(url);
+  }
+
+  static fetchEnterpriseCustomerCatalogs(enterpriseId) {
+    return EnterpriseCatalogApiService.apiClient().get(`${EnterpriseCatalogApiService.enterpriseCustomerCatalogsUrl}?enterprise_customer=${enterpriseId}`);
   }
 }
 

--- a/src/data/services/LmsApiService.js
+++ b/src/data/services/LmsApiService.js
@@ -22,8 +22,6 @@ class LmsApiService {
 
   static createPendingUsersUrl = `${LmsApiService.baseUrl}/enterprise/api/v1/link_pending_enterprise_users`;
 
-  static enterpriseCustomerCatalogsUrl = `${LmsApiService.baseUrl}/enterprise/api/v1/enterprise_catalogs/`;
-
   static notificationReadUrl = `${LmsApiService.baseUrl}/enterprise/api/v1/read_notification`;
 
   static enterpriseCustomerInviteKeyListUrl = `${LmsApiService.baseUrl}/enterprise/api/v1/enterprise-customer-invite-key/basic-list/`;
@@ -249,10 +247,6 @@ class LmsApiService {
 
   static createPendingEnterpriseUsers(formData, uuid) {
     return LmsApiService.apiClient().post(`${LmsApiService.createPendingUsersUrl}/${uuid}`, formData);
-  }
-
-  static fetchEnterpriseCustomerCatalogs(enterpriseId) {
-    return LmsApiService.apiClient().get(`${LmsApiService.enterpriseCustomerCatalogsUrl}?enterprise_customer=${enterpriseId}`);
   }
 
   static markBannerNotificationAsRead(formData) {


### PR DESCRIPTION
(2 of 5) for closes https://github.com/openedx/public-engineering/issues/61
##### Latest: https://github.com/openedx/edx-enterprise/pull/1582

## Description:

Replace this [usage](https://github.com/openedx/frontend-app-admin-portal/blob/master/src/data/services/LmsApiService.js#L254-L256) with corresponding to the **enterprise-catalog** service