### PR TITLE
fix: Bulk email validator handles whitespace padding

### DIFF
--- a/src/data/validation/email.js
+++ b/src/data/validation/email.js
@@ -68,12 +68,13 @@ const validateEmailAddresses = (emails) => {
     return result;
   }
   emails.forEach((email, index) => {
-    if (email) {
-      if (!isEmail(email)) {
-        result.invalidEmails.push(email);
+    const sanitizedEmail = email.trim();
+    if (sanitizedEmail) {
+      if (!isEmail(sanitizedEmail)) {
+        result.invalidEmails.push(sanitizedEmail);
         result.invalidEmailIndices.push(index);
       } else {
-        result.validEmails.push(email);
+        result.validEmails.push(sanitizedEmail);
         result.validEmailIndices.push(index);
       }
     }

--- a/src/data/validation/email.test.js
+++ b/src/data/validation/email.test.js
@@ -28,6 +28,14 @@ describe('email validation', () => {
       expect(validateEmailAddresses(validEmails)).toEqual(expectedResult);
     });
 
+    it('returns valid email addresses and indices when whitespace padding is in the picture', () => {
+      const validEmails = ['timmy@test.co ', ' bigsby@test.co', 'coolstorybro@gtest.com   '];
+      const expectedResult = { ...baseResults };
+      expectedResult.validEmails = ['timmy@test.co', 'bigsby@test.co', 'coolstorybro@gtest.com'];
+      expectedResult.validEmailIndices = _.range(validEmails.length);
+      expect(validateEmailAddresses(validEmails)).toEqual(expectedResult);
+    });
+
     it('returns invalid email addresses and indices', () => {
       const invalidEmails = ['bobbyb', 'yooooooo3.a.x.y', 'argh@', 'blargh@.co.uk'];
       const expectedResult = { ...baseResults };


### PR DESCRIPTION
On the Admin portal Subscription management screen, entering a list of emails with any whitespace around individual emails will show errors.  This change disregards the extraneous whitespace, while still validating proper email structure.

[Jira Ticket](https://2u-internal.atlassian.net/browse/ENT-4739)
# For all changes

- [X] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Before
<img src="https://user-images.githubusercontent.com/322346/196278464-2ec953fc-c3f9-4143-be39-cf40900d11cb.gif" alt="Your image title" width="250"/>

# After
<img src="https://user-images.githubusercontent.com/322346/196279955-0cf62739-4c39-4858-985e-533d97a84d98.gif" alt="Your image title" width="250"/>

# Only if submitting a visual change

- [X] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
