### PR TITLE
fix: configure step bug fixes and typo fixes

### DIFF
--- a/src/components/settings/SettingsSSOTab/SSOConfigConfiguredCard.jsx
+++ b/src/components/settings/SettingsSSOTab/SSOConfigConfiguredCard.jsx
@@ -37,7 +37,7 @@ const SSOConfigConfiguredCard = ({
         aProviderConfig => (aProviderConfig.name === config.name) && (aProviderConfig.entity_id === config.entity_id),
       ).shift();
       if (theProvider) { setProviderConfig(theProvider); }
-      if (theProvider?.was_valid_at !== null) {
+      if (theProvider && theProvider.was_valid_at !== null) {
         dispatchSsoState(updateConnectInProgress(false));
         setIsSsoValid(true);
         setInfoMessage('SSO connected successfully');

--- a/src/components/settings/SettingsSSOTab/SSOStepper.jsx
+++ b/src/components/settings/SettingsSSOTab/SSOStepper.jsx
@@ -57,34 +57,33 @@ const SSOStepper = ({ enterpriseSlug, enterpriseId, enterpriseName }) => {
     const configFormData = new FormData();
     Object.keys(configValues).forEach(key => configFormData.append(key, configValues[key]));
     configFormData.append('enterprise_customer_uuid', enterpriseId);
+    configFormData.append('enabled', true);
     try {
-      const response = await LmsApiService.updateProviderConfig(configFormData, providerConfig.id);
-      if (type === 'update') {
-        setProviderConfig(response.data);
-      }
-      return null;
+      await LmsApiService.updateProviderConfig(configFormData, providerConfig.id).then((response) => {
+        if (type === 'update') {
+          setProviderConfig(response.data);
+        }
+      });
     } catch (error) {
       setConnectError(true);
       return handleErrors(error);
     }
+    return null;
   }
 
   const saveOnQuit = async () => {
-    let err;
-    if (configValues !== null) {
-      err = sendData('save');
-    }
-    if (!err) {
-      handleCancel();
-    }
+    await sendData('save').then((err) => {
+      if (!err) { handleCancel(); }
+    });
+    return null;
   };
 
   const updateConfig = async () => {
-    let err;
     if (configValues !== null) {
-      err = sendData('update');
-    }
-    if (!err) {
+      await sendData('update').then((err) => {
+        if (!err) { setCurrentStep('connect'); }
+      });
+    } else {
       setCurrentStep('connect');
     }
   };

--- a/src/components/settings/SettingsSSOTab/steps/SSOConfigIDPStep.jsx
+++ b/src/components/settings/SettingsSSOTab/steps/SSOConfigIDPStep.jsx
@@ -44,7 +44,7 @@ const SSOConfigIDPStep = ({ enterpriseId }) => {
             value={entityID || ''}
           />
           <p className="mt-0 form-text text-muted">
-            You can find the URL in your Identiity Provider portal or on your IDP website.
+            You can find the URL in your Identity Provider portal or on your IDP website.
           </p>
           { existingProviderData.length > 0 && (
             <>

--- a/src/components/settings/SettingsSSOTab/tests/NewSSOConfigForm.test.jsx
+++ b/src/components/settings/SettingsSSOTab/tests/NewSSOConfigForm.test.jsx
@@ -7,8 +7,10 @@ import NewSSOConfigForm from '../NewSSOConfigForm';
 import { SSOConfigContext, SSO_INITIAL_STATE } from '../SSOConfigContext';
 import LmsApiService from '../../../../data/services/LmsApiService';
 import { getMockStore, initialStore } from '../testutils';
+import { updateCurrentStep } from '../data/actions';
 import handleErrors from '../../utils';
 
+jest.mock('../data/actions');
 jest.mock('../../utils');
 const entryType = 'direct';
 const metadataURL = 'https://foobar.com';
@@ -106,17 +108,21 @@ describe('SAML Config Tab', () => {
         + ' to allow quick access to your organization\'s learning catalog.',
       ),
     ).toBeInTheDocument();
-    await expect(
-      screen.queryByText('I have added edX as a Service Provider in my SAML configuration'),
-    ).toBeInTheDocument();
-    userEvent.click(screen.getByText('Cancel'));
+    await waitFor(() => {
+      expect(
+        screen.queryByText('I have added edX as a Service Provider in my SAML configuration'),
+      ).toBeInTheDocument();
+    }, []);
+    await waitFor(() => {
+      userEvent.click(screen.getByText('Cancel'));
+    }, []);
     expect(mockSetProviderConfig).toHaveBeenCalledWith(null);
   });
   test('error while configure step updating config from cancel button', async () => {
     // Setup
     const mockUpdateProviderConfig = jest.spyOn(LmsApiService, 'updateProviderConfig');
     mockUpdateProviderConfig.mockImplementation(() => {
-      throw new Error({ response: { data: 'foobar' } });
+      throw new Error();
     });
     contextValue.ssoState.currentStep = 'configure';
 
@@ -132,10 +138,14 @@ describe('SAML Config Tab', () => {
       ),
     ).toBeInTheDocument();
     userEvent.type(screen.getByText('Maximum Session Length (seconds)'), '2');
-    userEvent.click(screen.getByText('Cancel'));
-    await expect(screen.queryByText('Do you want to save your work?')).toBeInTheDocument();
-    userEvent.click(screen.getByText('Save'));
-    await expect(handleErrors).toHaveBeenCalled();
+    await waitFor(() => {
+      userEvent.click(screen.getByText('Cancel'));
+    }, []);
+    expect(screen.queryByText('Do you want to save your work?')).toBeInTheDocument();
+    await waitFor(() => {
+      userEvent.click(screen.getByText('Save'));
+    }, []);
+    expect(handleErrors).toHaveBeenCalled();
     expect(screen.queryByText('Our system experienced an error.'));
   });
   test('canceling configure step without making changes', async () => {
@@ -153,9 +163,31 @@ describe('SAML Config Tab', () => {
         + ' to allow quick access to your organization\'s learning catalog.',
       ),
     ).toBeInTheDocument();
-    userEvent.click(screen.getByText('Cancel'));
+    await waitFor(() => {
+      userEvent.click(screen.getByText('Cancel'));
+    }, []);
     expect(mockUpdateProviderConfig).not.toHaveBeenCalled();
     expect(mockSetProviderConfig).toHaveBeenCalledWith(null);
+  });
+  test('update config method does not make api call if form is not updated', async () => {
+    const mockUpdateProviderConfig = jest.spyOn(LmsApiService, 'updateProviderConfig');
+    contextValue.ssoState.currentStep = 'configure';
+    render(
+      <SSOConfigContext.Provider value={contextValue}>
+        <Provider store={store}><NewSSOConfigForm enterpriseId={enterpriseId} /></Provider>
+      </SSOConfigContext.Provider>,
+    );
+    expect(
+      screen.queryByText(
+        'Connect to a SAML identity provider for single sign-on'
+        + ' to allow quick access to your organization\'s learning catalog.',
+      ),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      userEvent.click(screen.getByText('Next'));
+    }, []);
+    expect(mockUpdateProviderConfig).not.toHaveBeenCalled();
+    expect(updateCurrentStep).toHaveBeenCalledWith('connect');
   });
   test('error while configure step updating config from next button', async () => {
     // Setup
@@ -164,7 +196,6 @@ describe('SAML Config Tab', () => {
       throw new Error({ response: { data: 'foobar' } });
     });
     contextValue.ssoState.currentStep = 'configure';
-
     render(
       <SSOConfigContext.Provider value={contextValue}>
         <Provider store={store}><NewSSOConfigForm enterpriseId={enterpriseId} /></Provider>
@@ -177,8 +208,10 @@ describe('SAML Config Tab', () => {
       ),
     ).toBeInTheDocument();
     userEvent.type(screen.getByText('Maximum Session Length (seconds)'), '2');
-    userEvent.click(screen.getByText('Next'));
-    await expect(handleErrors).toHaveBeenCalled();
+    await waitFor(() => {
+      userEvent.click(screen.getByText('Next'));
+    }, []);
+    await waitFor(() => (expect(handleErrors).toHaveBeenCalled()), []);
     expect(screen.queryByText('Our system experienced an error.'));
   });
   test('canceling without saving configure form', async () => {
@@ -197,9 +230,13 @@ describe('SAML Config Tab', () => {
     ).toBeInTheDocument();
     userEvent.type(screen.getByText('Maximum Session Length (seconds)'), 'haha hehe');
     expect(screen.getByText('Next')).toBeDisabled();
-    userEvent.click(screen.getByText('Cancel'));
+    await waitFor(() => {
+      userEvent.click(screen.getByText('Cancel'));
+    }, []);
     await expect(screen.queryByText('Do you want to save your work?')).toBeInTheDocument();
-    userEvent.click(screen.getByText('Exit without saving'));
+    await waitFor(() => {
+      userEvent.click(screen.getByText('Exit without saving'));
+    }, []);
     await expect(mockUpdateProviderConfig).not.toHaveBeenCalled();
   });
   test('saving while canceling configure form updates config', async () => {
@@ -243,9 +280,13 @@ describe('SAML Config Tab', () => {
     ).toBeInTheDocument();
     userEvent.type(screen.getByText('Maximum Session Length (seconds)'), 'haha hehe');
     expect(screen.getByText('Next')).toBeDisabled();
-    userEvent.click(screen.getByText('Cancel'));
+    await waitFor(() => {
+      userEvent.click(screen.getByText('Cancel'));
+    }, []);
     await expect(screen.queryByText('Do you want to save your work?')).toBeInTheDocument();
-    userEvent.click(screen.getByText('Save'));
+    await waitFor(() => {
+      userEvent.click(screen.getByText('Save'));
+    }, []);
     await expect(mockUpdateProviderConfig).toHaveBeenCalled();
   });
   test('configure step calls set provider config after updating', async () => {
@@ -265,7 +306,9 @@ describe('SAML Config Tab', () => {
       ),
     ).toBeInTheDocument();
     userEvent.type(screen.getByText('Maximum Session Length (seconds)'), '2');
-    userEvent.click(screen.getByText('Next'));
+    await waitFor(() => {
+      userEvent.click(screen.getByText('Next'));
+    }, []);
     await expect(mockUpdateProviderConfig).toHaveBeenCalled();
   });
   test('idp completed check for url entry', async () => {


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-6050"

- methods in the SSO stepper that used the `sendData` function were not properly waiting for the function to return, causing the page to think an error had occurred / causing the current provider config state to be lost
- editing fields in the configure step causes the backend to set configs to inactive
- bug with polling the backend to check for a validated config was erroneously returning true when false
- types with the IDP step

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
