### PR TITLE
chore: adding default provider config values to self service

### DIFF
--- a/src/components/settings/SettingsSSOTab/SSOStepper.jsx
+++ b/src/components/settings/SettingsSSOTab/SSOStepper.jsx
@@ -57,11 +57,21 @@ const SSOStepper = ({ enterpriseSlug, enterpriseId, enterpriseName }) => {
   async function sendData(type) {
     const configFormData = new FormData();
     const newConfigValues = { ...configValues };
+    // Values we want all provider configs to by default contain
     configFormData.append('enterprise_customer_uuid', enterpriseId);
     configFormData.append('enabled', true);
+    configFormData.append('debug_mode', true);
+    configFormData.append('skip_hinted_login_dialog', true);
+    configFormData.append('skip_registration_form', true);
+    configFormData.append('skip_email_verification', true);
+    configFormData.append('send_to_registration_first', true);
+    configFormData.append('automatic_refresh_enabled', true);
+
+    // Add all our config values to the form data
     Object.keys(configValues).forEach(key => configFormData.append(key, configValues[key]));
+
     // Depending on whether the user is using SAP or not as an identity provider, we need to update
-    // both the update payload, as well as the config values.
+    // both the form data payload, as well as the config values.
     if (isUsingSap) {
       configFormData.append('identity_provider_type', 'sap_success_factors');
       configFormData.set('max_session_length', '');

--- a/src/components/settings/SettingsSSOTab/tests/NewSSOConfigForm.test.jsx
+++ b/src/components/settings/SettingsSSOTab/tests/NewSSOConfigForm.test.jsx
@@ -395,6 +395,12 @@ describe('SAML Config Tab', () => {
       attr_last_name: '',
       attr_email: 'NameID',
       enabled: 'true',
+      debug_mode: 'true',
+      skip_hinted_login_dialog: 'true',
+      skip_registration_form: 'true',
+      skip_email_verification: 'true',
+      send_to_registration_first: 'true',
+      automatic_refresh_enabled: 'true',
       attr_username: 'loggedinuserid',
       other_settings: {
         odata_api_root_url: 'foobar.com',
@@ -477,6 +483,12 @@ describe('SAML Config Tab', () => {
       attr_username: 'foobar',
       other_settings: '',
       enabled: 'true',
+      debug_mode: 'true',
+      skip_hinted_login_dialog: 'true',
+      skip_registration_form: 'true',
+      skip_email_verification: 'true',
+      send_to_registration_first: 'true',
+      automatic_refresh_enabled: 'true',
     };
     mockUpdateProviderConfig.mock.calls[0][0].forEach((value, key) => {
       expect(expectedConfigFormData[key]).toEqual(value);


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-6207

adding default values
```* Debug Mode
* Skip hinted dialog
* Skip registration form
* Skip email verfication
* Send to registration first
* Automatic metadata refresh with metadata URL specified
```


to form data when creating/updating provider config forms in the self service settings page

Tested locally that both old and new forms update with the new default values