### PR TITLE
feat: Learner Credit Disclaimer message added

### DIFF
--- a/src/components/learner-credit-management/LearnerCreditDisclaimer.jsx
+++ b/src/components/learner-credit-management/LearnerCreditDisclaimer.jsx
@@ -1,0 +1,22 @@
+import {
+  Icon, Col, Stack,
+} from '@edx/paragon';
+import { Info } from '@edx/paragon/icons';
+import PropTypes from 'prop-types';
+
+const LearnerCreditDisclaimer = ({ offerLastUpdated }) => (
+  <Stack direction="horizontal" className="mb-4">
+    <Icon src={Info} className="align-self-start" />
+    <Col className="col-8 pl-2">
+      Data last updated on {offerLastUpdated}. This data reflects
+      the current active learner credit only and does not include
+      other spend by your organization (codes, manual enrollments, past offers).
+    </Col>
+  </Stack>
+);
+
+LearnerCreditDisclaimer.propTypes = {
+  offerLastUpdated: PropTypes.string.isRequired,
+};
+
+export default LearnerCreditDisclaimer;

--- a/src/components/learner-credit-management/LearnerCreditManagement.jsx
+++ b/src/components/learner-credit-management/LearnerCreditManagement.jsx
@@ -18,6 +18,7 @@ import { EnterpriseSubsidiesContext } from '../EnterpriseSubsidiesContext';
 import { NotFound } from '../NotFoundPage';
 import LearnerCreditAllocationTable from './LearnerCreditAllocationTable';
 import LearnerCreditAggregateCards from './LearnerCreditAggregateCards';
+import LearnerCreditDisclaimer from './LearnerCreditDisclaimer';
 import OfferDates from './OfferDates';
 import OfferNameHeading from './OfferNameHeading';
 import { useOfferSummary, useOfferRedemptions } from './data/hooks';
@@ -55,7 +56,6 @@ const LearnerCreditManagement = ({ enterpriseUUID }) => {
   // deduce when the data was last updated based on when any of the offer redemptions
   // records were created.
   const offerDataLastUpdatedTimestamp = offerRedemptions.results[0]?.created;
-
   return (
     <>
       <Helmet>
@@ -70,7 +70,7 @@ const LearnerCreditManagement = ({ enterpriseUUID }) => {
           enterpriseUUID={enterpriseUUID}
         />
         <OfferNameHeading name={enterpriseOffer.displayName} />
-        <div className="d-flex flex-wrap align-items-center mb-5">
+        <div className="d-flex flex-wrap align-items-center mb-3.5">
           <Stack direction="horizontal" gap={3}>
             {enterpriseOffer.isCurrent ? (
               <Badge variant="primary">Active</Badge>
@@ -83,16 +83,15 @@ const LearnerCreditManagement = ({ enterpriseUUID }) => {
             />
           </Stack>
         </div>
-        <p className="small mb-2">
-          {(isLoadingOfferSummary || isLoadingOfferRedemptions) ? (
+        {isLoadingOfferSummary || isLoadingOfferRedemptions ? (
+          <>
             <Skeleton width={320} />
-          ) : (
-            <>
-              Data last updated on{' '}
-              {moment(offerDataLastUpdatedTimestamp).format(DATE_FORMAT)}
-            </>
-          )}
-        </p>
+          </>
+        ) : (
+          <>
+            <LearnerCreditDisclaimer offerLastUpdated={moment(offerDataLastUpdatedTimestamp).format(DATE_FORMAT)} />
+          </>
+        )}
         <div className="mb-4.5 d-flex flex-wrap mx-n3">
           <LearnerCreditAggregateCards
             isLoading={isLoadingOfferSummary}

--- a/src/components/learner-credit-management/tests/LearnerCreditDisclaimer.test.jsx
+++ b/src/components/learner-credit-management/tests/LearnerCreditDisclaimer.test.jsx
@@ -1,0 +1,13 @@
+import {
+  screen,
+  render,
+} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import LearnerCreditDisclaimer from '../LearnerCreditDisclaimer';
+
+describe('<LearnerCreditDisclaimer />', () => {
+  it('renders', () => {
+    render(<LearnerCreditDisclaimer offerLastUpdated="February 20th, 2022" />);
+    expect(screen.getByText('Data last updated on February 20th, 2022. This data reflects', { exact: false })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-6262
Associated Figma: https://www.figma.com/file/glKHoHBACvTw2oeKs2TO1O/Offers?node-id=378%3A27432

Added disclaimer message along with icon on LCM page
Passes dynamic date to render within the disclaimer

<img width="1512" alt="Screen Shot 2022-09-16 at 12 03 03 PM" src="https://user-images.githubusercontent.com/82611798/190681894-c9a65fc0-4b13-49c3-b349-b0533a95424c.png">


# For all changes

- [ X] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ X] Ensure to attach screenshots
- [ X] Ensure to have UX team confirm screenshots
