### PR TITLE
feat: Render 404 page on non-existent enterprise-slug

### DIFF
--- a/src/components/EnterpriseApp/EnterpriseApp.test.jsx
+++ b/src/components/EnterpriseApp/EnterpriseApp.test.jsx
@@ -36,7 +36,7 @@ jest.mock('../ProductTours/ProductTours', () => ({
 
 jest.mock('./EnterpriseAppContextProvider', () => ({
   __esModule: true,
-  default: ({ children }) => <EnterpriseSubsidiesContextProvider>{ children }</EnterpriseSubsidiesContextProvider>,
+  default: ({ children }) => <EnterpriseSubsidiesContextProvider>{children}</EnterpriseSubsidiesContextProvider>,
 }));
 
 jest.mock('../../containers/Sidebar', () => ({
@@ -50,7 +50,6 @@ describe('<EnterpriseApp />', () => {
       url: '',
       params: {
         enterpriseSlug: 'foo',
-        page: 'settings',
       },
     },
     location: {
@@ -67,6 +66,11 @@ describe('<EnterpriseApp />', () => {
     enterpriseName: 'test-enterprise',
   };
 
+  const invalidEnterpriseId = {
+    ...basicProps,
+    enterpriseId: null,
+    enterpriseName: null,
+  };
   beforeEach(() => {
     getAuthenticatedUser.mockReturnValue({
       username: 'edx',
@@ -83,5 +87,10 @@ describe('<EnterpriseApp />', () => {
   it('should hide settings page if there are no visible tabs', () => {
     render(<EnterpriseApp {...basicProps} enableLearnerPortal={false} />);
     expect(screen.queryByText('/admin/settings')).not.toBeInTheDocument();
+  });
+
+  it('should show error page if enterprise name is invalid', () => {
+    render(<EnterpriseApp {...invalidEnterpriseId} />);
+    expect(screen.getByText("Oops, sorry we can't find that page!")).toBeInTheDocument();
   });
 });

--- a/src/components/EnterpriseApp/index.jsx
+++ b/src/components/EnterpriseApp/index.jsx
@@ -12,6 +12,7 @@ import FeatureAnnouncementBanner from '../FeatureAnnouncementBanner';
 import EnterpriseAppContextProvider from './EnterpriseAppContextProvider';
 import EnterpriseAppRoutes from './EnterpriseAppRoutes';
 import ProductTours from '../ProductTours/ProductTours';
+import NotFoundPage from '../NotFoundPage';
 
 class EnterpriseApp extends React.Component {
   constructor(props) {
@@ -125,6 +126,10 @@ class EnterpriseApp extends React.Component {
       return <EnterpriseAppSkeleton />;
     }
 
+    if (!enterpriseId) {
+      return <NotFoundPage />;
+    }
+
     return (
       <EnterpriseAppContextProvider
         enterpriseId={enterpriseId}
@@ -199,7 +204,6 @@ EnterpriseApp.propTypes = {
     url: PropTypes.string.isRequired,
     params: PropTypes.shape({
       enterpriseSlug: PropTypes.string.isRequired,
-      page: PropTypes.string.isRequired,
     }).isRequired,
   }).isRequired,
   enterpriseId: PropTypes.string,


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-3600

- Add unified logic to redirect to 404 page on bad enterprise slug
- Use pre-existing component to render 404 page
- Checks enterprise existence before provider renders

![Screen Shot 2022-09-06 at 16 06 54 PM](https://user-images.githubusercontent.com/82611798/188728648-7b4b881d-5496-4b6b-9831-f01c3e7c43bb.png)


# For all changes

- [X] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [X] Ensure to attach screenshots
- [X] Ensure to have UX team confirm screenshots
