### PR TITLE
feat: Show more user-friendly error message for sync failures

### DIFF
--- a/src/components/settings/SettingsLMSTab/ErrorReporting/tests/ErrorReporting.test.jsx
+++ b/src/components/settings/SettingsLMSTab/ErrorReporting/tests/ErrorReporting.test.jsx
@@ -59,9 +59,9 @@ const contentSyncData = {
       {
         content_title: 'Demo4',
         content_id: 'DemoX-4',
-        sync_status: 'pending',
+        sync_status: 'error',
         sync_last_attempted_at: '2022-09-26T19:27:18.127225Z',
-        friendly_status_message: 'The request was unauthorized, check your credentials.',
+        friendly_status_message: null,
       },
       {
         content_title: 'Demo5',
@@ -191,10 +191,15 @@ describe('<ExistingLMSCardDeck />', () => {
     expect(screen.getAllByText('Pending')[0]).toBeInTheDocument();
 
     expect(screen.getByText('Demo3')).toBeInTheDocument();
-    expect(screen.getByText('Error')).toBeInTheDocument();
+    expect(screen.getAllByText('Error')[0]).toBeInTheDocument();
 
-    await waitFor(() => userEvent.click(screen.queryByText('Read')));
+    const readLinks = screen.queryAllByText('Read');
+    await waitFor(() => userEvent.click(readLinks[0]));
     expect(screen.getByText('The request was unauthorized, check your credentials.')).toBeInTheDocument();
+    // Click away to close message
+    await waitFor(() => userEvent.click(readLinks[0]));
+    await waitFor(() => userEvent.click(readLinks[1]));
+    expect(screen.getByText(/Something went wrong.*Please contact enterprise customer support/)).toBeInTheDocument();
   });
   it('paginates over data', async () => {
     const mockFetchCmits = jest.spyOn(LmsApiService, 'fetchContentMetadataItemTransmission');

--- a/src/components/settings/SettingsLMSTab/ErrorReporting/utils.jsx
+++ b/src/components/settings/SettingsLMSTab/ErrorReporting/utils.jsx
@@ -42,7 +42,7 @@ export function getSyncStatus(status, statusMessage) {
             <Popover variant="danger" id="error-popover">
               <Popover.Content>
                 <h5 className="mb-2"><Error className="text-danger-500 mr-1" />Error<br /></h5>
-                {statusMessage}
+                {statusMessage || 'Something went wrong.  Please contact enterprise customer support.'}
               </Popover.Content>
             </Popover>
       )}

--- a/src/components/settings/SettingsSSOTab/ExistingSSOConfigs.jsx
+++ b/src/components/settings/SettingsSSOTab/ExistingSSOConfigs.jsx
@@ -91,7 +91,7 @@ const ExistingSSOConfigs = ({
         Enabling single sign-on for your edX account allows quick access to
         your organization’s learning catalog
       </p>
-      <h4 className="mt-5 mb-4">Existing configurationss</h4>
+      <h4 className="mt-5 mb-4">Existing configurations</h4>
       <CardGrid
         className="mb-3 mr-3"
         columnSizes={{


### PR DESCRIPTION
[Jira Ticket](https://2u-internal.atlassian.net/browse/ENT-6531)

We want a better error message when a sync job fails with an unknown status code.

## Previous Error Message
![image](https://user-images.githubusercontent.com/322346/206025142-cf8e6a90-7a44-440f-9914-04c5956568ce.png)

## New Error Message
![image](https://user-images.githubusercontent.com/322346/206025179-ceb368fd-f0ff-4a8a-ac62-6877330db324.png)

## Misc Fixes

- 'Existing configurationss' Typo

# For all changes

- [X] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [X] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
