### PR TITLE
fix: persist selection ordering for highlights

### DIFF
--- a/src/components/ContentHighlights/HighlightStepper/ContentConfirmContentCard.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/ContentConfirmContentCard.jsx
@@ -20,7 +20,7 @@ const ContentConfirmContentCard = ({ enterpriseSlug, original }) => {
   } = original;
 
   return (
-    <div className="d-flex w-100">
+    <div className="d-flex w-100" data-testid="title-test">
       <ContentHighlightCardItem
         title={title}
         href={generateAboutPageUrl({

--- a/src/components/ContentHighlights/HighlightStepper/HighlightStepperConfirmContent.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/HighlightStepperConfirmContent.jsx
@@ -29,6 +29,7 @@ import SkeletonContentCardContainer from '../SkeletonContentCardContainer';
 export const BaseReviewContentSelections = ({
   searchResults,
   isSearchStalled,
+  currentSelectedRowIds,
 }) => {
   if (isSearchStalled) {
     return (
@@ -40,10 +41,14 @@ export const BaseReviewContentSelections = ({
   }
 
   const { hits } = camelCaseObject(searchResults);
+  // ensures content is persisted in the order it was selected from the previous step.
+  const sortedHits = hits.sort(
+    (a, b) => currentSelectedRowIds.indexOf(a.aggregationKey) - currentSelectedRowIds.indexOf(b.aggregationKey),
+  );
 
   return (
     <CardGrid columnSizes={HIGHLIGHTS_CARD_GRID_COLUMN_SIZES}>
-      {hits.map((original) => (
+      {sortedHits.map((original) => (
         <ContentConfirmContentCard key={original.aggregationKey} original={original} />))}
     </CardGrid>
   );
@@ -57,6 +62,7 @@ BaseReviewContentSelections.propTypes = {
     })).isRequired,
   }),
   isSearchStalled: PropTypes.bool.isRequired,
+  currentSelectedRowIds: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
 BaseReviewContentSelections.defaultProps = {
@@ -116,7 +122,7 @@ export const SelectedContent = ({ enterpriseId }) => {
         filters={algoliaFilters}
         hitsPerPage={MAX_CONTENT_ITEMS_PER_HIGHLIGHT_SET}
       />
-      <ReviewContentSelections />
+      <ReviewContentSelections currentSelectedRowIds={currentSelectedRowIds} />
     </InstantSearch>
   );
 };

--- a/src/components/ContentHighlights/HighlightStepper/tests/HighlightStepperConfirmContent.test.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/tests/HighlightStepperConfirmContent.test.jsx
@@ -100,8 +100,8 @@ describe('<HighlightStepperConfirmContent />', () => {
         <HighlightStepperConfirmContent enterpriseId={enterpriseId} />
       </HighlightStepperConfirmContentWrapper>,
     );
-    container.querySelectorAll('div[class="pgn__card-header-title-md"]').forEach((element, index) => {
-      expect(new RegExp(sortedTestCourseTitles[index]).test(element.querySelectorAll('span')[0].textContent)).toBeTruthy();
+    container.querySelectorAll('div[data-testid="title-test"]').forEach((element, index) => {
+      expect(element).toHaveTextContent(sortedTestCourseTitles[index]);
       expect(screen.getByText(sortedTestCourseTitles[index])).toBeInTheDocument();
     });
   });

--- a/src/components/ContentHighlights/HighlightStepper/tests/HighlightStepperConfirmContent.test.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/tests/HighlightStepperConfirmContent.test.jsx
@@ -51,11 +51,14 @@ const HighlightStepperConfirmContentWrapper = ({ children, currentSelectedRowIds
   );
 };
 
-testCourseData.forEach((element, index) => {
-  if (!element.objectID) {
-    testCourseData[index].objectID = index + 1;
-  }
-});
+// testCourseDataAggregation is the course keys coming from the Algolia search results
+const testCourseDataAggregation = testCourseData.map((element) => element.aggregationKey.split(':')[1]);
+// testCourseAggregationCourses is the course keys coming from the user's expected selection order
+const testCourseAggregationCourses = Object.keys(testCourseAggregation).map((element) => element.split(':')[1]);
+// returns titles of sorted course data
+const sortedTestCourseTitles = testCourseAggregationCourses.map(
+  element => testCourseData[testCourseDataAggregation.indexOf(element)].title,
+);
 
 const mockCourseData = [...testCourseData];
 jest.mock('react-instantsearch-dom', () => ({
@@ -89,6 +92,17 @@ describe('<HighlightStepperConfirmContent />', () => {
     );
     testCourseData.forEach((element) => {
       expect(screen.getByText(element.title)).toBeInTheDocument();
+    });
+  });
+  it('renders the content in the correct order based on testCourseAggregationCourses', () => {
+    const { container } = renderWithRouter(
+      <HighlightStepperConfirmContentWrapper currentSelectedRowIds={testCourseAggregation}>
+        <HighlightStepperConfirmContent enterpriseId={enterpriseId} />
+      </HighlightStepperConfirmContentWrapper>,
+    );
+    container.querySelectorAll('div[class="pgn__card-header-title-md"]').forEach((element, index) => {
+      expect(new RegExp(sortedTestCourseTitles[index]).test(element.querySelectorAll('span')[0].textContent)).toBeTruthy();
+      expect(screen.getByText(sortedTestCourseTitles[index])).toBeInTheDocument();
     });
   });
 });

--- a/src/components/ContentHighlights/data/constants.js
+++ b/src/components/ContentHighlights/data/constants.js
@@ -390,8 +390,8 @@ testCourseData.forEach((element, index) => {
 });
 
 export const testCourseAggregation = {
-  'course:HarvardX+CS50x': true,
-  'course:HarvardX+CS50P': true,
   'course:HarvardX+CS50W': true,
   'course:HarvardX+CS50AI': true,
+  'course:HarvardX+CS50P': true,
+  'course:HarvardX+CS50x': true,
 };


### PR DESCRIPTION
Adam:
Added ability to sort returned Algolia search results based on the user selection order

Hamzah:
Added a test to verify expected behavior

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
