### PR TITLE
fix: Highlight set card image cap fixed

### DIFF
--- a/src/components/ContentHighlights/ContentHighlightCardContainer.jsx
+++ b/src/components/ContentHighlights/ContentHighlightCardContainer.jsx
@@ -8,6 +8,7 @@ import HighlightSetSection from './HighlightSetSection';
 const ContentHighlightCardContainer = () => {
   const { enterpriseCuration: { enterpriseCuration } } = useContext(EnterpriseAppContext);
   const highlightSets = useHighlightSetsForCuration(enterpriseCuration);
+
   return (
     <Stack gap={4}>
       <HighlightSetSection

--- a/src/components/ContentHighlights/ContentHighlightsCardItemsContainer.jsx
+++ b/src/components/ContentHighlights/ContentHighlightsCardItemsContainer.jsx
@@ -25,12 +25,12 @@ const ContentHighlightsCardItemsContainer = ({ enterpriseSlug, isLoading, highli
   return (
     <CardGrid columnSizes={HIGHLIGHTS_CARD_GRID_COLUMN_SIZES}>
       {highlightedContent.map(({
-        uuid, title, contentType, authoringOrganizations, contentKey,
+        uuid, title, contentType, authoringOrganizations, contentKey, cardImageUrl,
       }) => (
         <ContentHighlightCardItem
           isLoading={isLoading}
           key={uuid}
-          cardImageUrl="https://picsum.photos/200/300"
+          cardImageUrl={cardImageUrl}
           title={title}
           href={generateAboutPageUrl({
             enterpriseSlug,

--- a/src/components/ContentHighlights/HighlightSetSection.jsx
+++ b/src/components/ContentHighlights/HighlightSetSection.jsx
@@ -22,6 +22,7 @@ const HighlightSetSection = ({
           uuid,
           isPublished,
           highlightedContentUuids,
+          cardImageUrl,
         }) => (
           <ContentHighlightSetCard
             key={uuid}
@@ -29,7 +30,7 @@ const HighlightSetSection = ({
             highlightSetUUID={uuid}
             isPublished={isPublished}
             itemCount={highlightedContentUuids.length}
-            imageCapSrc="https://picsum.photos/360/200/"
+            imageCapSrc={cardImageUrl}
           />
         ))}
       </CardGrid>


### PR DESCRIPTION
Add image card cap object data reference to highlight set card (previously hardcoded picsum image)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
