### PR TITLE
fix: ensure enterprise curation config loading state is set to false if feature is disabled

### DIFF
--- a/src/components/EnterpriseApp/data/hooks/useEnterpriseCuration.js
+++ b/src/components/EnterpriseApp/data/hooks/useEnterpriseCuration.js
@@ -47,7 +47,7 @@ function useEnterpriseCuration({ enterpriseId, curationTitleForCreation }) {
   );
 
   useEffect(() => {
-    if (!enterpriseId) {
+    if (!enterpriseId || !config.FEATURE_CONTENT_HIGHLIGHTS) {
       setIsLoading(false);
       return;
     }
@@ -65,10 +65,7 @@ function useEnterpriseCuration({ enterpriseId, curationTitleForCreation }) {
         setIsLoading(false);
       }
     };
-
-    if (config.FEATURE_CONTENT_HIGHLIGHTS) {
-      getOrCreateConfiguration();
-    }
+    getOrCreateConfiguration();
   }, [
     enterpriseId,
     getEnterpriseCuration,


### PR DESCRIPTION
Ensures the loading state gets reset to `false` if `FEATURE_CONTENT_HIGHLIGHT` is disabled.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
