### PR TITLE
chore: current config status during auth

### DIFF
--- a/src/components/settings/SettingsLMSTab/LMSConfigPage.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigPage.jsx
@@ -27,6 +27,7 @@ const LMSConfigPage = ({
   enterpriseCustomerUuid,
   existingConfigFormData,
   existingConfigs,
+  setExistingConfigFormData,
 }) => (
   <span>
     <h3 className="mt-4.5 mb-3.5">
@@ -39,6 +40,7 @@ const LMSConfigPage = ({
         onClick={onClick}
         existingData={existingConfigFormData}
         existingConfigs={existingConfigs}
+        setExistingConfigFormData={setExistingConfigFormData}
       />
     )}
     {LMSType === CANVAS_TYPE && (
@@ -47,6 +49,7 @@ const LMSConfigPage = ({
         onClick={onClick}
         existingData={existingConfigFormData}
         existingConfigs={existingConfigs}
+        setExistingConfigFormData={setExistingConfigFormData}
       />
     )}
     {LMSType === CORNERSTONE_TYPE && (
@@ -106,6 +109,7 @@ LMSConfigPage.propTypes = {
   onClick: PropTypes.func.isRequired,
   existingConfigFormData: PropTypes.shape({}).isRequired,
   existingConfigs: PropTypes.arrayOf(PropTypes.string),
+  setExistingConfigFormData: PropTypes.func.isRequired,
 };
 
 export default connect(mapStateToProps)(LMSConfigPage);

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/BlackboardConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/BlackboardConfig.jsx
@@ -20,7 +20,7 @@ import {
 } from '../../data/constants';
 
 const BlackboardConfig = ({
-  enterpriseCustomerUuid, onClick, existingData, existingConfigs,
+  enterpriseCustomerUuid, onClick, existingData, existingConfigs, setExistingConfigFormData,
 }) => {
   const [displayName, setDisplayName] = React.useState('');
   const [nameValid, setNameValid] = React.useState(true);
@@ -91,6 +91,17 @@ const BlackboardConfig = ({
     }
   };
 
+  const formatConfigResponseData = (responseData) => {
+    const formattedConfig = {};
+    formattedConfig.blackboardBaseUrl = responseData.blackboard_base_url;
+    formattedConfig.displayName = responseData.display_name;
+    formattedConfig.id = responseData.id;
+    formattedConfig.active = responseData.active;
+    formattedConfig.clientId = responseData.client_id;
+    formattedConfig.uuid = responseData.uuid;
+    return formattedConfig;
+  };
+
   const handleAuthorization = async (event) => {
     event.preventDefault();
     const transformedConfig = snakeCaseDict(config);
@@ -107,6 +118,7 @@ const BlackboardConfig = ({
         const response = await LmsApiService.updateBlackboardConfig(transformedConfig, existingData.id);
         configUuid = response.data.uuid;
         fetchedConfigId = response.data.id;
+        setExistingConfigFormData(formatConfigResponseData(response.data));
       } catch (error) {
         err = handleErrors(error);
       }
@@ -116,6 +128,7 @@ const BlackboardConfig = ({
         const response = await LmsApiService.postNewBlackboardConfig(transformedConfig);
         configUuid = response.data.uuid;
         fetchedConfigId = response.data.id;
+        setExistingConfigFormData(formatConfigResponseData(response.data));
       } catch (error) {
         err = handleErrors(error);
       }
@@ -134,7 +147,7 @@ const BlackboardConfig = ({
       if (!appKey) {
         try {
           const response = await LmsApiService.fetchBlackboardGlobalConfig();
-          appKey = response.data.results[0].app_key;
+          appKey = response.data.results[response.data.results.length - 1].app_key;
         } catch (error) {
           err = handleErrors(error);
         }
@@ -279,14 +292,6 @@ const BlackboardConfig = ({
               Authorize
             </Button>
           )}
-          {authorized && (
-            <Button
-              onClick={handleSubmit}
-              disabled={!buttonBool(config) || !urlValid || !nameValid}
-            >
-              Submit
-            </Button>
-          )}
         </span>
       </Form>
     </span>
@@ -307,5 +312,6 @@ BlackboardConfig.propTypes = {
     uuid: PropTypes.string,
   }).isRequired,
   existingConfigs: PropTypes.arrayOf(PropTypes.string).isRequired,
+  setExistingConfigFormData: PropTypes.func.isRequired,
 };
 export default BlackboardConfig;

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/CanvasConfig.jsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/CanvasConfig.jsx
@@ -21,7 +21,7 @@ import {
 } from '../../data/constants';
 
 const CanvasConfig = ({
-  enterpriseCustomerUuid, onClick, existingData, existingConfigs,
+  enterpriseCustomerUuid, onClick, existingData, existingConfigs, setExistingConfigFormData,
 }) => {
   const [displayName, setDisplayName] = React.useState('');
   const [nameValid, setNameValid] = React.useState(true);
@@ -98,6 +98,19 @@ const CanvasConfig = ({
     }
   };
 
+  const formatConfigResponseData = (responseData) => {
+    const formattedConfig = {};
+    formattedConfig.canvasAccountId = responseData.canvas_account_id;
+    formattedConfig.canvasBaseUrl = responseData.canvas_base_url;
+    formattedConfig.displayName = responseData.display_name;
+    formattedConfig.clientId = responseData.client_id;
+    formattedConfig.clientSecret = responseData.client_secret;
+    formattedConfig.id = responseData.id;
+    formattedConfig.active = responseData.active;
+    formattedConfig.uuid = responseData.uuid;
+    return formattedConfig;
+  };
+
   const handleAuthorization = async (event) => {
     event.preventDefault();
     const transformedConfig = snakeCaseDict(config);
@@ -114,6 +127,7 @@ const CanvasConfig = ({
         const response = await LmsApiService.updateCanvasConfig(transformedConfig, existingData.id);
         fetchedConfigUuid = response.data.uuid;
         fetchedConfigId = response.data.id;
+        setExistingConfigFormData(formatConfigResponseData(response.data));
       } catch (error) {
         err = handleErrors(error);
       }
@@ -124,6 +138,7 @@ const CanvasConfig = ({
         const response = await LmsApiService.postNewCanvasConfig(transformedConfig);
         fetchedConfigUuid = response.data.uuid;
         fetchedConfigId = response.data.id;
+        setExistingConfigFormData(formatConfigResponseData(response.data));
       } catch (error) {
         err = handleErrors(error);
       }
@@ -306,14 +321,6 @@ const CanvasConfig = ({
               Authorize
             </Button>
           )}
-          {authorized && (
-            <Button
-              onClick={handleSubmit}
-              disabled={!buttonBool(config) || !urlValid || !nameValid}
-            >
-              Submit
-            </Button>
-          )}
         </span>
       </Form>
     </span>
@@ -335,5 +342,6 @@ CanvasConfig.propTypes = {
     uuid: PropTypes.string,
   }).isRequired,
   existingConfigs: PropTypes.arrayOf(PropTypes.string).isRequired,
+  setExistingConfigFormData: PropTypes.func.isRequired,
 };
 export default CanvasConfig;

--- a/src/components/settings/SettingsLMSTab/index.jsx
+++ b/src/components/settings/SettingsLMSTab/index.jsx
@@ -228,6 +228,7 @@ export default function SettingsLMSTab({
             onClick={onClick}
             existingConfigFormData={existingConfigFormData}
             existingConfigs={displayNames}
+            setExistingConfigFormData={setExistingConfigFormData}
           />
         </span>
       )}


### PR DESCRIPTION
Bug fix on current config data after a config is created during the authorization step. Clicking the authorization button triggers a creation of an LMS integration config on the backend. Since the page doesn't trigger a success signal until confirming the config has a refresh token, and the process of retrieving the refresh token can potentially fail, the current config data needs to be set between the time the new config is created and the page has confirmed the refresh token exists and triggers the success signal.

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
