### PR TITLE
feat: add maintenance page for tableau analytics

### DIFF
--- a/src/components/analytics/AnalyticsCharts.jsx
+++ b/src/components/analytics/AnalyticsCharts.jsx
@@ -2,8 +2,8 @@ import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { logError } from '@edx/frontend-platform/logging';
 import url from 'url';
+import { Container } from '@edx/paragon';
 import LoadingMessage from '../LoadingMessage';
-import ErrorPage from '../ErrorPage';
 import { configuration } from '../../config';
 
 import AnalyticsApiService from './data/service';
@@ -42,9 +42,13 @@ export default function AnalyticsCharts({ enterpriseId }) {
   useEffect(() => {
     setIsLoading(true);
     AnalyticsApiService.fetchTableauToken({ enterpriseId })
-      .then((response) => {
+      .then((response) => { // eslint-disable-line consistent-return
         setIsLoading(false);
         setTokenUsedOnce(false);
+        if (response.data === '-1') {
+          // tableau returns '-1' when user cannot be assigned a valid ticket because of license issues or bad request
+          return Promise.reject(new Error('Ticket returned by tableau is invalid.'));
+        }
         initViz(response.data);
       })
       .catch((err) => {
@@ -59,10 +63,16 @@ export default function AnalyticsCharts({ enterpriseId }) {
   }
   if (error) {
     return (
-      <ErrorPage
-        status={error.response && error.response.status}
-        message={error.message}
-      />
+      <Container size="lg" className="mt-5">
+        <div style={{ textAlign: 'center' }}>
+          <h2>
+            We are updating our servers! We apologize for the interruption.
+          </h2>
+          <p>
+            If you need something from here urgently, reach out to your customer success representative.
+          </p>
+        </div>
+      </Container>
     );
   }
 


### PR DESCRIPTION
# Description
We are switching from Tableau to Plotly and this PR adds a maintenance page. This page will be shown when the license expires for Tableau. 

<img width="1593" alt="Screenshot 2022-10-20 at 2 46 52 PM" src="https://user-images.githubusercontent.com/106396899/196916323-33a14344-75f9-42c1-bf5d-8ea17bf7a5c6.png">

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
