### PR TITLE
fix: cleaning up self serve integration config settings page

### DIFF
--- a/src/components/settings/SettingsLMSTab/LMSConfigs/BlackboardConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/BlackboardConfig.jsx
@@ -53,6 +53,8 @@ const BlackboardConfig = ({
           setOauthPollingInterval(null);
           setOauthPollingTimeout(null);
           setOauthTimeout(false);
+          // trigger a success call which will redirect the user back to the landing page
+          onClick(SUCCESS_LABEL);
         }
       } catch (error) {
         err = handleErrors(error);
@@ -158,12 +160,6 @@ const BlackboardConfig = ({
     }
   };
 
-  useEffect(() => {
-    if (authorized) {
-      onClick(SUCCESS_LABEL);
-    }
-  }, [authorized, onClick]);
-
   const handleSubmit = async (event) => {
     event.preventDefault();
     // format config data for the backend
@@ -254,6 +250,7 @@ const BlackboardConfig = ({
             maxLength={255}
             isInvalid={!urlValid}
             onChange={(e) => {
+              setAuthorized(false);
               setEdited(true);
               validateField('Blackboard Base URL', e.target.value);
             }}

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/CanvasConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/CanvasConfig.jsx
@@ -59,6 +59,8 @@ const CanvasConfig = ({
           setOauthPollingInterval(null);
           setOauthPollingTimeout(null);
           setOauthTimeout(false);
+          // trigger a success call which will redirect the user back to the landing page
+          onClick(SUCCESS_LABEL);
         }
       } catch (error) {
         err = handleErrors(error);
@@ -103,11 +105,14 @@ const CanvasConfig = ({
     transformedConfig.enterprise_customer = enterpriseCustomerUuid;
     let err;
     let fetchedConfigId;
+    let fetchedConfigUuid;
     // First either submit the new config or update the existing one before attempting to authorize
     // If the config exists but has been edited, update it
     if (!isEmpty(existingData) && edited) {
       try {
+        transformedConfig.active = existingData.active;
         const response = await LmsApiService.updateCanvasConfig(transformedConfig, existingData.id);
+        fetchedConfigUuid = response.data.uuid;
         fetchedConfigId = response.data.id;
       } catch (error) {
         err = handleErrors(error);
@@ -117,12 +122,14 @@ const CanvasConfig = ({
       try {
         transformedConfig.active = false;
         const response = await LmsApiService.postNewCanvasConfig(transformedConfig);
+        fetchedConfigUuid = response.data.uuid;
         fetchedConfigId = response.data.id;
       } catch (error) {
         err = handleErrors(error);
       }
     // else we can retrieve the unedited, existing form's UUID and ID
     } else {
+      fetchedConfigUuid = existingData.uuid;
       fetchedConfigId = existingData.id;
     }
     if (err) {
@@ -137,19 +144,13 @@ const CanvasConfig = ({
       setOauthPollingTimeout(LMS_CONFIG_OAUTH_POLLING_TIMEOUT);
 
       const oauthUrl = `${canvasBaseUrl}/login/oauth2/auth?client_id=${clientId}&`
-      + `state=${fetchedConfigId}&response_type=code&`
+      + `state=${fetchedConfigUuid}&response_type=code&`
       + `redirect_uri=${CANVAS_OAUTH_REDIRECT_URL}`;
 
       // Open the oauth window for the user
       window.open(oauthUrl);
     }
   };
-
-  useEffect(() => {
-    if (authorized) {
-      onClick(SUCCESS_LABEL);
-    }
-  }, [authorized, onClick]);
 
   const handleSubmit = async (event) => {
     event.preventDefault();
@@ -234,6 +235,7 @@ const CanvasConfig = ({
             type="text"
             maxLength={255}
             onChange={(e) => {
+              setAuthorized(false);
               setEdited(true);
               setClientId(e.target.value);
             }}
@@ -247,6 +249,7 @@ const CanvasConfig = ({
             type="password"
             maxLength={255}
             onChange={(e) => {
+              setAuthorized(false);
               setEdited(true);
               setClientSecret(e.target.value);
             }}
@@ -261,6 +264,7 @@ const CanvasConfig = ({
             maxLength={255}
             onChange={(e) => {
               setEdited(true);
+              setAuthorized(false);
               setCanvasAccountId(e.target.value);
             }}
             floatingLabel="Canvas Account Number"
@@ -274,6 +278,7 @@ const CanvasConfig = ({
             isInvalid={!urlValid}
             onChange={(e) => {
               setEdited(true);
+              setAuthorized(false);
               validateField('Canvas Base URL', e.target.value);
             }}
             floatingLabel="Canvas Base URL"

--- a/src/components/settings/SettingsLMSTab/index.jsx
+++ b/src/components/settings/SettingsLMSTab/index.jsx
@@ -51,7 +51,7 @@ export default function SettingsLMSTab({
   // onClick function for existing config cards' edit action
   const editExistingConfig = (configData, configType) => {
     setConfigsLoading(false);
-    // Set the form data to the card's
+    // Set the form data to the card's associated config data
     setExistingConfigFormData(configData);
     // Set the config type to the card's type
     setConfig(configType);

--- a/src/components/settings/SettingsLMSTab/tests/BlackboardConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/BlackboardConfig.test.jsx
@@ -29,12 +29,9 @@ mockFetchSingleConfig.mockResolvedValue({ data: { refresh_token: 'foobar' } });
 const enterpriseId = 'test-enterprise-id';
 const mockOnClick = jest.fn();
 const noConfigs = [];
-const existingConfig = [{
-  displayName: 'name',
-}];
-const existingConfig2 = [{
-  displayName: 'foobar',
-}];
+const existingConfigDisplayNames = ['name'];
+const existingConfigDisplayNames2 = ['foobar'];
+
 // Freshly creating a config will have an empty existing data object
 const noExistingData = {};
 // Existing config data that has been authorized
@@ -78,7 +75,7 @@ describe('<BlackboardConfig />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={noExistingData}
-        existingConfigs={existingConfig}
+        existingConfigs={existingConfigDisplayNames}
       />,
     );
     expect(screen.getByText('Authorize')).toBeDisabled();
@@ -118,7 +115,7 @@ describe('<BlackboardConfig />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={existingConfigData}
-        existingConfigs={existingConfig2}
+        existingConfigs={existingConfigDisplayNames2}
       />,
     );
     fireEvent.change(screen.getByLabelText('Display Name'), {
@@ -130,10 +127,11 @@ describe('<BlackboardConfig />', () => {
     userEvent.type(screen.getByLabelText('Display Name'), 'displayName');
     userEvent.type(screen.getByLabelText('Blackboard Base URL'), 'https://www.test.com');
 
-    expect(screen.getByText('Submit')).not.toBeDisabled();
+    expect(screen.getByText('Authorize')).not.toBeDisabled();
 
-    userEvent.click(screen.getByText('Submit'));
+    await waitFor(() => userEvent.click(screen.getByText('Authorize')));
     const expectedConfig = {
+      active: false,
       blackboard_base_url: 'https://www.test.com',
       display_name: 'displayName',
       enterprise_customer: enterpriseId,
@@ -213,7 +211,7 @@ describe('<BlackboardConfig />', () => {
     userEvent.type(screen.getByLabelText('Blackboard Base URL'), 'https://www.test.com');
 
     expect(screen.getByText('Authorize')).not.toBeDisabled();
-    userEvent.click(screen.getByText('Authorize'));
+    await waitFor(() => userEvent.click(screen.getByText('Authorize')));
 
     // Await a find by text in order to account for state changes in the button callback
     await waitFor(() => expect(screen.queryByText('Authorize')).not.toBeInTheDocument());
@@ -227,7 +225,7 @@ describe('<BlackboardConfig />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={existingConfigDataNoAuth}
-        existingConfigs={existingConfig2}
+        existingConfigs={existingConfigDisplayNames2}
       />,
     );
     act(() => {
@@ -242,7 +240,7 @@ describe('<BlackboardConfig />', () => {
     userEvent.type(screen.getByLabelText('Blackboard Base URL'), 'https://www.test.com');
 
     expect(screen.getByText('Authorize')).not.toBeDisabled();
-    userEvent.click(screen.getByText('Authorize'));
+    await waitFor(() => userEvent.click(screen.getByText('Authorize')));
 
     await waitFor(() => expect(screen.queryByText('Authorize')).not.toBeInTheDocument());
     expect(mockOnClick).toHaveBeenCalledWith(SUCCESS_LABEL);
@@ -256,12 +254,12 @@ describe('<BlackboardConfig />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={existingConfigDataNoAuth}
-        existingConfigs={existingConfig2}
+        existingConfigs={existingConfigDisplayNames2}
       />,
     );
     expect(screen.getByText('Authorize')).not.toBeDisabled();
 
-    userEvent.click(screen.getByText('Authorize'));
+    await waitFor(() => userEvent.click(screen.getByText('Authorize')));
 
     // Await a find by text in order to account for state changes in the button callback
     await waitFor(() => expect(screen.queryByText('Authorize')).not.toBeInTheDocument());

--- a/src/components/settings/SettingsLMSTab/tests/CanvasConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/CanvasConfig.test.jsx
@@ -50,12 +50,8 @@ const existingConfigDataNoAuth = {
 };
 
 const noConfigs = [];
-const existingConfig = [{
-  displayName: 'name',
-}];
-const existingConfig2 = [{
-  displayName: 'foobar',
-}];
+const existingConfigDisplayNames = ['name'];
+const existingConfigDisplayNames2 = ['foobar'];
 
 afterEach(() => {
   jest.clearAllMocks();
@@ -83,7 +79,7 @@ describe('<CanvasConfig />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={noExistingData}
-        existingConfigs={existingConfig}
+        existingConfigs={existingConfigDisplayNames}
       />,
     );
     expect(screen.getByText('Authorize')).toBeDisabled();
@@ -116,7 +112,7 @@ describe('<CanvasConfig />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={existingConfigData}
-        existingConfigs={existingConfig2}
+        existingConfigs={existingConfigDisplayNames2}
       />,
     );
     await act(async () => {
@@ -143,9 +139,9 @@ describe('<CanvasConfig />', () => {
     userEvent.type(screen.getByLabelText('Canvas Account Number'), '3');
     userEvent.type(screen.getByLabelText('API Client Secret'), 'test2');
 
-    expect(screen.getByText('Submit')).not.toBeDisabled();
+    expect(screen.getByText('Authorize')).not.toBeDisabled();
 
-    userEvent.click(screen.getByText('Submit'));
+    userEvent.click(screen.getByText('Authorize'));
 
     // Await a find by text in order to account for state changes in the button callback
     await waitFor(() => screen.getByText('Submit'));
@@ -258,7 +254,7 @@ describe('<CanvasConfig />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={existingConfigDataNoAuth}
-        existingConfigs={existingConfig2}
+        existingConfigs={existingConfigDisplayNames2}
       />,
     );
     act(() => {
@@ -277,10 +273,10 @@ describe('<CanvasConfig />', () => {
 
     // Await a find by text in order to account for state changes in the button callback
     await waitFor(() => expect(screen.queryByText('Authorize')).not.toBeInTheDocument());
-    expect(mockOnClick).toHaveBeenCalledWith(SUCCESS_LABEL);
     expect(mockUpdateConfigApi).toHaveBeenCalled();
     expect(window.open).toHaveBeenCalled();
     expect(mockFetchSingleConfig).toHaveBeenCalledWith(1);
+    await waitFor(() => expect(mockOnClick).toHaveBeenCalledWith(SUCCESS_LABEL));
   });
   test('Authorizing an existing config will not call update or create config endpoint', async () => {
     render(
@@ -288,7 +284,7 @@ describe('<CanvasConfig />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={existingConfigDataNoAuth}
-        existingConfigs={existingConfig2}
+        existingConfigs={existingConfigDisplayNames2}
       />,
     );
     expect(screen.getByText('Authorize')).not.toBeDisabled();
@@ -320,7 +316,7 @@ describe('<CanvasConfig />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={existingConfigDataNoAuth}
-        existingConfigs={existingConfig2}
+        existingConfigs={existingConfigDisplayNames2}
       />,
     );
     expect(screen.queryByText(INVALID_LINK)).not.toBeInTheDocument();

--- a/src/components/settings/SettingsLMSTab/tests/CornerstoneConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/CornerstoneConfig.test.jsx
@@ -14,12 +14,9 @@ const enterpriseId = 'test-enterprise-id';
 
 const mockOnClick = jest.fn();
 const noConfigs = [];
-const existingConfig = [{
-  displayName: 'name',
-}];
-const existingConfigInvalid = [{
-  displayName: 'fooooooooobaaaaaaaaar',
-}];
+const existingConfigDisplayNames = ['name'];
+const existingConfigDisplayNamesInvalid = ['fooooooooobaaaaaaaaar'];
+
 const noExistingData = {};
 // Existing invalid data that will be validated on load
 const invalidExistingData = {
@@ -89,7 +86,7 @@ describe('<CornerstoneConfig />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={existingConfigData}
-        existingConfigs={existingConfig}
+        existingConfigs={existingConfigDisplayNames}
       />,
     );
     fireEvent.change(screen.getByLabelText('Display Name'), {
@@ -161,7 +158,7 @@ describe('<CornerstoneConfig />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={invalidExistingData}
-        existingConfigs={existingConfigInvalid}
+        existingConfigs={existingConfigDisplayNamesInvalid}
       />,
     );
     expect(screen.getByText(INVALID_LINK)).toBeInTheDocument();
@@ -173,7 +170,7 @@ describe('<CornerstoneConfig />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={existingConfigData}
-        existingConfigs={existingConfig}
+        existingConfigs={existingConfigDisplayNamesInvalid}
       />,
     );
     expect(screen.queryByText(INVALID_LINK)).not.toBeInTheDocument();

--- a/src/components/settings/SettingsLMSTab/tests/Degreed2Config.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/Degreed2Config.test.jsx
@@ -13,12 +13,8 @@ jest.mock('../../../../data/services/LmsApiService');
 const enterpriseId = 'test-enterprise-id';
 const mockOnClick = jest.fn();
 const noConfigs = [];
-const existingConfig = [{
-  displayName: 'test ayylmao',
-}];
-const existingConfigInvalid = [{
-  displayName: 'fooooooooobaaaaaaaaar',
-}];
+const existingConfigDisplayNames = ['name'];
+const existingConfigDisplayNamesInvalid = ['foobar'];
 const noExistingData = {};
 const existingConfigData = {
   id: 1,
@@ -106,7 +102,7 @@ describe('<Degreed2Config />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={existingConfigData}
-        existingConfigs={existingConfig}
+        existingConfigs={existingConfigDisplayNames}
       />,
     );
     fireEvent.change(screen.getByLabelText('API Client ID'), {
@@ -198,7 +194,7 @@ describe('<Degreed2Config />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={invalidExistingData}
-        existingConfigs={existingConfigInvalid}
+        existingConfigs={existingConfigDisplayNamesInvalid}
       />,
     );
     expect(screen.getByText(INVALID_LINK)).toBeInTheDocument();
@@ -210,7 +206,7 @@ describe('<Degreed2Config />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={existingConfigData}
-        existingConfigs={existingConfig}
+        existingConfigs={existingConfigDisplayNames}
       />,
     );
     expect(screen.queryByText(INVALID_LINK)).not.toBeInTheDocument();

--- a/src/components/settings/SettingsLMSTab/tests/DegreedConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/DegreedConfig.test.jsx
@@ -13,12 +13,8 @@ jest.mock('../../../../data/services/LmsApiService');
 const enterpriseId = 'test-enterprise-id';
 const mockOnClick = jest.fn();
 const noConfigs = [];
-const existingConfig = [{
-  displayName: 'test ayylmao',
-}];
-const existingConfigInvalid = [{
-  displayName: 'fooooooooobaaaaaaaaar',
-}];
+const existingConfigDisplayNames = ['name'];
+const existingConfigDisplayNamesInvalid = ['foobar'];
 const noExistingData = {};
 const existingConfigData = {
   id: 1,
@@ -109,7 +105,7 @@ describe('<DegreedConfig />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={existingConfigData}
-        existingConfigs={existingConfig}
+        existingConfigs={existingConfigDisplayNames}
       />,
     );
     fireEvent.change(screen.getByLabelText('API Client ID'), {
@@ -221,7 +217,7 @@ describe('<DegreedConfig />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={invalidExistingData}
-        existingConfigs={existingConfigInvalid}
+        existingConfigs={existingConfigDisplayNamesInvalid}
       />,
     );
     expect(screen.getByText(INVALID_LINK)).toBeInTheDocument();
@@ -233,7 +229,7 @@ describe('<DegreedConfig />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={existingConfigData}
-        existingConfigs={existingConfig}
+        existingConfigs={existingConfigDisplayNames}
       />,
     );
     expect(screen.queryByText(INVALID_LINK)).not.toBeInTheDocument();

--- a/src/components/settings/SettingsLMSTab/tests/ExistingLMSCardDeck.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/ExistingLMSCardDeck.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 
@@ -74,7 +74,7 @@ describe('<ExistingLMSCardDeck />', () => {
     expect(screen.getByText('Active')).toBeInTheDocument();
     expect(screen.getByText('foobar')).toBeInTheDocument();
   });
-  it('renders incomplete config card', () => {
+  it('renders incomplete config card', async () => {
     render(
       <ExistingLMSCardDeck
         configData={incompleteConfigData}
@@ -85,7 +85,7 @@ describe('<ExistingLMSCardDeck />', () => {
     );
     expect(screen.getByText('Incomplete')).toBeInTheDocument();
     expect(screen.getByText('barfoo')).toBeInTheDocument();
-    userEvent.hover(screen.getByText('Incomplete'));
+    await waitFor(() => userEvent.hover(screen.getByText('Incomplete')));
     expect(screen.getByText('Next Steps')).toBeInTheDocument();
     expect(screen.getByText('2 fields')).toBeInTheDocument();
   });
@@ -157,7 +157,7 @@ describe('<ExistingLMSCardDeck />', () => {
     };
     expect(LmsApiService.updateBlackboardConfig).toHaveBeenCalledWith(expectedConfigOptions, configData[0].id);
   });
-  it('renders correct single field incomplete config hover text', () => {
+  it('renders correct single field incomplete config hover text', async () => {
     render(
       <ExistingLMSCardDeck
         configData={singleInvalidFieldConfigData}
@@ -166,12 +166,12 @@ describe('<ExistingLMSCardDeck />', () => {
         enterpriseCustomerUuid={enterpriseCustomerUuid}
       />,
     );
-    expect(screen.getByText('Incomplete')).toBeInTheDocument();
-    userEvent.hover(screen.getByText('Incomplete'));
+    await waitFor(() => expect(screen.getByText('Incomplete')).toBeInTheDocument());
+    await waitFor(() => userEvent.hover(screen.getByText('Incomplete')));
     expect(screen.getByText('Next Steps')).toBeInTheDocument();
     expect(screen.getByText('1 field')).toBeInTheDocument();
   });
-  it('renders correct refresh token needed hover text', () => {
+  it('renders correct refresh token needed hover text', async () => {
     render(
       <ExistingLMSCardDeck
         configData={needsRefreshTokenConfigData}
@@ -180,9 +180,11 @@ describe('<ExistingLMSCardDeck />', () => {
         enterpriseCustomerUuid={enterpriseCustomerUuid}
       />,
     );
-    expect(screen.getByText('Incomplete')).toBeInTheDocument();
-    userEvent.hover(screen.getByText('Incomplete'));
-    expect(screen.getByText('Next Steps')).toBeInTheDocument();
-    expect(screen.getByText('authorize your LMS')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('Incomplete')).toBeInTheDocument());
+    await waitFor(() => userEvent.hover(screen.getByText('Incomplete')));
+    expect(screen.getByText('Next Steps'))
+      .toBeInTheDocument();
+    expect(screen.getByText('authorize your LMS'))
+      .toBeInTheDocument();
   });
 });

--- a/src/components/settings/SettingsLMSTab/tests/LmsConfigPage.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/LmsConfigPage.test.jsx
@@ -205,12 +205,13 @@ describe('<SettingsLMSTab />', () => {
       expect(screen.findByText(channelMapping[MOODLE_TYPE].displayName));
     });
     const moodleCard = screen.getByText(channelMapping[MOODLE_TYPE].displayName);
-    fireEvent.click(moodleCard);
-    expect(screen.queryByText('Connect Moodle')).toBeTruthy();
+
+    await waitFor(() => fireEvent.click(moodleCard));
+    await waitFor(() => expect(screen.queryByText('Connect Moodle')).toBeTruthy());
     const cancelButton = screen.getByText('Cancel');
-    fireEvent.click(cancelButton);
-    expect(screen.queryByText('Exit without saving')).toBeFalsy();
-    expect(screen.queryByText('Connect Moodle')).toBeFalsy();
+    await waitFor(() => fireEvent.click(cancelButton));
+    await waitFor(() => expect(screen.queryByText('Exit without saving')).toBeFalsy());
+    await waitFor(() => expect(screen.queryByText('Connect Moodle')).toBeFalsy());
   });
   test('No action Degreed2 card cancel flow', async () => {
     renderWithRouter(<SettingsLMSWrapper />);
@@ -220,10 +221,10 @@ describe('<SettingsLMSTab />', () => {
       expect(screen.findByText(channelMapping[DEGREED2_TYPE].displayName));
     });
     const degreedCard = screen.getByText(channelMapping[DEGREED2_TYPE].displayName);
-    fireEvent.click(degreedCard);
+    await waitFor(() => fireEvent.click(degreedCard));
     expect(screen.queryByText('Connect Degreed')).toBeTruthy();
     const cancelButton = screen.getByText('Cancel');
-    fireEvent.click(cancelButton);
+    await waitFor(() => fireEvent.click(cancelButton));
     expect(screen.queryByText('Exit without saving')).toBeFalsy();
     expect(screen.queryByText('Connect Degreed')).toBeFalsy();
   });
@@ -235,10 +236,10 @@ describe('<SettingsLMSTab />', () => {
       expect(screen.findByText(channelMapping[DEGREED_TYPE].displayName));
     });
     const degreedCard = screen.getByText(channelMapping[DEGREED_TYPE].displayName);
-    fireEvent.click(degreedCard);
+    await waitFor(() => fireEvent.click(degreedCard));
     expect(screen.queryByText('Connect Degreed')).toBeTruthy();
     const cancelButton = screen.getByText('Cancel');
-    fireEvent.click(cancelButton);
+    await waitFor(() => fireEvent.click(cancelButton));
     expect(screen.queryByText('Exit without saving')).toBeFalsy();
     expect(screen.queryByText('Connect Degreed')).toBeFalsy();
   });
@@ -250,10 +251,10 @@ describe('<SettingsLMSTab />', () => {
       expect(screen.findByText(channelMapping[CORNERSTONE_TYPE].displayName));
     });
     const cornerstoneCard = screen.getByText(channelMapping[CORNERSTONE_TYPE].displayName);
-    fireEvent.click(cornerstoneCard);
+    await waitFor(() => fireEvent.click(cornerstoneCard));
     expect(screen.queryByText('Connect Cornerstone')).toBeTruthy();
     const cancelButton = screen.getByText('Cancel');
-    fireEvent.click(cancelButton);
+    await waitFor(() => fireEvent.click(cancelButton));
     expect(screen.queryByText('Exit without saving')).toBeFalsy();
     expect(screen.queryByText('Connect Cornerstone')).toBeFalsy();
   });
@@ -265,10 +266,10 @@ describe('<SettingsLMSTab />', () => {
       expect(screen.findByText(channelMapping[CANVAS_TYPE].displayName));
     });
     const canvasCard = screen.getByText(channelMapping[CANVAS_TYPE].displayName);
-    fireEvent.click(canvasCard);
+    await waitFor(() => fireEvent.click(canvasCard));
     expect(screen.queryByText('Connect Canvas')).toBeTruthy();
     const cancelButton = screen.getByText('Cancel');
-    fireEvent.click(cancelButton);
+    await waitFor(() => fireEvent.click(cancelButton));
     expect(screen.queryByText('Exit without saving')).toBeFalsy();
     expect(screen.queryByText('Connect Canvas')).toBeFalsy();
   });
@@ -280,10 +281,10 @@ describe('<SettingsLMSTab />', () => {
       expect(screen.findByText(channelMapping[BLACKBOARD_TYPE].displayName));
     });
     const blackboardCard = screen.getByText(channelMapping[BLACKBOARD_TYPE].displayName);
-    fireEvent.click(blackboardCard);
+    await waitFor(() => fireEvent.click(blackboardCard));
     expect(screen.queryByText('Connect Blackboard')).toBeTruthy();
     const cancelButton = screen.getByText('Cancel');
-    fireEvent.click(cancelButton);
+    await waitFor(() => fireEvent.click(cancelButton));
     expect(screen.queryByText('Exit without saving')).toBeFalsy();
     expect(screen.queryByText('Connect Blackbard')).toBeFalsy();
   });
@@ -329,12 +330,12 @@ describe('<SettingsLMSTab />', () => {
     expect(history.location.pathname).toEqual('/');
     await screen.findByText('No SSO configured');
     const configureSSOButton = screen.getByText('Configure SSO');
-    fireEvent.click(configureSSOButton);
+    await waitFor(() => fireEvent.click(configureSSOButton));
     expect(history.location.pathname).toEqual(`/${enterpriseSlug}/admin/settings/sso`);
   });
   test('Expected behavior when customer has IDP configured', async () => {
     renderWithRouter(<SettingsLMSWrapper />);
-    expect(screen.queryByText('No SSO configured')).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText('No SSO configured')).not.toBeInTheDocument());
   });
   test('test button text', () => {
     expect(!buttonBool(draftConfig));

--- a/src/components/settings/SettingsLMSTab/tests/MoodleConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/MoodleConfig.test.jsx
@@ -13,12 +13,8 @@ jest.mock('../../../../data/services/LmsApiService');
 const enterpriseId = 'test-enterprise-id';
 const mockOnClick = jest.fn();
 const noConfigs = [];
-const existingConfig = [{
-  displayName: 'foobar',
-}];
-const existingConfigInvalid = [{
-  displayName: 'fooooooooobaaaaaaaaar',
-}];
+const existingConfigDisplayNames = ['name'];
+const existingConfigDisplayNamesInvalid = ['foobar'];
 const noExistingData = {};
 const existingConfigData = {
   id: 1,
@@ -95,7 +91,7 @@ describe('<MoodleConfig />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={existingConfigData}
-        existingConfigs={existingConfig}
+        existingConfigs={existingConfigDisplayNames}
       />,
     );
     fireEvent.change(screen.getByLabelText('Moodle Base URL'), {
@@ -183,7 +179,7 @@ describe('<MoodleConfig />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={invalidExistingData}
-        existingConfigs={existingConfigInvalid}
+        existingConfigs={existingConfigDisplayNamesInvalid}
       />,
     );
     expect(screen.getByText(INVALID_LINK)).toBeInTheDocument();
@@ -195,7 +191,7 @@ describe('<MoodleConfig />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={existingConfigData}
-        existingConfigs={existingConfig}
+        existingConfigs={existingConfigDisplayNames}
       />,
     );
     expect(screen.queryByText(INVALID_LINK)).not.toBeInTheDocument();

--- a/src/components/settings/SettingsLMSTab/tests/SAPConfig.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/SAPConfig.test.jsx
@@ -13,12 +13,8 @@ jest.mock('../../../../data/services/LmsApiService');
 const enterpriseId = 'test-enterprise-id';
 const mockOnClick = jest.fn();
 const noConfigs = [];
-const existingConfig = [{
-  displayName: 'foobar',
-}];
-const existingConfigInvalid = [{
-  displayName: 'fooooooooobaaaaaaaaar',
-}];
+const existingConfigDisplayNames = ['name'];
+const existingConfigDisplayNamesInvalid = ['foobar'];
 const noExistingData = {};
 const existingConfigData = {
   id: 1,
@@ -101,7 +97,7 @@ describe('<SAPConfig />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={existingConfigData}
-        existingConfigs={existingConfig}
+        existingConfigs={existingConfigDisplayNames}
       />,
     );
     fireEvent.change(screen.getByLabelText('SAP Company ID'), {
@@ -208,7 +204,7 @@ describe('<SAPConfig />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={invalidExistingData}
-        existingConfigs={existingConfigInvalid}
+        existingConfigs={existingConfigDisplayNamesInvalid}
       />,
     );
     expect(screen.getByText(INVALID_LINK)).toBeInTheDocument();
@@ -220,7 +216,7 @@ describe('<SAPConfig />', () => {
         enterpriseCustomerUuid={enterpriseId}
         onClick={mockOnClick}
         existingData={existingConfigData}
-        existingConfigs={existingConfig}
+        existingConfigs={existingConfigDisplayNames}
       />,
     );
     expect(screen.queryByText(INVALID_LINK)).not.toBeInTheDocument();

--- a/src/components/settings/SettingsLMSTab/utils.js
+++ b/src/components/settings/SettingsLMSTab/utils.js
@@ -12,7 +12,7 @@ export default function buttonBool(config) {
 
 export const isExistingConfig = (configs, value, existingInput) => {
   for (let i = 0; i < configs.length; i++) {
-    if (String(Object.values(configs[i])) === value && existingInput === value) {
+    if (configs[i] === value && existingInput === value) {
       return true;
     }
   }


### PR DESCRIPTION
- Removing automatic form submission if config has a refresh token (I don't know why this was thing in the first place)
- fixing canvas config id being used instead of uuid for auth completion urls
- requiring re-authorization if blackboard or canvas fields are changed
- fixing util function bug

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
