### PR TITLE
feat: added new product tour for portal appearance feature

### DIFF
--- a/src/components/ProductTours/ProductTours.jsx
+++ b/src/components/ProductTours/ProductTours.jsx
@@ -4,8 +4,10 @@ import { ProductTour } from '@edx/paragon';
 import { useHistory } from 'react-router-dom';
 import { connect } from 'react-redux';
 import browseAndRequestTour from './browseAndRequestTour';
+import { features } from '../../config';
+import portalAppearanceTour from './portalAppearanceTour';
 import learnerCreditTour from './learnerCreditTour';
-import { useBrowseAndRequestTour, useLearnerCreditTour } from './data/hooks';
+import { useBrowseAndRequestTour, usePortalAppearanceTour, useLearnerCreditTour } from './data/hooks';
 
 /**
  * All the logic here is for determining what ProductTours we should show.
@@ -19,9 +21,20 @@ const ProductTours = ({
     enableLearnerPortal,
   });
   const [learnerCreditTourEnabled, setLearnerCreditTourEnabled] = useLearnerCreditTour();
+  const enablePortalAppearance = features.SETTINGS_PAGE_APPEARANCE_TAB;
+  const [portalAppearanceTourEnabled, setPortalAppearanceTourEnabled] = usePortalAppearanceTour({
+    enablePortalAppearance,
+  });
 
   const history = useHistory();
   const tours = [
+    portalAppearanceTour({
+      enterpriseSlug,
+      tourEnabled: portalAppearanceTourEnabled,
+      history,
+      onDismiss: () => setPortalAppearanceTourEnabled(false),
+      onEnd: () => setPortalAppearanceTourEnabled(false),
+    }),
     browseAndRequestTour({
       enterpriseSlug,
       tourEnabled: browseAndRequestTourEnabled,

--- a/src/components/ProductTours/constants.js
+++ b/src/components/ProductTours/constants.js
@@ -7,6 +7,10 @@ export const TOUR_TARGETS = {
   LEARNER_CREDIT,
 };
 
+export const PORTAL_APPEARANCE_TOUR_COOKIE_NAME = 'dismissed-portal-appearance-tour';
+export const PORTAL_APPEARANCE_DISMISS_EVENT_NAME = 'edx.ui.enterprise.admin-portal.tours.portal-appearance.dismissed';
+export const PORTAL_APPEARANCE_ON_END_EVENT_NAME = 'edx.ui.enterprise.admin-portal.tours.portal-appearance.navigated-to-page';
+
 export const BROWSE_AND_REQUEST_TOUR_COOKIE_NAME = 'dismissed-browse-and-request-tour';
 export const LEARNER_CREDIT_COOKIE_NAME = 'dismissed-learner-credit-tour';
 

--- a/src/components/ProductTours/data/hooks.js
+++ b/src/components/ProductTours/data/hooks.js
@@ -4,12 +4,23 @@ import Cookies from 'universal-cookie';
 import { ROUTE_NAMES } from '../../EnterpriseApp/constants';
 import {
   BROWSE_AND_REQUEST_TOUR_COOKIE_NAME,
+  PORTAL_APPEARANCE_TOUR_COOKIE_NAME,
   LEARNER_CREDIT_COOKIE_NAME,
 } from '../constants';
 import { SubsidyRequestsContext } from '../../subsidy-requests';
 import { EnterpriseSubsidiesContext } from '../../EnterpriseSubsidiesContext';
 
 const cookies = new Cookies();
+
+export const usePortalAppearanceTour = ({ enablePortalAppearance }) => {
+  const { enterpriseAppPage } = useParams();
+  const inSettingsPage = enterpriseAppPage === ROUTE_NAMES.settings;
+  const dismissedLearnerCreditTourCookie = cookies.get(PORTAL_APPEARANCE_TOUR_COOKIE_NAME);
+  // Only show tour if feature is enabled, hide cookie is undefined or false or not in the settings page
+  const showPortalAppearanceTour = enablePortalAppearance && !dismissedLearnerCreditTourCookie && !inSettingsPage;
+  const [portalAppearanceTourEnabled, setPortalAppearanceTourEnabled] = useState(showPortalAppearanceTour);
+  return [portalAppearanceTourEnabled, setPortalAppearanceTourEnabled];
+};
 
 export const useBrowseAndRequestTour = ({
   enableLearnerPortal,

--- a/src/components/ProductTours/portalAppearanceTour.jsx
+++ b/src/components/ProductTours/portalAppearanceTour.jsx
@@ -1,0 +1,74 @@
+import PropTypes from 'prop-types';
+import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
+import Cookies from 'universal-cookie';
+
+import { ROUTE_NAMES } from '../EnterpriseApp/constants';
+import { SETTINGS_TABS_VALUES } from '../settings/data/constants';
+import {
+  PORTAL_APPEARANCE_TOUR_COOKIE_NAME,
+  PORTAL_APPEARANCE_DISMISS_EVENT_NAME,
+  PORTAL_APPEARANCE_ON_END_EVENT_NAME,
+  TOUR_TARGETS,
+} from './constants';
+
+const cookies = new Cookies();
+
+const portalAppearanceTour = ({
+  enterpriseSlug,
+  tourEnabled,
+  history,
+  onDismiss,
+  onEnd,
+}) => {
+  const disableTour = () => {
+    cookies.set(
+      PORTAL_APPEARANCE_TOUR_COOKIE_NAME,
+      true,
+      { sameSite: 'strict' },
+    );
+  };
+
+  const handleDismissTour = () => {
+    disableTour();
+    onDismiss();
+    sendEnterpriseTrackEvent(enterpriseSlug, PORTAL_APPEARANCE_DISMISS_EVENT_NAME);
+  };
+
+  const handleTourEnd = () => {
+    disableTour();
+    history.push({ pathname: `/${enterpriseSlug}/admin/${ROUTE_NAMES.settings}/${SETTINGS_TABS_VALUES.appearance}` });
+    onEnd();
+    sendEnterpriseTrackEvent(enterpriseSlug, PORTAL_APPEARANCE_ON_END_EVENT_NAME);
+  };
+
+  const tour = {
+    tourId: 'browseAndRequestTour',
+    endButtonText: 'Portal Appearance',
+    dismissButtonText: 'Dismiss',
+    enabled: tourEnabled,
+    onDismiss: handleDismissTour,
+    onEnd: handleTourEnd,
+    checkpoints: [
+      {
+        placement: 'right',
+        body: 'With the new Portal Appearance feature, you can now upload a logo or select custom or theme '
+          + 'colors to align the look and feel of your Admin and Learner Portals with your brand. Continue to '
+          + 'Portal Appearance under Settings to learn more.',
+        target: `#${TOUR_TARGETS.SETTINGS_SIDEBAR}`,
+        title: 'New Feature',
+        showDismissButton: true,
+      },
+    ],
+  };
+
+  return tour;
+};
+
+portalAppearanceTour.propTypes = {
+  enterpriseSlug: PropTypes.string.isRequired,
+  tourEnabled: PropTypes.bool.isRequired,
+  onDismiss: PropTypes.func.isRequired,
+  onEnd: PropTypes.func.isRequired,
+};
+
+export default portalAppearanceTour;


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-6100

Added product tour for portal appearance. Placed behind portal appearance feature flag.

![Screen Shot 2022-09-09 at 2 55 37 PM](https://user-images.githubusercontent.com/67655836/189665987-0ebbfda2-25d1-4bbb-80bc-a50b4add9c86.png)

Notes for testing locally- if you missed the pop up you will most likely have to remove the `portal appearance seen` cookie which will be listed under localhost cookies. 

(Don't mind the cat logo)
