### PR TITLE
fix: password is required when PGP is provided and test

### DIFF
--- a/src/components/ReportingConfig/ReportingConfigForm.jsx
+++ b/src/components/ReportingConfig/ReportingConfigForm.jsx
@@ -33,7 +33,6 @@ const REQUIRED_NEW_SFTP_FEILDS = [
 ];
 const REQUIRED_NEW_EMAIL_FIELDS = [
   ...REQUIRED_EMAIL_FIELDS,
-  'encryptedPassword',
 ];
 const MONTHLY_MAX = 31;
 const MONTHLY_MIN = 1;
@@ -59,6 +58,14 @@ class ReportingConfigForm extends React.Component {
     const invalidFields = requiredFields
       .filter(field => !formData.get(field))
       .reduce((prevFields, currField) => ({ ...prevFields, [currField]: true }), {});
+
+    // Password is conditionally required only when pgp key will not be present
+    // and delivery method is email
+    if (!formData.get('pgpEncryptionKey') && formData.get('deliveryMethod') === 'email') {
+      if (!formData.get('encryptedPassword')) {
+        invalidFields.encryptedPassword = true;
+      }
+    }
     return invalidFields;
   };
 

--- a/src/components/ReportingConfig/ReportingConfigForm.test.jsx
+++ b/src/components/ReportingConfig/ReportingConfigForm.test.jsx
@@ -286,26 +286,6 @@ describe('<ReportingConfigForm />', () => {
       wrapper.find('select#enterpriseCustomerCatalogs').instance().value,
     ).toEqual('test-enterprise-customer-catalog');
   });
-  it('Submit enterprise uuid upon report config creation', async () => {
-    const wrapper = mount((
-      <ReportingConfigForm
-        config={defaultConfig}
-        createConfig={createConfig}
-        updateConfig={updateConfig}
-        availableCatalogs={availableCatalogs}
-        reportingConfigTypes={reportingConfigTypes}
-        enterpriseCustomerUuid={enterpriseCustomerUuid}
-      />
-    ));
-    const flushPromises = () => new Promise(setImmediate);
-    const formData = new FormData();
-    Object.entries(defaultConfig).forEach(([key, value]) => {
-      formData.append(key, value);
-    });
-    wrapper.instance().handleSubmit(formData, null);
-    await act(() => flushPromises());
-    expect(createConfig.mock.calls[0][0].get('enterprise_customer_id')).toEqual(enterpriseCustomerUuid);
-  });
   it('handles API response errors correctly.', async () => {
     defaultConfig.pgpEncryptionKey = 'invalid-key';
     const mock = jest.fn();
@@ -341,5 +321,71 @@ describe('<ReportingConfigForm />', () => {
 
     wrapper.instance().handleAPIErrorResponse(null);
     expect(mock).not.toHaveBeenCalled();
+  });
+  it('Submit if PGP key is present and password is empty and delivery method is email', async () => {
+    const config = { ...defaultConfig };
+    config.deliveryMethod = 'email';
+    config.pgpEncryptionKey = 'some-pgp-key';
+    config.encryptedPassword = '';
+    const wrapper = mount((
+      <ReportingConfigForm
+        config={config}
+        createConfig={createConfig}
+        updateConfig={updateConfig}
+        availableCatalogs={availableCatalogs}
+        reportingConfigTypes={reportingConfigTypes}
+        enterpriseCustomerUuid={enterpriseCustomerUuid}
+      />
+    ));
+    const flushPromises = () => new Promise(setImmediate);
+    const formData = new FormData();
+    Object.entries(config).forEach(([key, value]) => {
+      formData.append(key, value);
+    });
+    wrapper.instance().handleSubmit(formData, null);
+    await act(() => flushPromises());
+    expect(createConfig.mock.calls[0][0].get('enterprise_customer_id')).toEqual(enterpriseCustomerUuid);
+  });
+  it('Do not Submit if PGP key and password is empty and delivery method is email', async () => {
+    const config = { ...defaultConfig };
+    config.pgpEncryptionKey = '';
+    config.encryptedPassword = '';
+    const wrapper = mount((
+      <ReportingConfigForm
+        config={config}
+        createConfig={createConfig}
+        updateConfig={updateConfig}
+        availableCatalogs={availableCatalogs}
+        reportingConfigTypes={reportingConfigTypes}
+        enterpriseCustomerUuid={enterpriseCustomerUuid}
+      />
+    ));
+    const formData = new FormData();
+    Object.entries(config).forEach(([key, value]) => {
+      formData.append(key, value);
+    });
+    wrapper.instance().handleSubmit(formData, null);
+    wrapper.find('.form-control').forEach(input => input.simulate('blur'));
+    expect(wrapper.find('input#encryptedPassword').hasClass('is-invalid')).toBeTruthy();
+  });
+  it('Submit enterprise uuid upon report config creation', async () => {
+    const wrapper = mount((
+      <ReportingConfigForm
+        config={defaultConfig}
+        createConfig={createConfig}
+        updateConfig={updateConfig}
+        availableCatalogs={availableCatalogs}
+        reportingConfigTypes={reportingConfigTypes}
+        enterpriseCustomerUuid={enterpriseCustomerUuid}
+      />
+    ));
+    const flushPromises = () => new Promise(setImmediate);
+    const formData = new FormData();
+    Object.entries(defaultConfig).forEach(([key, value]) => {
+      formData.append(key, value);
+    });
+    wrapper.instance().handleSubmit(formData, null);
+    await act(() => flushPromises());
+    expect(createConfig.mock.calls[0][0].get('enterprise_customer_id')).toEqual(enterpriseCustomerUuid);
   });
 });


### PR DESCRIPTION
***Description***
The report configuration UI asks for a Password even when PGP key is provided.  See the screenshot attached. 
The expected behavior is that if a PGP is provided the password should not be mandatory in the UI.

![image](https://user-images.githubusercontent.com/86868918/209087586-67b03db5-ca0b-454a-9ddf-6d2f156a62c5.png)

***Solution***
Make the PGP key field required. if the PGP key or password is present and all other requirements are fulfilled the form will be submitted successfully. Also, write a test case for it.

***After Changing***

<img width="1097" alt="Screenshot 2022-12-22 at 1 21 12 PM" src="https://user-images.githubusercontent.com/86868918/209090104-9235cb7d-9047-4904-b771-d9cbcb545d50.png">

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirms screenshots
