### PR TITLE
refactor: migrate off paragon modal deprecated migration

### DIFF
--- a/src/components/CodeAssignmentModal/CodeAssignmentModal.test.jsx
+++ b/src/components/CodeAssignmentModal/CodeAssignmentModal.test.jsx
@@ -90,7 +90,7 @@ const initialProps = {
   enterpriseSlug: 'bearsRus',
   setEmailAddress: () => {},
   enterpriseUuid: 'foo',
-  createPendingEnterpriseUsers: () => {},
+  createPendingEnterpriseUsers: () => { },
 };
 
 const mockStore = configureMockStore([thunk]);
@@ -134,7 +134,6 @@ const CodeAssignmentModalWrapper = (props) => (
   </MemoryRouter>
 );
 /* eslint-enable react/prop-types */
-
 describe('CodeAssignmentModal component', () => {
   it('displays a modal', () => {
     render(<CodeAssignmentModalWrapper />);

--- a/src/components/CodeAssignmentModal/index.jsx
+++ b/src/components/CodeAssignmentModal/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm, SubmissionError } from 'redux-form';
 import {
-  Button, Icon, Modal, Form,
+  Button, Icon, ModalDialog, ActionRow, Form,
 } from '@edx/paragon';
 import isEmail from 'validator/lib/isEmail';
 
@@ -373,7 +373,7 @@ export class BaseCodeAssignmentModal extends React.Component {
           >
             Notify learners by email
           </Form.Checkbox>
-          { notify && (
+          {notify && (
             <EmailTemplateForm
               emailTemplateType={MODAL_TYPES.assign}
               fields={ASSIGNMENT_MODAL_FIELDS}
@@ -402,35 +402,50 @@ export class BaseCodeAssignmentModal extends React.Component {
     } = this.state;
 
     return (
-      <>
-        <Modal
-          ref={this.modalRef}
-          dialogClassName="code-assignment"
-          title={this.renderTitle()}
-          body={this.renderBody()}
-          buttons={[
-            <Button
-              key="assign-submit-btn"
-              disabled={submitting}
-              onClick={handleSubmit(this.handleModalSubmit)}
-              data-testid={SUBMIT_BUTTON_TEST_ID}
-            >
-              <>
-                {mode === MODAL_TYPES.assign && submitting && <Icon className="fa fa-spinner fa-spin mr-2" />}
-                {`Assign ${isBulkAssign ? 'Codes' : 'Code'}`}
-              </>
-            </Button>,
-            <SaveTemplateButton
-              key="save-assign-template-btn"
-              templateType={MODAL_TYPES.assign}
-              setMode={this.setMode}
-              handleSubmit={handleSubmit}
-            />,
-          ]}
+      <div ref={this.modalRef}>
+        <ModalDialog
+          isOpen
           onClose={onClose}
-          open
-        />
-      </>
+          className="code-assignment"
+          hasCloseButton
+
+        >
+          <ModalDialog.Header>
+            <ModalDialog.Title>
+              {this.renderTitle()}
+            </ModalDialog.Title>
+          </ModalDialog.Header>
+          <ModalDialog.Body>
+            <div className="p-2">
+              {this.renderBody()}
+            </div>
+          </ModalDialog.Body>
+          <ModalDialog.Footer>
+            <ActionRow>
+              <ModalDialog.CloseButton variant="link">
+                Cancel
+              </ModalDialog.CloseButton>
+              <Button
+                key="assign-submit-btn"
+                disabled={submitting}
+                onClick={handleSubmit(this.handleModalSubmit)}
+                data-testid={SUBMIT_BUTTON_TEST_ID}
+              >
+                <>
+                  {mode === MODAL_TYPES.assign && submitting && <Icon className="fa fa-spinner fa-spin mr-2" />}
+                  {`Assign ${isBulkAssign ? 'Codes' : 'Code'}`}
+                </>
+              </Button>,
+              <SaveTemplateButton
+                key="save-assign-template-btn"
+                templateType={MODAL_TYPES.assign}
+                setMode={this.setMode}
+                handleSubmit={handleSubmit}
+              />,
+            </ActionRow>
+          </ModalDialog.Footer>
+        </ModalDialog>
+      </div>
     );
   }
 }

--- a/src/components/CodeReminderModal/CodeReminderModal.test.jsx
+++ b/src/components/CodeReminderModal/CodeReminderModal.test.jsx
@@ -126,10 +126,10 @@ const CodeReminderModalWrapper = (props) => (
   </MemoryRouter>
 );
 /* eslint-enable react/prop-types */
-
 describe('CodeReminderModal component', () => {
   it('displays a modal', () => {
     render(<CodeReminderModalWrapper />);
+
     expect(screen.getByText(initialProps.title)).toBeInTheDocument();
   });
   it('displays an error', () => {

--- a/src/components/CodeReminderModal/index.jsx
+++ b/src/components/CodeReminderModal/index.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm, SubmissionError } from 'redux-form';
-import { Button, Icon, Modal } from '@edx/paragon';
+import {
+  Button, Icon, ModalDialog, ActionRow,
+} from '@edx/paragon';
 import SaveTemplateButton from '../../containers/SaveTemplateButton';
 
 import { EMAIL_TEMPLATE_SUBJECT_KEY } from '../../data/constants/emailTemplate';
@@ -214,35 +216,51 @@ export class BaseCodeReminderModal extends React.Component {
     } = this.state;
 
     return (
-      <>
-        <Modal
-          ref={this.modalRef}
-          dialogClassName="code-reminder"
-          title={this.renderTitle()}
-          body={this.renderBody()}
-          buttons={[
-            <Button
-              key="remind-submit-btn"
-              disabled={submitting}
-              className="code-remind-save-btn"
-              onClick={handleSubmit(this.handleModalSubmit)}
-            >
-              <>
-                {mode === REMIND_MODE && submitting && <Icon className="fa fa-spinner fa-spin mr-2" />}
-                Remind
-              </>
-            </Button>,
-            <SaveTemplateButton
-              key="save-remind-template-btn"
-              templateType={REMIND_MODE}
-              setMode={this.setMode}
-              handleSubmit={handleSubmit}
-            />,
-          ]}
+      <div ref={this.modalRef}>
+        <ModalDialog
+
+          isOpen
           onClose={onClose}
-          open
-        />
-      </>
+          className="code-reminder"
+          hasCloseButton
+
+        >
+          <ModalDialog.Header>
+            <ModalDialog.Title>
+              Invite Learners
+            </ModalDialog.Title>
+          </ModalDialog.Header>
+          <ModalDialog.Body>
+            <div className="p-2">
+              {this.renderBody()}
+            </div>
+          </ModalDialog.Body>
+          <ModalDialog.Footer>
+            <ActionRow>
+              <ModalDialog.CloseButton variant="link">
+                Cancel
+              </ModalDialog.CloseButton>
+              <Button
+                key="remind-submit-btn"
+                disabled={submitting}
+                className="code-remind-save-btn"
+                onClick={handleSubmit(this.handleModalSubmit)}
+              >
+                <>
+                  {mode === REMIND_MODE && submitting && <Icon className="fa fa-spinner fa-spin mr-2" />}
+                  Remind
+                </>
+              </Button>,
+              <SaveTemplateButton
+                key="save-remind-template-btn"
+                templateType={REMIND_MODE}
+                setMode={this.setMode}
+                handleSubmit={handleSubmit}
+              />,
+            </ActionRow>
+          </ModalDialog.Footer>
+        </ModalDialog>
+      </div>
     );
   }
 }

--- a/src/components/CodeRevokeModal/index.jsx
+++ b/src/components/CodeRevokeModal/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Field, reduxForm, SubmissionError } from 'redux-form';
 import {
-  Button, Icon, Modal,
+  Button, Icon, ModalDialog, ActionRow,
 } from '@edx/paragon';
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 
@@ -177,11 +177,11 @@ class CodeRevokeModal extends React.Component {
       <>
         {submitFailed
           && (
-          <ModalError
-            title={ERROR_MESSAGE_TITLES[mode]}
-            errors={error}
-            ref={this.errorMessageRef}
-          />
+            <ModalError
+              title={ERROR_MESSAGE_TITLES[mode]}
+              errors={error}
+              ref={this.errorMessageRef}
+            />
           )}
         <div className="assignment-details mb-4">
           {isBulkRevoke && (
@@ -232,36 +232,51 @@ class CodeRevokeModal extends React.Component {
     } = this.state;
 
     return (
-      <>
-        <Modal
-          ref={this.modalRef}
-          dialogClassName="code-revoke"
-          title={this.renderTitle()}
-          body={this.renderBody()}
-          buttons={[
-            <Button
-              key="revoke-submit-btn"
-              disabled={submitting}
-              className="code-revoke-save-btn"
-              onClick={handleSubmit(this.handleModalSubmit)}
-            >
-              <>
-                {mode === MODAL_TYPES.revoke && submitting && <Icon className="fa fa-spinner fa-spin mr-2" />}
-                Revoke
-              </>
-            </Button>,
-            <SaveTemplateButton
-              key="save-revoke-template-btn"
-              templateType={MODAL_TYPES.revoke}
-              setMode={this.setMode}
-              handleSubmit={handleSubmit}
-              disabled={doNotEmail}
-            />,
-          ]}
+      <div
+        ref={this.modalRef}
+      >
+        <ModalDialog
+          isOpen
           onClose={onClose}
-          open
-        />
-      </>
+          className="code-revoke"
+          hasCloseButton
+
+        >
+          <ModalDialog.Header>
+            <ModalDialog.Title>
+              {this.renderTitle()}
+            </ModalDialog.Title>
+          </ModalDialog.Header>
+          <ModalDialog.Body>
+            {this.renderBody()}
+          </ModalDialog.Body>
+          <ModalDialog.Footer>
+            <ActionRow>
+              <ModalDialog.CloseButton variant="link">
+                Close
+              </ModalDialog.CloseButton>
+              <Button
+                key="revoke-submit-btn"
+                disabled={submitting}
+                className="code-revoke-save-btn"
+                onClick={handleSubmit(this.handleModalSubmit)}
+              >
+                <>
+                  {mode === MODAL_TYPES.revoke && submitting && <Icon className="fa fa-spinner fa-spin mr-2" />}
+                  Revoke
+                </>
+              </Button>,
+              <SaveTemplateButton
+                key="save-revoke-template-btn"
+                templateType={MODAL_TYPES.revoke}
+                setMode={this.setMode}
+                handleSubmit={handleSubmit}
+                disabled={doNotEmail}
+              />,
+            </ActionRow>
+          </ModalDialog.Footer>
+        </ModalDialog>
+      </div>
     );
   }
 }

--- a/src/components/InviteLearnersModal/index.jsx
+++ b/src/components/InviteLearnersModal/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Field, reduxForm, SubmissionError } from 'redux-form';
 import {
-  Button, Icon, Modal, Alert,
+  Button, Icon, Alert, ModalDialog, ActionRow,
 } from '@edx/paragon';
 import { Cancel as ErrorIcon } from '@edx/paragon/icons';
 
@@ -179,30 +179,46 @@ class InviteLearnersModal extends React.Component {
     } = this.props;
 
     return (
-      <>
-        <Modal
-          ref={this.modalRef}
-          dialogClassName="add-users"
-          title="Invite learners"
-          body={this.renderBody()}
-          buttons={[
-            <Button
-              key="subscribe-users-submit-btn"
-              disabled={submitting}
-              className="subscribe-users-save-btn"
-              onClick={handleSubmit(this.handleModalSubmit)}
-            >
-              <>
-                {submitting && <Icon className="fa fa-spinner fa-spin mr-2" />}
-                Invite learners
-              </>
-            </Button>,
-          ]}
-          closeText="Cancel"
+      <div
+        ref={this.modalRef}
+      >
+        <ModalDialog
+          isOpen
           onClose={onClose}
-          open
-        />
-      </>
+          className="add-users"
+          hasCloseButton
+
+        >
+          <ModalDialog.Header>
+            <ModalDialog.Title>
+              Invite learners
+            </ModalDialog.Title>
+          </ModalDialog.Header>
+          <ModalDialog.Body>
+            <div className="p-2">
+              {this.renderBody()}
+            </div>
+          </ModalDialog.Body>
+          <ModalDialog.Footer>
+            <ActionRow>
+              <ModalDialog.CloseButton variant="link">
+                Cancel
+              </ModalDialog.CloseButton>
+              <Button
+                key="subscribe-users-submit-btn"
+                disabled={submitting}
+                className="subscribe-users-save-btn"
+                onClick={handleSubmit(this.handleModalSubmit)}
+              >
+                <>
+                  {submitting && <Icon className="fa fa-spinner fa-spin mr-2" />}
+                  Invite learners
+                </>
+              </Button>,
+            </ActionRow>
+          </ModalDialog.Footer>
+        </ModalDialog>
+      </div>
     );
   }
 }

--- a/src/containers/CodeReminderModal/CodeReminderModal.test.jsx
+++ b/src/containers/CodeReminderModal/CodeReminderModal.test.jsx
@@ -170,7 +170,7 @@ describe('CodeReminderModalWrapper', () => {
 
     expect(wrapper.find('.bulk-selected-codes').text()).toEqual('Selected codes: 2');
     expect(wrapper.find('#email-template')).toBeTruthy();
-    wrapper.find('.modal-footer .code-remind-save-btn').hostNodes().simulate('click');
+    wrapper.find('.pgn__modal-footer .code-remind-save-btn').hostNodes().simulate('click');
     expect(spy).toHaveBeenCalledWith(couponId, codeReminderRequestData(2));
   });
 
@@ -191,7 +191,7 @@ describe('CodeReminderModalWrapper', () => {
 
     expect(wrapper.find('.bulk-selected-codes').text()).toEqual('Selected codes: 2');
     expect(wrapper.find('#email-template')).toBeTruthy();
-    wrapper.find('.modal-footer .code-remind-save-btn').hostNodes().simulate('click');
+    wrapper.find('.pgn__modal-footer .code-remind-save-btn').hostNodes().simulate('click');
     const expectedData = codeReminderRequestData(2);
     delete expectedData.base_enterprise_url;
     expect(spy).toHaveBeenCalledWith(couponId, expectedData);
@@ -208,7 +208,7 @@ describe('CodeReminderModalWrapper', () => {
     />);
 
     expect(wrapper.find('.bulk-selected-codes').text()).toEqual('Selected codes: 3');
-    wrapper.find('.modal-footer .code-remind-save-btn').hostNodes().simulate('click');
+    wrapper.find('.pgn__modal-footer .code-remind-save-btn').hostNodes().simulate('click');
     expect(spy).toHaveBeenCalledWith(couponId, codeReminderRequestData(0, selectedToggle));
   });
 

--- a/src/containers/CodeRevokeModal/CodeRevokeModal.test.jsx
+++ b/src/containers/CodeRevokeModal/CodeRevokeModal.test.jsx
@@ -114,13 +114,13 @@ describe('CodeRevokeModalWrapper', () => {
     spy = jest.spyOn(EcommerceApiService, 'sendCodeRevoke');
 
     const wrapper = mount(<CodeRevokeModalWrapper data={data} />);
-    expect(wrapper.find('.modal-title').text()).toEqual(couponTitle);
+    expect(wrapper.find('.pgn__modal-title').text()).toEqual(couponTitle);
 
     expect(wrapper.find('.assignment-details p.code').text()).toEqual(`Code: ${data.code}`);
     expect(wrapper.find('.assignment-details p.email').text()).toEqual(`Email: ${data.assigned_to}`);
 
-    expect(wrapper.find('.modal-body form h3').text()).toEqual('Email Template');
-    wrapper.find('.modal-footer .code-revoke-save-btn .btn-primary').hostNodes().simulate('click');
+    expect(wrapper.find('.pgn__modal-body-content form h3').text()).toEqual('Email Template');
+    wrapper.find('.pgn__modal-footer .code-revoke-save-btn .btn-primary').hostNodes().simulate('click');
     expect(spy).toHaveBeenCalledWith(couponId, codeRevokeRequestData(1));
   });
 
@@ -133,7 +133,7 @@ describe('CodeRevokeModalWrapper', () => {
     />);
 
     expect(wrapper.find('.bulk-selected-codes').text()).toEqual('Selected codes: 2');
-    wrapper.find('.modal-footer .code-revoke-save-btn .btn-primary').hostNodes().simulate('click');
+    wrapper.find('.pgn__modal-footer .code-revoke-save-btn .btn-primary').hostNodes().simulate('click');
     expect(spy).toHaveBeenCalledWith(couponId, codeRevokeRequestData(2));
   });
 
@@ -149,7 +149,7 @@ describe('CodeRevokeModalWrapper', () => {
       })}
     />);
 
-    wrapper.find('.modal-footer .code-revoke-save-btn .btn-primary').hostNodes().simulate('click');
+    wrapper.find('.pgn__modal-footer .code-revoke-save-btn .btn-primary').hostNodes().simulate('click');
     const expectedData = codeRevokeRequestData(2);
     delete expectedData.base_enterprise_url;
     expect(spy).toHaveBeenCalledWith(couponId, expectedData);
@@ -164,7 +164,7 @@ describe('CodeRevokeModalWrapper', () => {
     />);
 
     expect(wrapper.find('.bulk-selected-codes').exists()).toBeFalsy();
-    wrapper.find('.modal-footer .code-revoke-save-btn .btn-primary').hostNodes().simulate('click');
+    wrapper.find('.pgn__modal-footer .code-revoke-save-btn .btn-primary').hostNodes().simulate('click');
     expect(spy).not.toHaveBeenCalled();
   });
 

--- a/src/containers/InviteLearnersModal/InviteLearnersModal.test.jsx
+++ b/src/containers/InviteLearnersModal/InviteLearnersModal.test.jsx
@@ -55,6 +55,6 @@ describe('UserSubscriptionModalWrapper', () => {
 
   it('renders user licenses modal', () => {
     const wrapper = mount(<InviteLearnersModalWrapper data={{}} />);
-    expect(wrapper.find('.modal-body form h3').first().text()).toEqual('Add Users');
+    expect(wrapper.find('.pgn__modal-body-content form h3').first().text()).toEqual('Add Users');
   });
 });


### PR DESCRIPTION
### Ticket

[Migrate off deprecated Paragon components ](https://github.com/openedx/frontend-wg/issues/102)

### What has Changed?

Migrate off paragon modal deprecation in 

-  **CodeAssignmentModal/index.jsx** 
- **CodeReminderModal/index.jsx**
- **CodeRevokeModal/index.jsx**
- **InviteLearnersModal/index.jsx**