### PR TITLE
fix: no longer multiply `percentUtilized` by 100 since API already returns this value.

### DIFF
--- a/src/components/learner-credit-management/LearnerCreditAggregateCards.jsx
+++ b/src/components/learner-credit-management/LearnerCreditAggregateCards.jsx
@@ -54,7 +54,7 @@ const LearnerCreditAggregateCards = ({
             <Card.Section className="d-flex align-items-center">
               <div>
                 <div className="small text-uppercase mb-2.5">Percentage Utilized</div>
-                <div className="h1">{(percentUtilized * 100).toFixed(1)}%</div>
+                <div className="h1">{percentUtilized.toFixed(1)}%</div>
               </div>
             </Card.Section>
           </Card>
@@ -74,7 +74,7 @@ const LearnerCreditAggregateCards = ({
             <Card.Section className="d-flex align-items-center justify-content-center">
               <div style={{ width: '90%' }}>
                 <ProgressBar.Annotated
-                  now={percentUtilized * 100}
+                  now={percentUtilized}
                   label={`$${redeemedFunds.toLocaleString()}`}
                   progressHint="Redeemed Funds"
                   variant="success"

--- a/src/components/learner-credit-management/data/tests/hooks.test.js
+++ b/src/components/learner-credit-management/data/tests/hooks.test.js
@@ -71,7 +71,7 @@ describe('useOfferSummary', () => {
       totalFunds: 5000,
       redeemedFunds: 200,
       remainingFunds: 4800,
-      percentUtilized: 0.04,
+      percentUtilized: 4,
     };
     expect(result.current).toEqual({
       offerSummary: expectedResult,

--- a/src/components/learner-credit-management/data/tests/hooks.test.js
+++ b/src/components/learner-credit-management/data/tests/hooks.test.js
@@ -32,7 +32,7 @@ const mockEnterpriseOffer = {
 const mockOfferEnrollments = [{
   user_email: 'edx@example.com',
   course_title: 'Test Course Title',
-  course_list_price: '100.00',
+  course_list_price: 100.0,
   enrollment_date: '2022-01-01',
 }];
 

--- a/src/components/learner-credit-management/data/tests/hooks.test.js
+++ b/src/components/learner-credit-management/data/tests/hooks.test.js
@@ -21,10 +21,10 @@ const mockOfferSummary = {
   offer_id: TEST_ENTERPRISE_OFFER_ID,
   status: 'Open',
   enterprise_customer_uuid: TEST_ENTERPRISE_UUID,
-  amount_of_offer_spent: '200.00',
-  max_discount: '5000.00',
-  percent_of_offer_spent: '0.04',
-  remaining_balance: '4800.00',
+  amount_of_offer_spent: 200.0,
+  max_discount: 5000.0,
+  percent_of_offer_spent: 4,
+  remaining_balance: 4800.0,
 };
 const mockEnterpriseOffer = {
   id: TEST_ENTERPRISE_OFFER_ID,

--- a/src/components/learner-credit-management/tests/LearnerCreditAggregateCards.test.jsx
+++ b/src/components/learner-credit-management/tests/LearnerCreditAggregateCards.test.jsx
@@ -18,14 +18,14 @@ describe('<LearnerCreditAggregateCards />', () => {
   it('renders with non-zero total funds', () => {
     const props = {
       totalFunds: 5000,
-      percentUtilized: 0.04,
+      percentUtilized: 4,
       remainingFunds: 4800,
       redeemedFunds: 200,
     };
     render(<LearnerCreditAggregateCards {...props} />);
 
     expect(screen.getByText('Percentage Utilized'));
-    expect(screen.getByText(`${(props.percentUtilized * 100).toFixed(1)}%`, {
+    expect(screen.getByText(`${(props.percentUtilized).toFixed(1)}%`, {
       exact: false,
     }));
 

--- a/src/components/learner-credit-management/tests/LearnerCreditManagement.test.jsx
+++ b/src/components/learner-credit-management/tests/LearnerCreditManagement.test.jsx
@@ -84,7 +84,7 @@ const mockOfferSummary = {
   totalFunds: 5000,
   redeemedFunds: 200,
   remainingFunds: 4800,
-  percentUtilized: 0.04,
+  percentUtilized: 4,
 };
 
 const LearnerCreditManagementWrapper = ({

--- a/src/components/learner-credit-management/tests/LearnerCreditManagement.test.jsx
+++ b/src/components/learner-credit-management/tests/LearnerCreditManagement.test.jsx
@@ -138,7 +138,7 @@ describe('<LearnerCreditManagement />', () => {
       expect(screen.getByTestId('learner-credit-aggregate-cards--total-funds')).toHaveTextContent('5000');
       expect(screen.getByTestId('learner-credit-aggregate-cards--redeemed-funds')).toHaveTextContent('200');
       expect(screen.getByTestId('learner-credit-aggregate-cards--remaining-funds')).toHaveTextContent('4800');
-      expect(screen.getByTestId('learner-credit-aggregate-cards--percent-utilized')).toHaveTextContent('0.04');
+      expect(screen.getByTestId('learner-credit-aggregate-cards--percent-utilized')).toHaveTextContent('4');
     });
 
     describe('status badge', () => {


### PR DESCRIPTION
# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
