### PR TITLE
Moving code coverage from codecov package to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,6 @@ jobs:
     - name: Test
       run: npm run test
     - name: Coverage
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
     - name: Build
       run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,6 @@
         "@testing-library/react": "11.2.7",
         "@testing-library/react-hooks": "5.0.3",
         "@testing-library/user-event": "12.8.3",
-        "codecov": "3.7.1",
         "css-loader": "5.2.6",
         "enzyme": "3.11.0",
         "enzyme-adapter-react-16": "1.15.6",
@@ -8610,13 +8609,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/argv": {
-      "version": "0.0.2",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6.10"
-      }
-    },
     "node_modules/aria-hidden": {
       "version": "1.1.3",
       "license": "ISC",
@@ -10618,36 +10610,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/codecov": {
-      "version": "3.7.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argv": "0.0.2",
-        "ignore-walk": "3.0.3",
-        "js-yaml": "3.13.1",
-        "teeny-request": "6.0.1",
-        "urlgrey": "0.4.4"
-      },
-      "bin": {
-        "codecov": "bin/codecov"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/codecov/node_modules/js-yaml": {
-      "version": "3.13.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -15239,14 +15201,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/ignore-walk": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minimatch": "^3.0.4"
-      }
-    },
     "node_modules/image-webpack-loader": {
       "version": "8.1.0",
       "dev": true,
@@ -18864,36 +18818,6 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-forge": {
@@ -23555,14 +23479,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/stream-events": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "stubs": "^3.0.0"
-      }
-    },
     "node_modules/strict-uri-encode": {
       "version": "1.1.0",
       "license": "MIT",
@@ -23737,11 +23653,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/stubs": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/style-loader": {
       "version": "2.0.0",
@@ -24007,38 +23918,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/teeny-request": {
-      "version": "6.0.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "http-proxy-agent": "^4.0.0",
-        "https-proxy-agent": "^4.0.0",
-        "node-fetch": "^2.2.0",
-        "stream-events": "^1.0.5",
-        "uuid": "^3.3.2"
-      }
-    },
-    "node_modules/teeny-request/node_modules/agent-base": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/teeny-request/node_modules/https-proxy-agent": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "5",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
       }
     },
     "node_modules/temp-dir": {
@@ -24827,11 +24706,6 @@
       "version": "1.3.2",
       "license": "MIT"
     },
-    "node_modules/urlgrey": {
-      "version": "0.4.4",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
     "node_modules/use": {
       "version": "3.1.1",
       "dev": true,
@@ -24909,6 +24783,7 @@
       "version": "3.4.0",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "bin": {
         "uuid": "bin/uuid"
       }
@@ -31667,10 +31542,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "argv": {
-      "version": "0.0.2",
-      "dev": true
-    },
     "aria-hidden": {
       "version": "1.1.3",
       "requires": {
@@ -33009,27 +32880,6 @@
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
-          }
-        }
-      }
-    },
-    "codecov": {
-      "version": "3.7.1",
-      "dev": true,
-      "requires": {
-        "argv": "0.0.2",
-        "ignore-walk": "3.0.3",
-        "js-yaml": "3.13.1",
-        "teeny-request": "6.0.1",
-        "urlgrey": "0.4.4"
-      },
-      "dependencies": {
-        "js-yaml": {
-          "version": "3.13.1",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
           }
         }
       }
@@ -36103,13 +35953,6 @@
       "version": "4.0.6",
       "dev": true
     },
-    "ignore-walk": {
-      "version": "3.0.3",
-      "dev": true,
-      "requires": {
-        "minimatch": "^3.0.4"
-      }
-    },
     "image-webpack-loader": {
       "version": "8.1.0",
       "dev": true,
@@ -38487,31 +38330,6 @@
       "requires": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
-      }
-    },
-    "node-fetch": {
-      "version": "2.6.6",
-      "dev": true,
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      },
-      "dependencies": {
-        "tr46": {
-          "version": "0.0.3",
-          "dev": true
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "dev": true
-        },
-        "whatwg-url": {
-          "version": "5.0.0",
-          "dev": true,
-          "requires": {
-            "tr46": "~0.0.3",
-            "webidl-conversions": "^3.0.0"
-          }
-        }
       }
     },
     "node-forge": {
@@ -41523,13 +41341,6 @@
       "version": "1.5.0",
       "dev": true
     },
-    "stream-events": {
-      "version": "1.0.5",
-      "dev": true,
-      "requires": {
-        "stubs": "^3.0.0"
-      }
-    },
     "strict-uri-encode": {
       "version": "1.1.0"
     },
@@ -41647,10 +41458,6 @@
       "version": "1.0.5",
       "dev": true,
       "optional": true
-    },
-    "stubs": {
-      "version": "3.0.0",
-      "dev": true
     },
     "style-loader": {
       "version": "2.0.0",
@@ -41833,31 +41640,6 @@
         "readable-stream": "^2.3.0",
         "to-buffer": "^1.1.1",
         "xtend": "^4.0.0"
-      }
-    },
-    "teeny-request": {
-      "version": "6.0.1",
-      "dev": true,
-      "requires": {
-        "http-proxy-agent": "^4.0.0",
-        "https-proxy-agent": "^4.0.0",
-        "node-fetch": "^2.2.0",
-        "stream-events": "^1.0.5",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "5.1.1",
-          "dev": true
-        },
-        "https-proxy-agent": {
-          "version": "4.0.0",
-          "dev": true,
-          "requires": {
-            "agent-base": "5",
-            "debug": "4"
-          }
-        }
       }
     },
     "temp-dir": {
@@ -42344,10 +42126,6 @@
       "dev": true,
       "optional": true
     },
-    "urlgrey": {
-      "version": "0.4.4",
-      "dev": true
-    },
     "use": {
       "version": "3.1.1",
       "dev": true
@@ -42391,7 +42169,8 @@
     },
     "uuid": {
       "version": "3.4.0",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "@testing-library/react": "11.2.7",
     "@testing-library/react-hooks": "5.0.3",
     "@testing-library/user-event": "12.8.3",
-    "codecov": "3.7.1",
     "css-loader": "5.2.6",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.6",


### PR DESCRIPTION
Codecov NodeJS Uploader [package](https://www.npmjs.com/package/codecov) is depreciated since version 3.8.3

This PR move the coverage to CI according to the new guidelines and [depreciation](https://about.codecov.io/blog/codecov-uploader-deprecation-plan/) plan of codecov 