### PR TITLE
feat: adding SAP IDP support to self service settings

### DIFF
--- a/src/components/settings/SettingsSSOTab/SSOStepper.jsx
+++ b/src/components/settings/SettingsSSOTab/SSOStepper.jsx
@@ -36,6 +36,7 @@ const SSOStepper = ({ enterpriseSlug, enterpriseId, enterpriseName }) => {
   const [showValidatedText, setShowValidatedText] = useState(false);
   const [idpNextButtonDisabled, setIdpNextButtonDisabled] = useState(false);
   const [configNextButtonDisabled, setConfigNextButtonDisabled] = useState(false);
+  const [isUsingSap, setIsUsingSap] = React.useState(false);
 
   const {
     metadataURL,
@@ -55,9 +56,32 @@ const SSOStepper = ({ enterpriseSlug, enterpriseId, enterpriseName }) => {
 
   async function sendData(type) {
     const configFormData = new FormData();
-    Object.keys(configValues).forEach(key => configFormData.append(key, configValues[key]));
+    const newConfigValues = { ...configValues };
     configFormData.append('enterprise_customer_uuid', enterpriseId);
     configFormData.append('enabled', true);
+    Object.keys(configValues).forEach(key => configFormData.append(key, configValues[key]));
+    // Depending on whether the user is using SAP or not as an identity provider, we need to update
+    // both the update payload, as well as the config values.
+    if (isUsingSap) {
+      configFormData.append('identity_provider_type', 'sap_success_factors');
+      configFormData.set('max_session_length', '');
+      delete newConfigValues.max_session_length;
+      configFormData.set('attr_user_permanent_id', '');
+      delete newConfigValues.attr_user_permanent_id;
+      configFormData.set('attr_full_name', '');
+      delete newConfigValues.attr_full_name;
+      configFormData.set('attr_first_name', '');
+      delete newConfigValues.attr_first_name;
+      configFormData.set('attr_last_name', '');
+      delete newConfigValues.attr_last_name;
+      configFormData.set('attr_email', '');
+      delete newConfigValues.attr_email;
+    } else {
+      configFormData.append('identity_provider_type', 'standard_saml_provider');
+      configFormData.set('other_settings', '');
+      delete newConfigValues.other_settings;
+    }
+    setConfigValues(newConfigValues);
     try {
       await LmsApiService.updateProviderConfig(configFormData, providerConfig.id).then((response) => {
         if (type === 'update') {
@@ -117,6 +141,8 @@ const SSOStepper = ({ enterpriseSlug, enterpriseId, enterpriseName }) => {
               setRefreshBool={setRefreshBool}
               setFormUpdated={setFormUpdated}
               setConfigNextButtonDisabled={setConfigNextButtonDisabled}
+              isUsingSap={isUsingSap}
+              setIsUsingSap={setIsUsingSap}
             />
           </Stepper.Step>
 
@@ -188,7 +214,10 @@ const SSOStepper = ({ enterpriseSlug, enterpriseId, enterpriseName }) => {
               Cancel
             </Button>
             <Stepper.ActionRow.Spacer />
-            <Button disabled={configNextButtonDisabled} onClick={() => updateConfig()}>Next<ArrowForward className="ml-2" /></Button>
+            <Button disabled={configNextButtonDisabled} onClick={() => updateConfig()}>
+              Next
+              <ArrowForward className="ml-2" />
+            </Button>
           </Stepper.ActionRow>
           <Stepper.ActionRow eventKey="connect">
             <Button variant="outline-primary" onClick={() => setCurrentStep('configure')}>

--- a/src/components/settings/SettingsSSOTab/steps/SSOConfigConfigureStep.jsx
+++ b/src/components/settings/SettingsSSOTab/steps/SSOConfigConfigureStep.jsx
@@ -1,11 +1,20 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   Alert, Button, Form, Hyperlink, ModalDialog,
 } from '@edx/paragon';
 import { Info } from '@edx/paragon/icons';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { HELP_CENTER_SAML_LINK, INVALID_LENGTH, INVALID_NAME } from '../../data/constants';
+import isURL from 'validator/lib/isURL';
+import {
+  HELP_CENTER_SAML_LINK,
+  INVALID_LENGTH,
+  INVALID_NAME,
+  INVALID_API_ROOT_URL,
+  INVALID_SAPSF_OAUTH_ROOT_URL,
+  HELP_CENTER_SAP_IDP_LINK,
+  INVALID_ODATA_API_TIMEOUT_INTERVAL,
+} from '../../data/constants';
 
 const SSOConfigConfigureStep = ({
   setConfigValues,
@@ -19,15 +28,66 @@ const SSOConfigConfigureStep = ({
   refreshBool,
   setFormUpdated,
   setConfigNextButtonDisabled,
+  isUsingSap,
+  setIsUsingSap,
 }) => {
   const [nameValid, setNameValid] = React.useState(true);
+  const [odataApiRootUrlValid, setOdataApiRootUrlValid] = React.useState(true);
+  const [sapsfOauthRootUrlValid, setSapsfOauthRootUrlValid] = React.useState(true);
+  const [odataApiTimeoutIntervalValid, setODataApiTimeoutIntervalValid] = React.useState(true);
   const [lengthValid, setLengthValid] = React.useState(true);
+  const [currentOtherSettings, setCurrentOtherSettings] = React.useState({});
+
+  // Setting current other settings object from the existing config data object
+  useEffect(() => {
+    if (existingConfigData.identity_provider_type === 'sap_success_factors') { setIsUsingSap(true); }
+    if (existingConfigData.other_settings) {
+      const existingOtherSettings = JSON.parse(existingConfigData.other_settings);
+      const newOtherSettings = { ...currentOtherSettings, ...existingOtherSettings };
+      setCurrentOtherSettings(newOtherSettings);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [existingConfigData, setCurrentOtherSettings]);
+
+  // Disabling/enabling the next button based on the "using SAP" check box value and required fields
+  useEffect(() => {
+    if (isUsingSap) {
+      // If the user is using SAP we need all 7 additional SAP attributes
+      if (Object.keys(currentOtherSettings).length === 7) {
+        let buttonDisabled = false;
+        Object.keys(currentOtherSettings).forEach(key => {
+          // Sometimes the key will exist and the value will be empty
+          if (currentOtherSettings[key].length === 0) { buttonDisabled = true; }
+        });
+        setConfigNextButtonDisabled(buttonDisabled);
+      } else {
+        setConfigNextButtonDisabled(true);
+      }
+    } else {
+      setConfigNextButtonDisabled(false);
+    }
+  }, [isUsingSap, currentOtherSettings, setConfigNextButtonDisabled]);
 
   const addConfigVal = (key, value) => {
     setConfigValues((configValues) => ({
       ...configValues,
       [key]: value,
     }));
+  };
+
+  // "Using SAP" checkbox event onChange function
+  const handleChange = (event) => {
+    setIsUsingSap(event.target.checked);
+  };
+
+  // "Using SAP" checkbox onClick function
+  const updateAdvanceSettings = (advancedKey, advancedValue) => {
+    setFormUpdated(true);
+    const newAdvSetting = {};
+    newAdvSetting[advancedKey] = advancedValue;
+    const advSettings = { ...currentOtherSettings, ...newAdvSetting };
+    addConfigVal('other_settings', JSON.stringify(advSettings));
+    setCurrentOtherSettings(advSettings);
   };
 
   const validateField = (field, input) => {
@@ -43,6 +103,24 @@ const SSOConfigConfigureStep = ({
         inputValid = (input?.length <= 20);
         addConfigVal('display_name', input);
         setNameValid(inputValid);
+        setConfigNextButtonDisabled(!inputValid);
+        break;
+      case 'odata_api_root_url':
+        inputValid = (isURL(input));
+        updateAdvanceSettings('odata_api_root_url', input);
+        setOdataApiRootUrlValid(inputValid);
+        setConfigNextButtonDisabled(!inputValid);
+        break;
+      case 'sapsf_oauth_root_url':
+        inputValid = (isURL(input));
+        updateAdvanceSettings('sapsf_oauth_root_url', input);
+        setSapsfOauthRootUrlValid(inputValid);
+        setConfigNextButtonDisabled(!inputValid);
+        break;
+      case 'odata_api_timeout_interval':
+        inputValid = (!Number.isNaN(Number(input)) && Number(input) <= 30);
+        updateAdvanceSettings('odata_api_timeout_interval', input);
+        setODataApiTimeoutIntervalValid(inputValid);
         setConfigNextButtonDisabled(!inputValid);
         break;
       default:
@@ -68,10 +146,15 @@ const SSOConfigConfigureStep = ({
     <>
       <p>
         If necessary, enter any customized or unique SAML attributes as needed.
-        If no custom action is required, we will use{' '}
+        <strong> If no custom action is required, we will use</strong>{' '}
         <Hyperlink destination={HELP_CENTER_SAML_LINK} target="_blank">
-          these default attributes
+          these default attributes.
         </Hyperlink>{' '}
+      </p>
+      <p>
+        <strong>Please note</strong> that if you are using SAP Success Factors as an identity provider
+        <strong>you must check the box</strong> at the top of the form and fill out the appropriate
+        custom SAP attributes.
       </p>
       <ModalDialog
         onClose={closeExitModal}
@@ -135,121 +218,284 @@ const SSOConfigConfigureStep = ({
         </Alert>
       )}
       <div className="py-4">
-        <Form.Group>
-          <Form.Control
-            type="text"
-            isInvalid={!nameValid}
-            onChange={(e) => {
-              validateField('name', e.target.value);
-            }}
-            floatingLabel="SSO Configuration Name"
-            defaultValue={(connectError ? errorData.displayName : existingConfigData?.display_name)}
-          />
-          <Form.Text>Create a name for your configuration for easy navigation. Leave blank for default.</Form.Text>
-          {!nameValid && (
-            <Form.Control.Feedback type="invalid">
-              {INVALID_NAME}
-            </Form.Control.Feedback>
-          )}
-        </Form.Group>
-        <Form.Group>
-          <Form.Control
-            type="text"
-            isInvalid={!lengthValid}
-            onChange={(e) => {
-              validateField('seconds', e.target.value);
-            }}
-            floatingLabel="Maximum Session Length (seconds)"
-            defaultValue={(connectError ? errorData.maxSessionLength : existingConfigData?.max_session_length)}
-          />
-          <Form.Text>
-            Setting this option will limit user&apos;s session length to the set value.
-            If set to 0 (zero), the session will expire upon the user closing their browser.
-            If left blank, the Django platform session default length will be used.
-          </Form.Text>
-          {!lengthValid && (
-            <Form.Control.Feedback type="invalid">
-              {INVALID_LENGTH}
-            </Form.Control.Feedback>
-          )}
+        <Form.Group className="mb-5">
+          <Form.Checkbox checked={isUsingSap} onChange={handleChange}>
+            I am using SAP Success Factors as an Identity Provider
+          </Form.Checkbox>
         </Form.Group>
 
-        <Form.Group>
-          <Form.Control
-            type="text"
-            onChange={(e) => {
-              addConfigVal('attr_user_permanent_id', e.target.value);
-              setFormUpdated(true);
-            }}
-            maxLength={128}
-            floatingLabel="User ID Attribute"
-            defaultValue={(connectError ? errorData.userId : existingConfigData?.attr_user_permanent_id)}
-          />
-          <Form.Text>
-            URN of the SAML attribute that we can use as a unique, persistent user ID. Leave blank for default.
-          </Form.Text>
-        </Form.Group>
-        <Form.Group>
-          <Form.Control
-            type="text"
-            onChange={(e) => {
-              addConfigVal('attr_full_name', e.target.value);
-              setFormUpdated(true);
-            }}
-            maxLength={255}
-            floatingLabel="Full Name Attribute"
-            defaultValue={(connectError ? errorData.fullName : existingConfigData?.attr_full_name)}
-          />
-          <Form.Text>
-            URN of SAML attribute containing the user&apos;s full name. Leave blank for default.
-          </Form.Text>
-        </Form.Group>
-        <Form.Group>
-          <Form.Control
-            type="text"
-            onChange={(e) => {
-              addConfigVal('attr_first_name', e.target.value);
-              setFormUpdated(true);
-            }}
-            maxLength={128}
-            floatingLabel="First Name Attribute"
-            defaultValue={(connectError ? errorData.firstName : existingConfigData?.attr_first_name)}
-          />
-          <Form.Text>
-            URN of SAML attribute containing the user&apos;s first name. Leave blank for default.
-          </Form.Text>
-        </Form.Group>
-        <Form.Group>
-          <Form.Control
-            type="text"
-            onChange={(e) => {
-              addConfigVal('attr_last_name', e.target.value);
-              setFormUpdated(true);
-            }}
-            maxLength={128}
-            floatingLabel="Last Name Attribute"
-            defaultValue={(connectError ? errorData.lastName : existingConfigData?.attr_last_name)}
-          />
-          <Form.Text>
-            URN of SAML attribute containing the user&apos;s last name. Leave blank for default.
-          </Form.Text>
-        </Form.Group>
+        {!isUsingSap && (
+        <>
+          <Form.Group>
+            <Form.Control
+              type="text"
+              isInvalid={!nameValid}
+              onChange={(e) => {
+                validateField('name', e.target.value);
+              }}
+              floatingLabel="SSO Configuration Name"
+              defaultValue={(connectError ? errorData.displayName : existingConfigData?.display_name)}
+            />
+            <Form.Text>Create a name for your configuration for easy navigation. Leave blank for default.</Form.Text>
+            {!nameValid && (
+              <Form.Control.Feedback type="invalid">
+                {INVALID_NAME}
+              </Form.Control.Feedback>
+            )}
+          </Form.Group>
+          <Form.Group>
+            <Form.Control
+              type="text"
+              isInvalid={!lengthValid}
+              onChange={(e) => {
+                validateField('seconds', e.target.value);
+              }}
+              floatingLabel="Maximum Session Length (seconds)"
+              defaultValue={(connectError ? errorData.maxSessionLength : existingConfigData?.max_session_length)}
+            />
+            <Form.Text>
+              Setting this option will limit user&apos;s session length to the set value.
+              If set to 0 (zero), the session will expire upon the user closing their browser.
+              If left blank, the Django platform session default length will be used.
+            </Form.Text>
+            {!lengthValid && (
+              <Form.Control.Feedback type="invalid">
+                {INVALID_LENGTH}
+              </Form.Control.Feedback>
+            )}
+          </Form.Group>
 
-        <Form.Group>
-          <Form.Control
-            type="text"
-            onChange={(e) => {
-              addConfigVal('attr_email', e.target.value);
-              setFormUpdated(true);
-            }}
-            maxLength={128}
-            floatingLabel="Email Address Attribute"
-            defaultValue={(connectError ? errorData.emailAddress : existingConfigData?.attr_email)}
-          />
-          <Form.Text>
-            URN of SAML attribute containing the user&apos;s email address[es]. Leave blank for default.
-          </Form.Text>
-        </Form.Group>
+          <Form.Group>
+            <Form.Control
+              type="text"
+              onChange={(e) => {
+                addConfigVal('attr_user_permanent_id', e.target.value);
+                setFormUpdated(true);
+              }}
+              maxLength={128}
+              floatingLabel="User ID Attribute"
+              defaultValue={(connectError ? errorData.userId : existingConfigData?.attr_user_permanent_id)}
+            />
+            <Form.Text>
+              URN of the SAML attribute that we can use as a unique, persistent user ID. Leave blank for default.
+            </Form.Text>
+          </Form.Group>
+
+          <Form.Group>
+            <Form.Control
+              type="text"
+              onChange={(e) => {
+                addConfigVal('attr_full_name', e.target.value);
+                setFormUpdated(true);
+              }}
+              maxLength={255}
+              floatingLabel="Full Name Attribute"
+              defaultValue={(connectError ? errorData.fullName : existingConfigData?.attr_full_name)}
+            />
+            <Form.Text>
+              URN of SAML attribute containing the user&apos;s full name. Leave blank for default.
+            </Form.Text>
+          </Form.Group>
+
+          <Form.Group>
+            <Form.Control
+              type="text"
+              onChange={(e) => {
+                addConfigVal('attr_first_name', e.target.value);
+                setFormUpdated(true);
+              }}
+              maxLength={128}
+              floatingLabel="First Name Attribute"
+              defaultValue={(connectError ? errorData.firstName : existingConfigData?.attr_first_name)}
+            />
+            <Form.Text>
+              URN of SAML attribute containing the user&apos;s first name. Leave blank for default.
+            </Form.Text>
+          </Form.Group>
+
+          <Form.Group>
+            <Form.Control
+              type="text"
+              onChange={(e) => {
+                addConfigVal('attr_last_name', e.target.value);
+                setFormUpdated(true);
+              }}
+              maxLength={128}
+              floatingLabel="Last Name Attribute"
+              defaultValue={(connectError ? errorData.lastName : existingConfigData?.attr_last_name)}
+            />
+            <Form.Text>
+              URN of SAML attribute containing the user&apos;s last name. Leave blank for default.
+            </Form.Text>
+          </Form.Group>
+
+          <Form.Group>
+            <Form.Control
+              type="text"
+              onChange={(e) => {
+                addConfigVal('attr_email', e.target.value);
+                setFormUpdated(true);
+              }}
+              maxLength={128}
+              floatingLabel="Email Address Attribute"
+              defaultValue={(connectError ? errorData.emailAddress : existingConfigData?.attr_email)}
+            />
+            <Form.Text>
+              URN of SAML attribute containing the user&apos;s email address[es]. Leave blank for default.
+            </Form.Text>
+          </Form.Group>
+        </>
+        )}
+        {isUsingSap && (
+        <>
+          <p className="mb-5 mt-n4">
+            Find examples of these values in our {' '}
+            <Hyperlink destination={HELP_CENTER_SAP_IDP_LINK} target="_blank">
+              SAP Help Center Article.
+            </Hyperlink>
+          </p>
+          <Form.Group>
+            <Form.Control
+              type="text"
+              isInvalid={!nameValid}
+              onChange={(e) => {
+                validateField('name', e.target.value);
+              }}
+              floatingLabel="SSO Configuration Name"
+              defaultValue={(connectError ? errorData.displayName : existingConfigData?.display_name)}
+            />
+            <Form.Text>Create a name for your configuration for easy navigation. Leave blank for default.</Form.Text>
+            {!nameValid && (
+              <Form.Control.Feedback type="invalid">
+                {INVALID_NAME}
+              </Form.Control.Feedback>
+            )}
+          </Form.Group>
+
+          <Form.Group>
+            <Form.Control
+              type="text"
+              onChange={(e) => {
+                validateField('odata_api_root_url', e.target.value);
+              }}
+              floatingLabel="OData API Root URL"
+              defaultValue={
+                existingConfigData.other_settings ? JSON.parse(existingConfigData.other_settings).odata_api_root_url : ''
+              }
+            />
+            <Form.Text>The BizX OData API service hostname, typically aligned with the IdP entity id.</Form.Text>
+            {!odataApiRootUrlValid && (
+              <Form.Control.Feedback type="invalid">
+                {INVALID_API_ROOT_URL}
+              </Form.Control.Feedback>
+            )}
+          </Form.Group>
+
+          <Form.Group>
+            <Form.Control
+              type="text"
+              onChange={(e) => {
+                updateAdvanceSettings('odata_company_id', e.target.value);
+              }}
+              floatingLabel="OData Company ID"
+              defaultValue={
+                existingConfigData.other_settings ? JSON.parse(existingConfigData.other_settings).odata_company_id : ''
+              }
+            />
+            <Form.Text>The BizX company profile identifier for your tenant.</Form.Text>
+          </Form.Group>
+
+          <Form.Group>
+            <Form.Control
+              type="text"
+              onChange={(e) => {
+                updateAdvanceSettings('odata_client_id', e.target.value);
+              }}
+              floatingLabel="OData Client ID"
+              defaultValue={
+                existingConfigData.other_settings ? JSON.parse(existingConfigData.other_settings).odata_client_id : ''
+              }
+            />
+            <Form.Text>The API Key value found in the OAuth2 Client Application profile.</Form.Text>
+          </Form.Group>
+
+          <Form.Group>
+            <Form.Control
+              type="text"
+              onChange={(e) => {
+                validateField('odata_api_timeout_interval', e.target.value);
+              }}
+              floatingLabel="OData API Timeout Interval"
+              defaultValue={
+                existingConfigData.other_settings ? JSON.parse(existingConfigData.other_settings).odata_api_timeout_interval : ''
+              }
+            />
+            <Form.Text>
+              Configurable value that represents the amount of time in seconds, no greater than 30, that the
+              edX system will wait for a response before cancelling the request.
+            </Form.Text>
+            {!odataApiTimeoutIntervalValid && (
+              <Form.Control.Feedback type="invalid">
+                {INVALID_ODATA_API_TIMEOUT_INTERVAL}
+              </Form.Control.Feedback>
+            )}
+          </Form.Group>
+
+          <Form.Group>
+            <Form.Control
+              type="text"
+              onChange={(e) => {
+                validateField('sapsf_oauth_root_url', e.target.value);
+              }}
+              floatingLabel="SAP SuccessFactors OAuth Root URL"
+              defaultValue={
+                existingConfigData.other_settings ? JSON.parse(existingConfigData.other_settings).sapsf_oauth_root_url : ''
+              }
+            />
+            <Form.Text>
+              The URL hostname is what you see upon initial login to the SuccessFactors BizX system,
+              typically aligned with the IdP Entity ID.
+            </Form.Text>
+            {!sapsfOauthRootUrlValid && (
+              <Form.Control.Feedback type="invalid">
+                {INVALID_SAPSF_OAUTH_ROOT_URL}
+              </Form.Control.Feedback>
+            )}
+          </Form.Group>
+
+          <Form.Group>
+            <Form.Control
+              type="text"
+              onChange={(e) => {
+                updateAdvanceSettings('sapsf_private_key', e.target.value);
+              }}
+              floatingLabel="SAP SuccessFactors Private Key"
+              defaultValue={
+                existingConfigData.other_settings ? JSON.parse(existingConfigData.other_settings).sapsf_private_key : ''
+              }
+            />
+            <Form.Text>
+              The Private Key value found in the PEM file generated from the OAuth2 Client Application Profile.
+            </Form.Text>
+          </Form.Group>
+
+          <Form.Group>
+            <Form.Control
+              type="text"
+              onChange={(e) => {
+                updateAdvanceSettings('oauth_user_id', e.target.value);
+              }}
+              floatingLabel="OAuth User ID"
+              defaultValue={
+                existingConfigData.other_settings ? JSON.parse(existingConfigData.other_settings).oauth_user_id : ''
+              }
+            />
+            <Form.Text>
+              Username of the BizX administrator account that is configured for edX by the customer.
+            </Form.Text>
+          </Form.Group>
+        </>
+        )}
       </div>
     </>
   );
@@ -284,11 +530,15 @@ SSOConfigConfigureStep.propTypes = {
     attr_email: PropTypes.string,
     saml_configuration: PropTypes.number,
     max_session_length: PropTypes.number,
+    other_settings: PropTypes.string,
+    identity_provider_type: PropTypes.string,
   }),
   setRefreshBool: PropTypes.func.isRequired,
   refreshBool: PropTypes.bool.isRequired,
   setFormUpdated: PropTypes.func.isRequired,
   setConfigNextButtonDisabled: PropTypes.func.isRequired,
+  isUsingSap: PropTypes.bool.isRequired,
+  setIsUsingSap: PropTypes.func.isRequired,
 };
 
 export default SSOConfigConfigureStep;

--- a/src/components/settings/SettingsSSOTab/testutils.js
+++ b/src/components/settings/SettingsSSOTab/testutils.js
@@ -17,4 +17,5 @@ const getMockStore = aStore => mockStore(aStore);
 export {
   getMockStore,
   initialStore,
+  enterpriseId,
 };

--- a/src/components/settings/data/constants.js
+++ b/src/components/settings/data/constants.js
@@ -11,6 +11,7 @@ const SSO_TAB_LABEL = 'SSO';
 
 export const HELP_CENTER_LINK = 'https://business-support.edx.org/hc/en-us/categories/360000368453-Integrations';
 export const HELP_CENTER_SAML_LINK = 'https://business-support.edx.org/hc/en-us/articles/360005421073-5-Implementing-Single-Sign-on-SSO-with-edX';
+export const HELP_CENTER_SAP_IDP_LINK = 'https://business-support.edx.org/hc/en-us/articles/360005205314';
 export const SUCCESS_LABEL = 'success';
 export const TOGGLE_SUCCESS_LABEL = 'toggle success';
 export const DELETE_SUCCESS_LABEL = 'delete success';
@@ -26,6 +27,9 @@ export const SAP_TYPE = 'SAP';
 export const INVALID_LINK = 'Link must be properly formatted and start with http or https';
 export const INVALID_NAME = 'Display name must be unique and cannot be over 20 characters';
 export const INVALID_LENGTH = 'Max length must be a number, but cannot be over 2 weeks (1210000 seconds)';
+export const INVALID_API_ROOT_URL = 'OAuth API Root URL attribute must be a valid URL';
+export const INVALID_SAPSF_OAUTH_ROOT_URL = 'SAPSF OAuth URL attribute must be a valid URL';
+export const INVALID_ODATA_API_TIMEOUT_INTERVAL = 'OData API timeout interval must be a number less than 30';
 
 /**
  * Used as tab values and in router params


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-6065

If the user is using SAP as an IDP, we require specific custom configure attributes + have to designate the config as a SAP IDP config on the backend. This PR adds the ability to designate SAP as the IDP in the third, configure step of the SSO self service settings flow. 

![image](https://user-images.githubusercontent.com/67655836/179850151-bebc03a4-730d-473c-951c-eafc626c9d98.png)

![image](https://user-images.githubusercontent.com/67655836/179850173-63f2b18f-0b81-4b40-95dc-47abf482f065.png)


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
