### PR TITLE
Replace cookies with `localStorage` for alerts and product tour dismissal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
         "enzyme-adapter-react-16": "1.15.6",
         "husky": "0.14.3",
         "identity-obj-proxy": "3.0.0",
+        "jest-localstorage-mock": "^2.4.22",
         "postcss": "8.1.0",
         "react-dev-utils": "11.0.4",
         "react-test-renderer": "16.13.1",
@@ -16352,6 +16353,15 @@
       "dev": true,
       "engines": {
         "node": ">= 10.14.2"
+      }
+    },
+    "node_modules/jest-localstorage-mock": {
+      "version": "2.4.22",
+      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.22.tgz",
+      "integrity": "sha512-60PWSDFQOS5v7JzSmYLM3dPLg0JLl+2Vc4lIEz/rj2yrXJzegsFLn7anwc5IL0WzJbBa/Las064CHbFg491/DQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.16.0"
       }
     },
     "node_modules/jest-matcher-utils": {
@@ -38442,6 +38452,12 @@
           "dev": true
         }
       }
+    },
+    "jest-localstorage-mock": {
+      "version": "2.4.22",
+      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.22.tgz",
+      "integrity": "sha512-60PWSDFQOS5v7JzSmYLM3dPLg0JLl+2Vc4lIEz/rj2yrXJzegsFLn7anwc5IL0WzJbBa/Las064CHbFg491/DQ==",
+      "dev": true
     },
     "jest-matcher-utils": {
       "version": "29.3.1",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "enzyme-adapter-react-16": "1.15.6",
     "husky": "0.14.3",
     "identity-obj-proxy": "3.0.0",
+    "jest-localstorage-mock": "^2.4.22",
     "postcss": "8.1.0",
     "react-dev-utils": "11.0.4",
     "react-test-renderer": "16.13.1",

--- a/src/components/NewFeatureAlertBrowseAndRequest/NewFeatureAlertBrowseAndRequest.test.jsx
+++ b/src/components/NewFeatureAlertBrowseAndRequest/NewFeatureAlertBrowseAndRequest.test.jsx
@@ -47,24 +47,21 @@ const NewFeatureAlertBrowseAndRequestWrapper = () => (
 );
 
 describe('<NewFeatureAlertBrowseAndRequest/>', () => {
+  beforeEach(() => {
+    global.localStorage.clear();
+    jest.clearAllMocks();
+  });
+
   afterEach(() => { cleanup(); });
 
-  it('if cookie is found, alert is hidden', () => {
-    const cookieName = generateBrowseAndRequestAlertCookieName(ENTERPRISE_ID);
-    Object.defineProperty(window.document, 'cookie', {
-      writable: true,
-      value: `${cookieName}=true`,
-    });
+  it('if localStorage record is found, alert is hidden', () => {
+    const localStorageItemName = generateBrowseAndRequestAlertCookieName(ENTERPRISE_ID);
+    global.localStorage.setItem(localStorageItemName, true);
     render(<NewFeatureAlertBrowseAndRequestWrapper />);
     expect(screen.queryByText(BROWSE_AND_REQUEST_ALERT_TEXT)).toBeFalsy();
   });
 
-  it('show alert, if no cookie is found', () => {
-    const wrongCookieName = generateBrowseAndRequestAlertCookieName('foo');
-    Object.defineProperty(window.document, 'cookie', {
-      writable: true,
-      value: `${wrongCookieName}=true`,
-    });
+  it('show alert, if no localStorage record is found', () => {
     render(<NewFeatureAlertBrowseAndRequestWrapper />);
     expect(screen.queryByText(BROWSE_AND_REQUEST_ALERT_TEXT)).toBeTruthy();
   });

--- a/src/components/NewFeatureAlertBrowseAndRequest/index.jsx
+++ b/src/components/NewFeatureAlertBrowseAndRequest/index.jsx
@@ -3,8 +3,8 @@ import { Alert, Button } from '@edx/paragon';
 import Cookies from 'universal-cookie';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-
 import { useHistory } from 'react-router-dom';
+
 import {
   BROWSE_AND_REQUEST_ALERT_COOKIE_PREFIX,
   BROWSE_AND_REQUEST_ALERT_TEXT,
@@ -12,6 +12,7 @@ import {
 } from '../subscriptions/data/constants';
 import { ROUTE_NAMES } from '../EnterpriseApp/data/constants';
 import { SETTINGS_TABS_VALUES } from '../settings/data/constants';
+import { COOKIE_DISMISS_MAX_EXPIRY_DATE } from '../../data/constants';
 
 const cookies = new Cookies();
 
@@ -33,11 +34,7 @@ const NewFeatureAlertBrowseAndRequest = ({ enterpriseId, enterpriseSlug }) => {
    */
   const handleClose = () => {
     setShowAlert(false);
-    cookies.set(
-      browseAndRequestAlertCookieName,
-      true,
-      { sameSite: 'strict' },
-    );
+    cookies.set(browseAndRequestAlertCookieName, true, { expires: COOKIE_DISMISS_MAX_EXPIRY_DATE });
   };
 
   const history = useHistory();

--- a/src/components/NewFeatureAlertBrowseAndRequest/index.jsx
+++ b/src/components/NewFeatureAlertBrowseAndRequest/index.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { Alert, Button } from '@edx/paragon';
-import Cookies from 'universal-cookie';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { useHistory } from 'react-router-dom';
@@ -12,9 +11,6 @@ import {
 } from '../subscriptions/data/constants';
 import { ROUTE_NAMES } from '../EnterpriseApp/data/constants';
 import { SETTINGS_TABS_VALUES } from '../settings/data/constants';
-import { COOKIE_DISMISS_MAX_EXPIRY_DATE } from '../../data/constants';
-
-const cookies = new Cookies();
 
 /**
  * Generates string use to identify cookie
@@ -25,7 +21,7 @@ export const generateBrowseAndRequestAlertCookieName = (enterpriseId) => `${BROW
 
 const NewFeatureAlertBrowseAndRequest = ({ enterpriseId, enterpriseSlug }) => {
   const browseAndRequestAlertCookieName = generateBrowseAndRequestAlertCookieName(enterpriseId);
-  const hideAlert = cookies.get(browseAndRequestAlertCookieName);
+  const hideAlert = global.localStorage.getItem(browseAndRequestAlertCookieName);
 
   const [showAlert, setShowAlert] = useState(!hideAlert);
 
@@ -34,7 +30,7 @@ const NewFeatureAlertBrowseAndRequest = ({ enterpriseId, enterpriseSlug }) => {
    */
   const handleClose = () => {
     setShowAlert(false);
-    cookies.set(browseAndRequestAlertCookieName, true, { expires: COOKIE_DISMISS_MAX_EXPIRY_DATE });
+    global.localStorage.setItem(browseAndRequestAlertCookieName, true);
   };
 
   const history = useHistory();

--- a/src/components/ProductTours/ProductTours.jsx
+++ b/src/components/ProductTours/ProductTours.jsx
@@ -9,7 +9,7 @@ import { features } from '../../config';
 import portalAppearanceTour from './portalAppearanceTour';
 import learnerCreditTour from './learnerCreditTour';
 import highlightsTour from './highlightsTour';
-import disableAll, { filterCheckpoints } from './data/utils';
+import { disableAll, filterCheckpoints } from './data/utils';
 
 import {
   useBrowseAndRequestTour, usePortalAppearanceTour, useLearnerCreditTour, useHighlightsTour,

--- a/src/components/ProductTours/browseAndRequestTour.jsx
+++ b/src/components/ProductTours/browseAndRequestTour.jsx
@@ -9,7 +9,8 @@ import {
   BROWSE_AND_REQUEST_ON_END_EVENT_NAME,
   TOUR_TARGETS,
 } from './constants';
-import disableAll from './data/utils';
+import { disableAll } from './data/utils';
+import { COOKIE_DISMISS_MAX_EXPIRY_DATE } from '../../data/constants';
 
 const cookies = new Cookies();
 
@@ -17,11 +18,7 @@ const browseAndRequestTour = ({
   enterpriseSlug,
 }) => {
   const disableTour = () => {
-    cookies.set(
-      BROWSE_AND_REQUEST_TOUR_COOKIE_NAME,
-      true,
-      { sameSite: 'strict' },
-    );
+    cookies.set(BROWSE_AND_REQUEST_TOUR_COOKIE_NAME, true, { expires: COOKIE_DISMISS_MAX_EXPIRY_DATE });
   };
 
   const handleAdvanceTour = () => {

--- a/src/components/ProductTours/browseAndRequestTour.jsx
+++ b/src/components/ProductTours/browseAndRequestTour.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
-import Cookies from 'universal-cookie';
 
 import {
   BROWSE_AND_REQUEST_TOUR_COOKIE_NAME,
@@ -10,15 +9,12 @@ import {
   TOUR_TARGETS,
 } from './constants';
 import { disableAll } from './data/utils';
-import { COOKIE_DISMISS_MAX_EXPIRY_DATE } from '../../data/constants';
-
-const cookies = new Cookies();
 
 const browseAndRequestTour = ({
   enterpriseSlug,
 }) => {
   const disableTour = () => {
-    cookies.set(BROWSE_AND_REQUEST_TOUR_COOKIE_NAME, true, { expires: COOKIE_DISMISS_MAX_EXPIRY_DATE });
+    global.localStorage.setItem(BROWSE_AND_REQUEST_TOUR_COOKIE_NAME, true);
   };
 
   const handleAdvanceTour = () => {

--- a/src/components/ProductTours/data/hooks.js
+++ b/src/components/ProductTours/data/hooks.js
@@ -1,5 +1,4 @@
 import { useContext, useState } from 'react';
-import Cookies from 'universal-cookie';
 import {
   BROWSE_AND_REQUEST_TOUR_COOKIE_NAME,
   PORTAL_APPEARANCE_TOUR_COOKIE_NAME,
@@ -9,10 +8,8 @@ import {
 import { SubsidyRequestsContext } from '../../subsidy-requests';
 import { EnterpriseSubsidiesContext } from '../../EnterpriseSubsidiesContext';
 
-const cookies = new Cookies();
-
 export const usePortalAppearanceTour = ({ enablePortalAppearance }) => {
-  const dismissedLearnerCreditTourCookie = cookies.get(PORTAL_APPEARANCE_TOUR_COOKIE_NAME);
+  const dismissedLearnerCreditTourCookie = global.localStorage.getItem(PORTAL_APPEARANCE_TOUR_COOKIE_NAME);
   // Only show tour if feature is enabled, hide cookie is undefined or false or not in the settings page
   const showPortalAppearanceTour = enablePortalAppearance && !dismissedLearnerCreditTourCookie;
   const [portalAppearanceTourEnabled, setPortalAppearanceTourEnabled] = useState(showPortalAppearanceTour);
@@ -23,7 +20,7 @@ export const useBrowseAndRequestTour = ({
   enableLearnerPortal,
 }) => {
   const { subsidyRequestConfiguration, enterpriseSubsidyTypesForRequests } = useContext(SubsidyRequestsContext);
-  const dismissedBrowseAndRequestTourCookie = cookies.get(BROWSE_AND_REQUEST_TOUR_COOKIE_NAME);
+  const dismissedBrowseAndRequestTourCookie = global.localStorage.getItem(BROWSE_AND_REQUEST_TOUR_COOKIE_NAME);
   // Only show tour if the enterprise is eligible for the feature, browse and request tour cookie is undefined or false,
   // not in settings page, and subsidy requests are not already enabled
   const showBrowseAndRequestTour = enableLearnerPortal && enterpriseSubsidyTypesForRequests.length > 0
@@ -35,7 +32,7 @@ export const useBrowseAndRequestTour = ({
 
 export const useLearnerCreditTour = () => {
   const { canManageLearnerCredit } = useContext(EnterpriseSubsidiesContext);
-  const dismissedLearnerCreditTourCookie = cookies.get(LEARNER_CREDIT_COOKIE_NAME);
+  const dismissedLearnerCreditTourCookie = global.localStorage.getItem(LEARNER_CREDIT_COOKIE_NAME);
   // Only show tour if feature is enabled, the enterprise is eligible for the feature,
   // hide cookie is undefined or false, not in learner credit page
   const showLearnerCreditTour = canManageLearnerCredit && !dismissedLearnerCreditTourCookie;
@@ -45,7 +42,7 @@ export const useLearnerCreditTour = () => {
 };
 
 export const useHighlightsTour = (enableHighlights) => {
-  const dismissedHighlightsTourCookie = cookies.get(HIGHLIGHTS_COOKIE_NAME);
+  const dismissedHighlightsTourCookie = global.localStorage.getItem(HIGHLIGHTS_COOKIE_NAME);
   // Only show tour if feature is enabled, hide cookie is undefined or false or not in the settings page
   const showHighlightsTour = enableHighlights && !dismissedHighlightsTourCookie;
   const [highlightsTourEnabled, setHighlightsTourEnabled] = useState(showHighlightsTour);

--- a/src/components/ProductTours/data/utils.js
+++ b/src/components/ProductTours/data/utils.js
@@ -1,5 +1,7 @@
 import Cookies from 'universal-cookie';
+
 import { COOKIE_NAMES } from '../constants';
+import { COOKIE_DISMISS_MAX_EXPIRY_DATE } from '../../../data/constants';
 
 const cookies = new Cookies();
 
@@ -16,9 +18,9 @@ export function filterCheckpoints(checkpoints, enabledFeatures) {
 }
 
 // Enable all cookies when onDismiss is called to ensure that the tour is not shown again
-export default function disableAll() {
+export function disableAll() {
   // set all cookies to true to ensure that the tour checkpoints are not shown again
   Object.keys(COOKIE_NAMES).forEach((key) => {
-    cookies.set(COOKIE_NAMES[key], true, { sameSite: 'strict' });
+    cookies.set(COOKIE_NAMES[key], true, { expires: COOKIE_DISMISS_MAX_EXPIRY_DATE });
   });
 }

--- a/src/components/ProductTours/data/utils.js
+++ b/src/components/ProductTours/data/utils.js
@@ -1,9 +1,4 @@
-import Cookies from 'universal-cookie';
-
 import { COOKIE_NAMES } from '../constants';
-import { COOKIE_DISMISS_MAX_EXPIRY_DATE } from '../../../data/constants';
-
-const cookies = new Cookies();
 
 // Filter enabled features prescreened for cookie to populate tour array
 export function filterCheckpoints(checkpoints, enabledFeatures) {
@@ -21,6 +16,6 @@ export function filterCheckpoints(checkpoints, enabledFeatures) {
 export function disableAll() {
   // set all cookies to true to ensure that the tour checkpoints are not shown again
   Object.keys(COOKIE_NAMES).forEach((key) => {
-    cookies.set(COOKIE_NAMES[key], true, { expires: COOKIE_DISMISS_MAX_EXPIRY_DATE });
+    global.localStorage.setItem(COOKIE_NAMES[key], true);
   });
 }

--- a/src/components/ProductTours/highlightsTour.jsx
+++ b/src/components/ProductTours/highlightsTour.jsx
@@ -9,7 +9,8 @@ import {
   HIGHLIGHTS_ON_END_EVENT_NAME,
   TOUR_TARGETS,
 } from './constants';
-import disableAll from './data/utils';
+import { COOKIE_DISMISS_MAX_EXPIRY_DATE } from '../../data/constants';
+import { disableAll } from './data/utils';
 
 const cookies = new Cookies();
 
@@ -17,11 +18,7 @@ const highlightsTour = ({
   enterpriseSlug,
 }) => {
   const disableTour = () => {
-    cookies.set(
-      HIGHLIGHTS_COOKIE_NAME,
-      true,
-      { sameSite: 'strict' },
-    );
+    cookies.set(HIGHLIGHTS_COOKIE_NAME, true, { expires: COOKIE_DISMISS_MAX_EXPIRY_DATE });
   };
 
   const handleAdvanceTour = () => {

--- a/src/components/ProductTours/highlightsTour.jsx
+++ b/src/components/ProductTours/highlightsTour.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
-import Cookies from 'universal-cookie';
 
 import {
   HIGHLIGHTS_COOKIE_NAME,
@@ -9,16 +8,13 @@ import {
   HIGHLIGHTS_ON_END_EVENT_NAME,
   TOUR_TARGETS,
 } from './constants';
-import { COOKIE_DISMISS_MAX_EXPIRY_DATE } from '../../data/constants';
 import { disableAll } from './data/utils';
-
-const cookies = new Cookies();
 
 const highlightsTour = ({
   enterpriseSlug,
 }) => {
   const disableTour = () => {
-    cookies.set(HIGHLIGHTS_COOKIE_NAME, true, { expires: COOKIE_DISMISS_MAX_EXPIRY_DATE });
+    global.localStorage.setItem(HIGHLIGHTS_COOKIE_NAME, true);
   };
 
   const handleAdvanceTour = () => {

--- a/src/components/ProductTours/learnerCreditTour.jsx
+++ b/src/components/ProductTours/learnerCreditTour.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
-import Cookies from 'universal-cookie';
 
 import {
   LEARNER_CREDIT_COOKIE_NAME,
@@ -9,16 +8,13 @@ import {
   LEARNER_CREDIT_ON_END_EVENT_NAME,
   TOUR_TARGETS,
 } from './constants';
-import { COOKIE_DISMISS_MAX_EXPIRY_DATE } from '../../data/constants';
 import { disableAll } from './data/utils';
-
-const cookies = new Cookies();
 
 const learnerCreditTour = ({
   enterpriseSlug,
 }) => {
   const disableTour = () => {
-    cookies.set(LEARNER_CREDIT_COOKIE_NAME, true, { expires: COOKIE_DISMISS_MAX_EXPIRY_DATE });
+    global.localStorage.setItem(LEARNER_CREDIT_COOKIE_NAME, true);
   };
 
   const handleAdvanceTour = () => {

--- a/src/components/ProductTours/learnerCreditTour.jsx
+++ b/src/components/ProductTours/learnerCreditTour.jsx
@@ -9,7 +9,8 @@ import {
   LEARNER_CREDIT_ON_END_EVENT_NAME,
   TOUR_TARGETS,
 } from './constants';
-import disableAll from './data/utils';
+import { COOKIE_DISMISS_MAX_EXPIRY_DATE } from '../../data/constants';
+import { disableAll } from './data/utils';
 
 const cookies = new Cookies();
 
@@ -17,11 +18,7 @@ const learnerCreditTour = ({
   enterpriseSlug,
 }) => {
   const disableTour = () => {
-    cookies.set(
-      LEARNER_CREDIT_COOKIE_NAME,
-      true,
-      { sameSite: 'strict' },
-    );
+    cookies.set(LEARNER_CREDIT_COOKIE_NAME, true, { expires: COOKIE_DISMISS_MAX_EXPIRY_DATE });
   };
 
   const handleAdvanceTour = () => {

--- a/src/components/ProductTours/portalAppearanceTour.jsx
+++ b/src/components/ProductTours/portalAppearanceTour.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
-import Cookies from 'universal-cookie';
 
 import {
   PORTAL_APPEARANCE_TOUR_COOKIE_NAME,
@@ -9,16 +8,13 @@ import {
   PORTAL_APPEARANCE_ON_END_EVENT_NAME,
   TOUR_TARGETS,
 } from './constants';
-import { COOKIE_DISMISS_MAX_EXPIRY_DATE } from '../../data/constants';
 import { disableAll } from './data/utils';
-
-const cookies = new Cookies();
 
 const portalAppearanceTour = ({
   enterpriseSlug,
 }) => {
   const disableTour = () => {
-    cookies.set(PORTAL_APPEARANCE_TOUR_COOKIE_NAME, true, { expires: COOKIE_DISMISS_MAX_EXPIRY_DATE });
+    global.localStorage.setItem(PORTAL_APPEARANCE_TOUR_COOKIE_NAME, true);
   };
 
   const handleAdvanceTour = () => {

--- a/src/components/ProductTours/portalAppearanceTour.jsx
+++ b/src/components/ProductTours/portalAppearanceTour.jsx
@@ -9,7 +9,8 @@ import {
   PORTAL_APPEARANCE_ON_END_EVENT_NAME,
   TOUR_TARGETS,
 } from './constants';
-import disableAll from './data/utils';
+import { COOKIE_DISMISS_MAX_EXPIRY_DATE } from '../../data/constants';
+import { disableAll } from './data/utils';
 
 const cookies = new Cookies();
 
@@ -17,11 +18,7 @@ const portalAppearanceTour = ({
   enterpriseSlug,
 }) => {
   const disableTour = () => {
-    cookies.set(
-      PORTAL_APPEARANCE_TOUR_COOKIE_NAME,
-      true,
-      { sameSite: 'strict' },
-    );
+    cookies.set(PORTAL_APPEARANCE_TOUR_COOKIE_NAME, true, { expires: COOKIE_DISMISS_MAX_EXPIRY_DATE });
   };
 
   const handleAdvanceTour = () => {

--- a/src/components/ProductTours/tests/ProductTours.test.jsx
+++ b/src/components/ProductTours/tests/ProductTours.test.jsx
@@ -91,7 +91,7 @@ const ToursWithContext = ({
 
 const deleteCookie = (name) => {
   document.cookie = `${name}=; Path=/;  Domain=${window.location.host};`
-    + 'Expires=Thu, 01 Jan 1970 00:00:01 GMT; SameSite=None; Secure';
+    + 'Expires=Thu, 01 Jan 1970 00:00:01 GMT; SameSite=Lax; Secure';
 };
 
 describe('<ProductTours/>', () => {

--- a/src/components/ProductTours/tests/ProductTours.test.jsx
+++ b/src/components/ProductTours/tests/ProductTours.test.jsx
@@ -15,9 +15,7 @@ import { features } from '../../../config';
 import ProductTours from '../ProductTours';
 import {
   BROWSE_AND_REQUEST_TOUR_COOKIE_NAME,
-  PORTAL_APPEARANCE_TOUR_COOKIE_NAME,
   LEARNER_CREDIT_COOKIE_NAME,
-  HIGHLIGHTS_COOKIE_NAME,
   TOUR_TARGETS,
 } from '../constants';
 import { ROUTE_NAMES } from '../../EnterpriseApp/data/constants';
@@ -89,20 +87,15 @@ const ToursWithContext = ({
   </Provider>
 );
 
-const deleteCookie = (name) => {
-  document.cookie = `${name}=; Path=/;  Domain=${window.location.host};`
-    + 'Expires=Thu, 01 Jan 1970 00:00:01 GMT; SameSite=Lax; Secure';
-};
-
 describe('<ProductTours/>', () => {
   beforeEach(() => {
     mergeConfig({ FEATURE_CONTENT_HIGHLIGHTS: false });
     mergeConfig({ FEATURE_LEARNER_CREDIT_MANAGEMENT: false });
-    deleteCookie(BROWSE_AND_REQUEST_TOUR_COOKIE_NAME);
-    deleteCookie(LEARNER_CREDIT_COOKIE_NAME);
-    deleteCookie(PORTAL_APPEARANCE_TOUR_COOKIE_NAME);
-    deleteCookie(HIGHLIGHTS_COOKIE_NAME);
+
+    global.localStorage.clear();
+    jest.clearAllMocks();
   });
+
   afterEach(() => cleanup());
 
   describe('portal appearance tour', () => {
@@ -137,11 +130,8 @@ describe('<ProductTours/>', () => {
       expect(screen.queryByText('browse for courses', { exact: false })).toBeFalsy();
     });
 
-    it('is not shown when feature is enabled and cookie found ', () => {
-      Object.defineProperty(window.document, 'cookie', {
-        writable: true,
-        value: `${BROWSE_AND_REQUEST_TOUR_COOKIE_NAME}=true`,
-      });
+    it('is not shown when feature is enabled and localStorage record found ', () => {
+      global.localStorage.setItem(BROWSE_AND_REQUEST_TOUR_COOKIE_NAME, true);
       render(<ToursWithContext />);
       expect(screen.queryByText('New Feature')).toBeFalsy();
     });
@@ -169,6 +159,8 @@ describe('<ProductTours/>', () => {
 
   describe('learner credit management tour', () => {
     beforeEach(() => {
+      mergeConfig({ FEATURE_LEARNER_CREDIT_MANAGEMENT: true });
+
       // hide browse and request tour
       Object.defineProperty(window.document, 'cookie', {
         writable: true,
@@ -177,26 +169,18 @@ describe('<ProductTours/>', () => {
     });
 
     it('is shown if Learner Credit Management feature is on, enterprise has subsidy', () => {
-      mergeConfig({ FEATURE_LEARNER_CREDIT_MANAGEMENT: true });
-
       render(<ToursWithContext canManageLearnerCredit />);
       expect(screen.queryByText('New Feature')).toBeTruthy();
     });
 
-    it('is not shown if cookie is present', () => {
-      mergeConfig({ FEATURE_LEARNER_CREDIT_MANAGEMENT: true });
-
-      Object.defineProperty(window.document, 'cookie', {
-        writable: true,
-        value: `${BROWSE_AND_REQUEST_TOUR_COOKIE_NAME}=true;${LEARNER_CREDIT_COOKIE_NAME}=true`,
-      });
-
+    it('is not shown if localStorage record is present', () => {
+      global.localStorage.setItem(BROWSE_AND_REQUEST_TOUR_COOKIE_NAME, true);
+      global.localStorage.setItem(LEARNER_CREDIT_COOKIE_NAME, true);
       render(<ToursWithContext canManageLearnerCredit />);
       expect(screen.queryByText('New Feature')).toBeFalsy();
     });
 
-    it('is is shown if in Learner Credit page', () => {
-      mergeConfig({ FEATURE_LEARNER_CREDIT_MANAGEMENT: true });
+    it('is shown if in Learner Credit page', () => {
       render(<ToursWithContext pathname={LEARNER_CREDIT_PAGE_LOCATION} canManageLearnerCredit />);
       expect(screen.queryByText('New Feature')).toBeTruthy();
     });

--- a/src/components/subscriptions/expiration/SubscriptionExpiringModal.jsx
+++ b/src/components/subscriptions/expiration/SubscriptionExpiringModal.jsx
@@ -7,6 +7,7 @@ import { SubscriptionDetailContext } from '../SubscriptionDetailContextProvider'
 import { getSubscriptionExpiringCookieName } from '../data/utils';
 import ContactCustomerSupportButton from '../../ContactCustomerSupportButton';
 import { formatTimestamp } from '../../../utils';
+import { COOKIE_DISMISS_MAX_EXPIRY_DATE } from '../../../data/constants';
 
 export const EXPIRING_MODAL_TITLE = 'Renew your expiring subscription';
 
@@ -27,14 +28,7 @@ const SubscriptionExpiringModal = ({
         enterpriseId,
       });
       // Mark that the user has seen this range's expiration modal when they close it
-      cookies.set(
-        seenCurrentExpirationModalCookieName,
-        true,
-        // Cookies without the `sameSite` attribute are rejected if they are missing the `secure`
-        // attribute. See
-        // https//developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
-        { sameSite: 'strict' },
-      );
+      cookies.set(seenCurrentExpirationModalCookieName, true, { expires: COOKIE_DISMISS_MAX_EXPIRY_DATE });
     }
     onClose();
   };

--- a/src/components/subscriptions/expiration/SubscriptionExpiringModal.jsx
+++ b/src/components/subscriptions/expiration/SubscriptionExpiringModal.jsx
@@ -1,13 +1,11 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import Cookies from 'universal-cookie';
 import { ActionRow, ModalDialog } from '@edx/paragon';
 
 import { SubscriptionDetailContext } from '../SubscriptionDetailContextProvider';
 import { getSubscriptionExpiringCookieName } from '../data/utils';
 import ContactCustomerSupportButton from '../../ContactCustomerSupportButton';
 import { formatTimestamp } from '../../../utils';
-import { COOKIE_DISMISS_MAX_EXPIRY_DATE } from '../../../data/constants';
 
 export const EXPIRING_MODAL_TITLE = 'Renew your expiring subscription';
 
@@ -22,13 +20,12 @@ const SubscriptionExpiringModal = ({
 
   const handleClose = () => {
     if (expirationThreshold) {
-      const cookies = new Cookies();
       const seenCurrentExpirationModalCookieName = getSubscriptionExpiringCookieName({
         expirationThreshold,
         enterpriseId,
       });
       // Mark that the user has seen this range's expiration modal when they close it
-      cookies.set(seenCurrentExpirationModalCookieName, true, { expires: COOKIE_DISMISS_MAX_EXPIRY_DATE });
+      global.localStorage.setItem(seenCurrentExpirationModalCookieName, true);
     }
     onClose();
   };

--- a/src/data/constants/index.js
+++ b/src/data/constants/index.js
@@ -1,8 +1,0 @@
-/* eslint-disable import/prefer-default-export */
-
-/**
- * Maximum timestamp supported by browsers that won't
- * https://stackoverflow.com/questions/3290424/set-a-cookie-to-never-expire
- */
-export const COOKIE_DISMISS_MAX_EXPIRY = 2147483647; // 2038-01-19 03:14:07 GMT
-export const COOKIE_DISMISS_MAX_EXPIRY_DATE = new Date(COOKIE_DISMISS_MAX_EXPIRY * 1000).toUTCString();

--- a/src/data/constants/index.js
+++ b/src/data/constants/index.js
@@ -1,0 +1,8 @@
+/* eslint-disable import/prefer-default-export */
+
+/**
+ * Maximum timestamp supported by browsers that won't
+ * https://stackoverflow.com/questions/3290424/set-a-cookie-to-never-expire
+ */
+export const COOKIE_DISMISS_MAX_EXPIRY = 2147483647; // 2038-01-19 03:14:07 GMT
+export const COOKIE_DISMISS_MAX_EXPIRY_DATE = new Date(COOKIE_DISMISS_MAX_EXPIRY * 1000).toUTCString();

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file */
 /* eslint-disable import/no-extraneous-dependencies */
 import axios from 'axios';
 import Enzyme from 'enzyme';
@@ -5,6 +6,8 @@ import Adapter from 'enzyme-adapter-react-16';
 import MockAdapter from 'axios-mock-adapter';
 import ResizeObserverPolyfill from 'resize-observer-polyfill';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
+import 'jest-localstorage-mock';
 
 Enzyme.configure({ adapter: new Adapter() });
 


### PR DESCRIPTION
# Description

https://2u-internal.atlassian.net/browse/ENT-6529

Replaces cookies with `localStorage` so it doesn't need to have an explicit expiration, as is required by cookies.

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
