### PR TITLE
refactor: Refactor 'Toasts' to MFE from frontend-enterprise

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@edx/frontend-enterprise-hotjar": "1.2.0",
     "@edx/frontend-enterprise-logistration": "2.1.0",
     "@edx/frontend-enterprise-utils": "2.1.0",
+    "@edx/frontend-enterprise-toasts": "0.1.0",
     "@edx/frontend-platform": "2.4.0",
     "@edx/paragon": "20.4.1",
     "@fortawesome/fontawesome-svg-core": "1.2.35",

--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -4,9 +4,9 @@ import { Helmet } from 'react-helmet';
 import { initializeHotjar } from '@edx/frontend-enterprise-hotjar';
 import { AuthenticatedPageRoute, PageRoute, AppProvider } from '@edx/frontend-platform/react';
 import { logError } from '@edx/frontend-platform/logging';
+import { ToastsProvider, Toasts } from '@edx/frontend-enterprise-toasts';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { getConfig } from '@edx/frontend-platform/config';
-
 import Header from '../../containers/Header';
 import Footer from '../../containers/Footer';
 import EnterpriseIndexPage from '../../containers/EnterpriseIndexPage';
@@ -14,7 +14,7 @@ import AuthenticatedEnterpriseApp from '../AuthenticatedEnterpriseApp';
 import AdminRegisterPage from '../AdminRegisterPage';
 import UserActivationPage from '../UserActivationPage';
 import NotFoundPage from '../NotFoundPage';
-import { ToastsProvider, Toasts } from '../Toasts';
+
 import { SystemWideWarningBanner } from '../system-wide-banner';
 
 import store from '../../data/store';


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-5504

Refactored Toasts component to reusable Toast component from frontend-enterprise, upon refactor, component page still loads as intended


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
