### PR TITLE
feat: alerts and color variants for low/no funds remaining in Learner Credit Mgmt

### DIFF
--- a/src/components/ContactCustomerSupportButton/index.jsx
+++ b/src/components/ContactCustomerSupportButton/index.jsx
@@ -13,7 +13,8 @@ const ContactCustomerSupportButton = ({
 }) => {
   const destinationUrl = configuration.ENTERPRISE_SUPPORT_URL;
 
-  // intercept click behavior, if provided, to give enough time for event to dispatch
+  // intercept click behavior, if provided, to give enough time for event
+  // to dispatch since the hyperlink is to an external URL.
   const handleClick = (e) => {
     if (!onClick) {
       return;

--- a/src/components/ContactCustomerSupportButton/index.jsx
+++ b/src/components/ContactCustomerSupportButton/index.jsx
@@ -5,25 +5,48 @@ import classNames from 'classnames';
 
 import { configuration } from '../../config';
 
-const ContactCustomerSupportButton = ({ variant, children, ...rest }) => (
-  <Hyperlink
-    {...rest}
-    target="_blank"
-    className={classNames('btn', `btn-${variant}`)}
-    destination={configuration.ENTERPRISE_SUPPORT_URL}
-  >
-    {children}
-  </Hyperlink>
-);
+const ContactCustomerSupportButton = ({
+  variant,
+  children,
+  onClick,
+  ...rest
+}) => {
+  const destinationUrl = configuration.ENTERPRISE_SUPPORT_URL;
+
+  // intercept click behavior, if provided, to give enough time for event to dispatch
+  const handleClick = (e) => {
+    if (!onClick) {
+      return;
+    }
+    e.preventDefault();
+    onClick();
+    setTimeout(() => {
+      global.location.href = destinationUrl;
+    }, 300);
+  };
+  return (
+    <Hyperlink
+      {...rest}
+      target="_blank"
+      className={classNames('btn', `btn-${variant}`)}
+      destination={destinationUrl}
+      onClick={handleClick}
+    >
+      {children}
+    </Hyperlink>
+  );
+};
 
 ContactCustomerSupportButton.propTypes = {
   children: PropTypes.node,
   variant: PropTypes.string,
+  onClick: PropTypes.func,
 };
 
 ContactCustomerSupportButton.defaultProps = {
   children: 'Contact support',
   variant: 'outline-primary',
+  onClick: undefined,
 };
 
 export default ContactCustomerSupportButton;

--- a/src/components/ContactCustomerSupportButton/index.jsx
+++ b/src/components/ContactCustomerSupportButton/index.jsx
@@ -8,31 +8,16 @@ import { configuration } from '../../config';
 const ContactCustomerSupportButton = ({
   variant,
   children,
-  onClick,
   ...rest
 }) => {
   const destinationUrl = configuration.ENTERPRISE_SUPPORT_URL;
 
-  // intercept click behavior, if `onClick` prop is provided, to give enough time for
-  // `onClick` behavior to resolve (e.g., dispatching asynchronous Segment event) since
-  // the hyperlink is for an external URL.
-  const handleClick = (e) => {
-    if (!onClick) {
-      return;
-    }
-    e.preventDefault();
-    onClick();
-    setTimeout(() => {
-      global.location.href = destinationUrl;
-    }, 300);
-  };
   return (
     <Hyperlink
       {...rest}
       target="_blank"
       className={classNames('btn', `btn-${variant}`)}
       destination={destinationUrl}
-      onClick={handleClick}
     >
       {children}
     </Hyperlink>
@@ -42,13 +27,11 @@ const ContactCustomerSupportButton = ({
 ContactCustomerSupportButton.propTypes = {
   children: PropTypes.node,
   variant: PropTypes.string,
-  onClick: PropTypes.func,
 };
 
 ContactCustomerSupportButton.defaultProps = {
   children: 'Contact support',
   variant: 'outline-primary',
-  onClick: undefined,
 };
 
 export default ContactCustomerSupportButton;

--- a/src/components/ContactCustomerSupportButton/index.jsx
+++ b/src/components/ContactCustomerSupportButton/index.jsx
@@ -13,8 +13,8 @@ const ContactCustomerSupportButton = ({
 }) => {
   const destinationUrl = configuration.ENTERPRISE_SUPPORT_URL;
 
-  // intercept click behavior, if provided, to give enough time for event
-  // to dispatch since the hyperlink is to an external URL.
+  // intercept click behavior, if `onClick` prop is provided, to give enough time for
+  // asynchronous event to dispatch since the hyperlink is to an external URL.
   const handleClick = (e) => {
     if (!onClick) {
       return;

--- a/src/components/ContactCustomerSupportButton/index.jsx
+++ b/src/components/ContactCustomerSupportButton/index.jsx
@@ -14,7 +14,8 @@ const ContactCustomerSupportButton = ({
   const destinationUrl = configuration.ENTERPRISE_SUPPORT_URL;
 
   // intercept click behavior, if `onClick` prop is provided, to give enough time for
-  // asynchronous event to dispatch since the hyperlink is to an external URL.
+  // `onClick` behavior to resolve (e.g., dispatching asynchronous Segment event) since
+  // the hyperlink is for an external URL.
   const handleClick = (e) => {
     if (!onClick) {
       return;

--- a/src/components/EnterpriseApp/index.jsx
+++ b/src/components/EnterpriseApp/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Redirect } from 'react-router-dom';
-import classNames from 'classnames';
 import { breakpoints, MediaQuery } from '@edx/paragon';
 
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
@@ -122,9 +121,6 @@ class EnterpriseApp extends React.Component {
       return <EnterpriseAppSkeleton />;
     }
 
-    const mutedBackgroundRoutePaths = ['learner-credit'];
-    const hasMutedBackground = mutedBackgroundRoutePaths.some(path => this.props.location.pathname.includes(path));
-
     return (
       <EnterpriseAppContextProvider enterpriseId={enterpriseId}>
         <div className="enterprise-app">
@@ -145,7 +141,7 @@ class EnterpriseApp extends React.Component {
                   isMobile={!matchesMediaQ}
                 />
                 <div
-                  className={classNames('content-wrapper full-page', { 'bg-light-200': hasMutedBackground })}
+                  className="content-wrapper full-page"
                   tabIndex="-1"
                   ref={this.contentWrapperRef}
                   style={{

--- a/src/components/learner-credit-management/LearnerCreditAggregateCards.jsx
+++ b/src/components/learner-credit-management/LearnerCreditAggregateCards.jsx
@@ -49,7 +49,9 @@ const LearnerCreditAggregateCards = ({
   }
 
   if (totalFunds || totalFunds === 0) {
-    const progressBarVariant = getProgressBarVariant(percentUtilized);
+    const progressBarVariant = getProgressBarVariant({
+      percentUtilized, remainingFunds,
+    });
 
     return (
       <>

--- a/src/components/learner-credit-management/LearnerCreditAggregateCards.jsx
+++ b/src/components/learner-credit-management/LearnerCreditAggregateCards.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { Col, Card, ProgressBar } from '@edx/paragon';
 import Skeleton from 'react-loading-skeleton';
 
+import { getProgressBarVariant } from './data/utils';
+
 const LoadingCards = () => (
   <>
     <Col lg={6} xl={3} className="d-flex flex-column mb-4 mb-xl-0">
@@ -47,6 +49,8 @@ const LearnerCreditAggregateCards = ({
   }
 
   if (totalFunds || totalFunds === 0) {
+    const progressBarVariant = getProgressBarVariant(percentUtilized);
+
     return (
       <>
         <Col lg={6} xl={3} className="d-flex flex-column mb-4 mb-xl-0">
@@ -54,7 +58,9 @@ const LearnerCreditAggregateCards = ({
             <Card.Section className="d-flex align-items-center">
               <div>
                 <div className="small text-uppercase mb-2.5">Percentage Utilized</div>
-                <div className="h1">{(percentUtilized * 100).toFixed(1)}%</div>
+                <div className="h1">
+                  {(percentUtilized * 100).toFixed(1)}%
+                </div>
               </div>
             </Card.Section>
           </Card>
@@ -64,7 +70,9 @@ const LearnerCreditAggregateCards = ({
             <Card.Section className="d-flex align-items-center">
               <div>
                 <div className="small text-uppercase mb-2.5">Remaining Funds</div>
-                <div className="h1">${remainingFunds.toLocaleString()}</div>
+                <div className="h1">
+                  ${remainingFunds.toLocaleString()}
+                </div>
               </div>
             </Card.Section>
           </Card>
@@ -77,7 +85,7 @@ const LearnerCreditAggregateCards = ({
                   now={percentUtilized * 100}
                   label={`$${redeemedFunds.toLocaleString()}`}
                   progressHint="Redeemed Funds"
-                  variant="success"
+                  variant={progressBarVariant}
                   threshold={100}
                   thresholdLabel={`$${totalFunds.toLocaleString()}`}
                   thresholdVariant="dark"

--- a/src/components/learner-credit-management/LearnerCreditManagement.jsx
+++ b/src/components/learner-credit-management/LearnerCreditManagement.jsx
@@ -43,7 +43,12 @@ const LearnerCreditManagement = ({ enterpriseUUID }) => {
       </Helmet>
       <Hero title="Learner Credit Management" />
       <Container className="py-4">
-        <OfferUtilizationAlerts className="mb-4.5" percentUtilized={offerSummary?.percentUtilized} />
+        <OfferUtilizationAlerts
+          className="mb-4.5"
+          percentUtilized={offerSummary?.percentUtilized}
+          remainingFunds={offerSummary?.remainingFunds}
+          enterpriseUUID={enterpriseUUID}
+        />
         <OfferNameHeading name={enterpriseOffer.displayName} />
         <div className="d-flex flex-wrap align-items-center mb-4">
           <Stack direction="horizontal" gap={3}>

--- a/src/components/learner-credit-management/LearnerCreditManagement.jsx
+++ b/src/components/learner-credit-management/LearnerCreditManagement.jsx
@@ -15,6 +15,7 @@ import LearnerCreditAggregateCards from './LearnerCreditAggregateCards';
 import OfferDates from './OfferDates';
 import OfferNameHeading from './OfferNameHeading';
 import { useOfferSummary } from './data/hooks';
+import OfferUtilizationAlerts from './OfferUtilizationAlerts';
 
 const LearnerCreditManagement = ({ enterpriseUUID }) => {
   const { offers } = useContext(EnterpriseSubsidiesContext);
@@ -42,6 +43,7 @@ const LearnerCreditManagement = ({ enterpriseUUID }) => {
       </Helmet>
       <Hero title="Learner Credit Management" />
       <Container className="py-4">
+        <OfferUtilizationAlerts className="mb-4.5" percentUtilized={offerSummary?.percentUtilized} />
         <OfferNameHeading name={enterpriseOffer.displayName} />
         <div className="d-flex flex-wrap align-items-center mb-4">
           <Stack direction="horizontal" gap={3}>

--- a/src/components/learner-credit-management/OfferUtilizationAlerts.jsx
+++ b/src/components/learner-credit-management/OfferUtilizationAlerts.jsx
@@ -36,7 +36,7 @@ const OfferUtilizationAlerts = ({
           <ContactCustomerSupportButton variant="primary" />,
         ]}
       >
-        <Alert.Heading>Remaining funds low</Alert.Heading>
+        <Alert.Heading>Low remaining funds</Alert.Heading>
         <p>
           Your learning credit is over {(LEARNER_CREDIT_UTILIZATION_THRESHOLDS.warning * 100).toFixed(1)}% utilized. To
           add additional funds and avoid downtime for your learners, reach out to customer support.

--- a/src/components/learner-credit-management/OfferUtilizationAlerts.jsx
+++ b/src/components/learner-credit-management/OfferUtilizationAlerts.jsx
@@ -32,10 +32,14 @@ const OfferUtilizationAlerts = ({
 
   const isErrorAlertShown = remainingFunds <= NO_BALANCE_REMAINING_DOLLAR_THRESHOLD;
 
+  const handleContactSupportCTAClick = (eventName) => {
+    sendEnterpriseTrackEvent(enterpriseUUID, eventName);
+  };
+
   const handleOnCloseWarningAlert = () => {
     sendEnterpriseTrackEvent(
       enterpriseUUID,
-      'edx.ui.enterprise.admin-portal.learner-credit-management.alerts.low-balance-remaining.dismissed',
+      'edx.ui.enterprise.admin-portal.learner-credit-management.alerts.low-remaining-funds.dismissed',
     );
     setIsWarningAlertShown(false);
   };
@@ -50,7 +54,12 @@ const OfferUtilizationAlerts = ({
         dismissible
         onClose={handleOnCloseWarningAlert}
         actions={[
-          <ContactCustomerSupportButton variant="primary" />,
+          <ContactCustomerSupportButton
+            variant="primary"
+            onClick={() => handleContactSupportCTAClick(
+              'edx.ui.admin-portal.learner-credit-management.alerts.low-remaining-funds.contact-support.clicked',
+            )}
+          />,
         ]}
       >
         <Alert.Heading>Low remaining funds</Alert.Heading>
@@ -65,7 +74,12 @@ const OfferUtilizationAlerts = ({
         icon={Info}
         className={className}
         actions={[
-          <ContactCustomerSupportButton variant="primary" />,
+          <ContactCustomerSupportButton
+            variant="primary"
+            onClick={() => handleContactSupportCTAClick(
+              'edx.ui.admin-portal.learner-credit-management.alerts.no-remaining-funds.contact-support.clicked',
+            )}
+          />,
         ]}
       >
         <Alert.Heading>No remaining funds</Alert.Heading>

--- a/src/components/learner-credit-management/OfferUtilizationAlerts.jsx
+++ b/src/components/learner-credit-management/OfferUtilizationAlerts.jsx
@@ -64,7 +64,7 @@ const OfferUtilizationAlerts = ({
       >
         <Alert.Heading>Low remaining funds</Alert.Heading>
         <p>
-          Your learning credit is over {(LOW_REMAINING_BALANCE_PERCENT_THRESHOLD * 100).toFixed(1)}% utilized. To
+          Your learner credit is over {(LOW_REMAINING_BALANCE_PERCENT_THRESHOLD * 100).toFixed(1)}% utilized. To
           add additional funds and avoid downtime for your learners, reach out to customer support.
         </p>
       </Alert>
@@ -84,7 +84,7 @@ const OfferUtilizationAlerts = ({
       >
         <Alert.Heading>No remaining funds</Alert.Heading>
         <p>
-          Your learning credit no longer has funds remaining. To add additional funds and
+          Your learner credit no longer has funds remaining. To add additional funds and
           avoid downtime for your learners, reach out to customer support.
         </p>
       </Alert>

--- a/src/components/learner-credit-management/OfferUtilizationAlerts.jsx
+++ b/src/components/learner-credit-management/OfferUtilizationAlerts.jsx
@@ -31,6 +31,7 @@ const OfferUtilizationAlerts = ({
   }
 
   const isErrorAlertShown = remainingFunds <= NO_BALANCE_REMAINING_DOLLAR_THRESHOLD;
+
   const handleOnCloseWarningAlert = () => {
     sendEnterpriseTrackEvent(
       enterpriseUUID,

--- a/src/components/learner-credit-management/OfferUtilizationAlerts.jsx
+++ b/src/components/learner-credit-management/OfferUtilizationAlerts.jsx
@@ -19,11 +19,11 @@ const OfferUtilizationAlerts = ({
   const [isWarningAlertShown, setIsWarningAlertShown] = useState(false);
 
   useEffect(() => {
-    const isWarningTheshold = (
+    const isWarningThesholdReached = (
       percentUtilized > LOW_REMAINING_BALANCE_PERCENT_THRESHOLD
       && remainingFunds > NO_BALANCE_REMAINING_DOLLAR_THRESHOLD
     );
-    setIsWarningAlertShown(isWarningTheshold);
+    setIsWarningAlertShown(isWarningThesholdReached);
   }, [percentUtilized, remainingFunds]);
 
   if (percentUtilized === undefined || remainingFunds === undefined) {

--- a/src/components/learner-credit-management/OfferUtilizationAlerts.jsx
+++ b/src/components/learner-credit-management/OfferUtilizationAlerts.jsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Alert } from '@edx/paragon';
+import { Info, WarningFilled } from '@edx/paragon/icons';
+
+import ContactCustomerSupportButton from '../ContactCustomerSupportButton';
+import { LEARNER_CREDIT_UTILIZATION_THRESHOLDS } from './data/constants';
+
+const OfferUtilizationAlerts = ({
+  className,
+  percentUtilized,
+}) => {
+  const [isWarningAlertShown, setIsWarningAlertShown] = useState(false);
+
+  useEffect(() => {
+    const isWarningTheshold = percentUtilized > LEARNER_CREDIT_UTILIZATION_THRESHOLDS.warning && percentUtilized < 1;
+    setIsWarningAlertShown(isWarningTheshold);
+  }, [percentUtilized]);
+
+  if (!percentUtilized) {
+    return null;
+  }
+
+  const isErrorAlertShown = percentUtilized >= 1;
+
+  return (
+    <>
+      <Alert
+        variant="warning"
+        show={isWarningAlertShown}
+        icon={WarningFilled}
+        className={className}
+        dismissible
+        onClose={() => { setIsWarningAlertShown(false); }}
+        actions={[
+          <ContactCustomerSupportButton variant="primary" />,
+        ]}
+      >
+        <Alert.Heading>Remaining funds low</Alert.Heading>
+        <p>
+          Your learning credit is over {(LEARNER_CREDIT_UTILIZATION_THRESHOLDS.warning * 100).toFixed(1)}% utilized. To
+          add additional funds and avoid downtime for your learners, reach out to customer support.
+        </p>
+      </Alert>
+      <Alert
+        variant="danger"
+        show={isErrorAlertShown}
+        icon={Info}
+        className={className}
+        actions={[
+          <ContactCustomerSupportButton variant="primary" />,
+        ]}
+      >
+        <Alert.Heading>No remaining funds</Alert.Heading>
+        <p>
+          Your learning credit no longer has funds remaining. To add additional funds and
+          avoid downtime for your learners, reach out to customer support.
+        </p>
+      </Alert>
+    </>
+  );
+};
+
+OfferUtilizationAlerts.propTypes = {
+  className: PropTypes.string,
+  percentUtilized: PropTypes.number,
+};
+
+OfferUtilizationAlerts.defaultProps = {
+  className: undefined,
+  percentUtilized: 0.0,
+};
+
+export default OfferUtilizationAlerts;

--- a/src/components/learner-credit-management/data/constants.js
+++ b/src/components/learner-credit-management/data/constants.js
@@ -5,7 +5,10 @@ export const API_FIELDS_BY_TABLE_COLUMN_ACCESSOR = {
   courseListPrice: 'course_list_price',
 };
 
-export const LEARNER_CREDIT_UTILIZATION_THRESHOLDS = {
-  warning: 0.75,
-  error: 0.9,
-};
+// Percentage where messaging (e.g., Alert) on low remaining balance will begin appearing
+export const LOW_REMAINING_BALANCE_PERCENT_THRESHOLD = 0.75;
+
+// Dollar amount remaining where messaging (e.g., Alert) on no remaining balance will begin
+// appearing, as learners may not be able to redeem learning credit once the organization's
+// balance reaches this threshold.
+export const NO_BALANCE_REMAINING_DOLLAR_THRESHOLD = 100;

--- a/src/components/learner-credit-management/data/constants.js
+++ b/src/components/learner-credit-management/data/constants.js
@@ -1,7 +1,11 @@
-// eslint-disable-next-line import/prefer-default-export
 export const API_FIELDS_BY_TABLE_COLUMN_ACCESSOR = {
   courseTitle: 'course_title',
   enrollmentDate: 'enrollment_date',
   userEmail: 'user_email',
   courseListPrice: 'course_list_price',
+};
+
+export const LEARNER_CREDIT_UTILIZATION_THRESHOLDS = {
+  warning: 0.75,
+  error: 0.9,
 };

--- a/src/components/learner-credit-management/data/constants.js
+++ b/src/components/learner-credit-management/data/constants.js
@@ -9,6 +9,6 @@ export const API_FIELDS_BY_TABLE_COLUMN_ACCESSOR = {
 export const LOW_REMAINING_BALANCE_PERCENT_THRESHOLD = 0.75;
 
 // Dollar amount remaining where messaging (e.g., Alert) on no remaining balance will begin
-// appearing, as learners may not be able to redeem learning credit once the organization's
+// appearing, as learners may not be able to redeem learner credit once the organization's
 // balance reaches this threshold.
 export const NO_BALANCE_REMAINING_DOLLAR_THRESHOLD = 100;

--- a/src/components/learner-credit-management/data/utils.js
+++ b/src/components/learner-credit-management/data/utils.js
@@ -45,6 +45,7 @@ export const transformUtilizationTableResults = results => results.map(result =>
  * Gets appropriate color variant for the annotated progress bar.
  *
  * @param {Number} percentUtilized A float (0.0 - 1.0) of percentage funds utilized for an offer.
+ * @param {Number} remainingFunds A number representing remaining funds for an offer.
  *
  * @returns Appropriate color variant for annotated progress bar.
  */

--- a/src/components/learner-credit-management/data/utils.js
+++ b/src/components/learner-credit-management/data/utils.js
@@ -1,3 +1,5 @@
+import { LEARNER_CREDIT_UTILIZATION_THRESHOLDS } from './constants';
+
 /**
  * Transforms offer summary from API for display in the UI.
  *
@@ -35,3 +37,23 @@ export const transformUtilizationTableResults = results => results.map(result =>
   courseListPrice: result.courseListPrice,
   enrollmentDate: result.enrollmentDate,
 }));
+
+/**
+ * Gets appropriate color variant for the annotated progress bar.
+ *
+ * @param {Number} percentUtilized A float (0.0 - 1.0) of percentage funds utilized for an offer.
+ *
+ * @returns Appropriate color variant for annotated progress bar.
+ */
+export const getProgressBarVariant = (percentUtilized) => {
+  let variant = 'success'; // default to green
+  if (
+    percentUtilized > LEARNER_CREDIT_UTILIZATION_THRESHOLDS.warning
+    && percentUtilized < LEARNER_CREDIT_UTILIZATION_THRESHOLDS.error
+  ) {
+    variant = 'danger'; // yellow
+  } else if (percentUtilized > LEARNER_CREDIT_UTILIZATION_THRESHOLDS.error) {
+    variant = 'error'; // red
+  }
+  return variant;
+};

--- a/src/components/learner-credit-management/data/utils.js
+++ b/src/components/learner-credit-management/data/utils.js
@@ -1,4 +1,7 @@
-import { LEARNER_CREDIT_UTILIZATION_THRESHOLDS } from './constants';
+import {
+  LOW_REMAINING_BALANCE_PERCENT_THRESHOLD,
+  NO_BALANCE_REMAINING_DOLLAR_THRESHOLD,
+} from './constants';
 
 /**
  * Transforms offer summary from API for display in the UI.
@@ -45,14 +48,14 @@ export const transformUtilizationTableResults = results => results.map(result =>
  *
  * @returns Appropriate color variant for annotated progress bar.
  */
-export const getProgressBarVariant = (percentUtilized) => {
+export const getProgressBarVariant = ({ percentUtilized, remainingFunds }) => {
   let variant = 'success'; // default to green
   if (
-    percentUtilized > LEARNER_CREDIT_UTILIZATION_THRESHOLDS.warning
-    && percentUtilized < LEARNER_CREDIT_UTILIZATION_THRESHOLDS.error
+    percentUtilized > LOW_REMAINING_BALANCE_PERCENT_THRESHOLD
+    && remainingFunds > NO_BALANCE_REMAINING_DOLLAR_THRESHOLD
   ) {
     variant = 'danger'; // yellow
-  } else if (percentUtilized > LEARNER_CREDIT_UTILIZATION_THRESHOLDS.error) {
+  } else if (remainingFunds <= NO_BALANCE_REMAINING_DOLLAR_THRESHOLD) {
     variant = 'error'; // red
   }
   return variant;

--- a/src/components/learner-credit-management/tests/OfferUtilizationAlerts.test.jsx
+++ b/src/components/learner-credit-management/tests/OfferUtilizationAlerts.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ALERT_CLOSE_LABEL_TEXT } from '@edx/paragon';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
@@ -12,10 +13,16 @@ import {
 
 const TEST_ENTERPRISE_UUID = 'test-enterprise-uuid';
 
+const OfferUtilizationAlertsWrapper = (props) => (
+  <IntlProvider locale="en">
+    <OfferUtilizationAlerts {...props} />
+  </IntlProvider>
+);
+
 describe('<OfferUtilizationAlerts />', () => {
   it('does not render any alerts if percent utilized and/or remaining funds is undefined', () => {
     const { container } = render(
-      <OfferUtilizationAlerts
+      <OfferUtilizationAlertsWrapper
         enterpriseUUID={TEST_ENTERPRISE_UUID}
       />,
     );
@@ -24,7 +31,7 @@ describe('<OfferUtilizationAlerts />', () => {
 
   it('does not render any alerts if conditions are not met', () => {
     const { container } = render(
-      <OfferUtilizationAlerts
+      <OfferUtilizationAlertsWrapper
         enterpriseUUID={TEST_ENTERPRISE_UUID}
         percentUtilized={LOW_REMAINING_BALANCE_PERCENT_THRESHOLD - 0.1}
         remainingFunds={5000}
@@ -35,7 +42,7 @@ describe('<OfferUtilizationAlerts />', () => {
 
   it('renders low balance alert', async () => {
     const { container } = render(
-      <OfferUtilizationAlerts
+      <OfferUtilizationAlertsWrapper
         enterpriseUUID={TEST_ENTERPRISE_UUID}
         percentUtilized={LOW_REMAINING_BALANCE_PERCENT_THRESHOLD + 0.1}
         remainingFunds={2500}
@@ -55,7 +62,7 @@ describe('<OfferUtilizationAlerts />', () => {
 
   it('renders no balance alert', () => {
     render(
-      <OfferUtilizationAlerts
+      <OfferUtilizationAlertsWrapper
         enterpriseUUID={TEST_ENTERPRISE_UUID}
         percentUtilized={0.99}
         remainingFunds={NO_BALANCE_REMAINING_DOLLAR_THRESHOLD}

--- a/src/components/learner-credit-management/tests/OfferUtilizationAlerts.test.jsx
+++ b/src/components/learner-credit-management/tests/OfferUtilizationAlerts.test.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { ALERT_CLOSE_LABEL_TEXT } from '@edx/paragon';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/extend-expect';
+
+import OfferUtilizationAlerts from '../OfferUtilizationAlerts';
+import {
+  LOW_REMAINING_BALANCE_PERCENT_THRESHOLD,
+  NO_BALANCE_REMAINING_DOLLAR_THRESHOLD,
+} from '../data/constants';
+
+const TEST_ENTERPRISE_UUID = 'test-enterprise-uuid';
+
+describe('<OfferUtilizationAlerts />', () => {
+  it('does not render any alerts if percent utilized and/or remaining funds is undefined', () => {
+    const { container } = render(
+      <OfferUtilizationAlerts
+        enterpriseUUID={TEST_ENTERPRISE_UUID}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not render any alerts if conditions are not met', () => {
+    const { container } = render(
+      <OfferUtilizationAlerts
+        enterpriseUUID={TEST_ENTERPRISE_UUID}
+        percentUtilized={LOW_REMAINING_BALANCE_PERCENT_THRESHOLD - 0.1}
+        remainingFunds={5000}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders low balance alert', async () => {
+    const { container } = render(
+      <OfferUtilizationAlerts
+        enterpriseUUID={TEST_ENTERPRISE_UUID}
+        percentUtilized={LOW_REMAINING_BALANCE_PERCENT_THRESHOLD + 0.1}
+        remainingFunds={2500}
+      />,
+    );
+    expect(screen.getByText('Low remaining funds')).toBeInTheDocument();
+    expect(screen.getByText('Contact support')).toBeInTheDocument();
+
+    // assert alert is dismissible
+    const dismissBtn = screen.getByText(ALERT_CLOSE_LABEL_TEXT);
+    expect(dismissBtn).toBeInTheDocument();
+    userEvent.click(dismissBtn);
+    await waitFor(() => {
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  it('renders no balance alert', () => {
+    render(
+      <OfferUtilizationAlerts
+        enterpriseUUID={TEST_ENTERPRISE_UUID}
+        percentUtilized={0.99}
+        remainingFunds={NO_BALANCE_REMAINING_DOLLAR_THRESHOLD}
+      />,
+    );
+    expect(screen.getByText('No remaining funds')).toBeInTheDocument();
+    expect(screen.getByText('Contact support')).toBeInTheDocument();
+    expect(screen.queryByText(ALERT_CLOSE_LABEL_TEXT)).not.toBeInTheDocument();
+  });
+});

--- a/src/data/services/EnterpriseDataApiService.js
+++ b/src/data/services/EnterpriseDataApiService.js
@@ -31,12 +31,11 @@ class EnterpriseDataApiService {
   }
 
   static fetchEnterpriseOfferSummary(enterpriseId, offerId, options = {}) {
-    const queryParams = new URLSearchParams({
-      ...snakeCaseObject(options),
-    });
     let url = `${EnterpriseDataApiService.enterpriseBaseUrl}${enterpriseId}/offers/${offerId}/`;
-    // append query params, if applicable
-    if (Array.from(queryParams).length) {
+    if (Object.keys(options).length) {
+      const queryParams = new URLSearchParams({
+        ...snakeCaseObject(options),
+      });
       url += `?${queryParams.toString()}`;
     }
     return EnterpriseDataApiService.apiClient().get(url);

--- a/src/data/services/EnterpriseDataApiService.js
+++ b/src/data/services/EnterpriseDataApiService.js
@@ -34,9 +34,11 @@ class EnterpriseDataApiService {
     const queryParams = new URLSearchParams({
       ...snakeCaseObject(options),
     });
-
-    const url = `${EnterpriseDataApiService.enterpriseBaseUrl}${enterpriseId}/offers/${offerId}/?${queryParams.toString()}`;
-
+    let url = `${EnterpriseDataApiService.enterpriseBaseUrl}${enterpriseId}/offers/${offerId}/`;
+    // append query params, if applicable
+    if (Array.from(queryParams).length) {
+      url += `?${queryParams.toString()}`;
+    }
     return EnterpriseDataApiService.apiClient().get(url);
   }
 


### PR DESCRIPTION
# Description

* Includes warning alert for low remaining balance (> 75% utilization AND > $100 remaining)
* Includes error alert for no remaining balance (<= $100 remaining)
* Adds color variants for annotated progress bar depending on utilization.
* Note: copy/alert behavior/etc. is subject to change pending review with UX.
* TODO: 
  * [x] Segment instrumentation on `Alerts`
  * [x] Tests

<img width="1511" alt="image" src="https://user-images.githubusercontent.com/2828721/175990257-2093f1be-4631-4fea-bf47-8fef3658b387.png">

<img width="1493" alt="image" src="https://user-images.githubusercontent.com/2828721/176195253-1bc96410-9139-4c70-b7af-bd1924e1ca51.png">

<img width="1508" alt="image" src="https://user-images.githubusercontent.com/2828721/176195593-44a2ee4e-afbe-4818-9368-1d889585e7dc.png">

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
