### PR TITLE
fix: formats datatable footer into single component w/ actionRow

### DIFF
--- a/src/components/ContentHighlights/ContentHighlightCardItem.jsx
+++ b/src/components/ContentHighlights/ContentHighlightCardItem.jsx
@@ -29,7 +29,7 @@ const ContentHighlightCardItem = ({
     );
   }
   return (
-    <Card isLoading={isLoading}>
+    <Card variant={contentType !== 'course' && 'dark'} isLoading={isLoading}>
       <Card.ImageCap
         src={cardInfo.cardImgSrc}
         srcAlt=""

--- a/src/components/ContentHighlights/HighlightStepper/HighlightStepperSelectContentSearch.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/HighlightStepperSelectContentSearch.jsx
@@ -156,7 +156,6 @@ const BaseHighlightStepperSelectContentDataTable = ({
       {currentView === 'list' && <DataTable.Table /> }
       <DataTable.EmptyTable content="No results found" />
       <DataTable.TableFooter>
-        <DataTable.RowStatus />
         <SelectContentSearchPagination />
       </DataTable.TableFooter>
     </DataTable>

--- a/src/components/ContentHighlights/HighlightStepper/SelectContentSearchPagination.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/SelectContentSearchPagination.jsx
@@ -1,19 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connectPagination } from 'react-instantsearch-dom';
-import { Pagination } from '@edx/paragon';
+import { ActionRow, Pagination, DataTable } from '@edx/paragon';
 
 export const BaseSearchPagination = ({
   nbPages,
   currentRefinement,
   refine,
 }) => (
-  <>
+  <ActionRow>
+    <DataTable.RowStatus />
+    <ActionRow.Spacer />
     <Pagination.Reduced
       currentPage={currentRefinement}
       handlePageSelect={(pageNum) => refine(pageNum)}
       pageCount={nbPages}
     />
+    <ActionRow.Spacer />
     <Pagination
       variant="minimal"
       currentPage={currentRefinement}
@@ -21,7 +24,7 @@ export const BaseSearchPagination = ({
       paginationLabel="select content pagination"
       onPageSelect={(pageNum) => refine(pageNum)}
     />
-  </>
+  </ActionRow>
 );
 
 BaseSearchPagination.propTypes = {


### PR DESCRIPTION
Quick fix that moves datatable format into a single component in preparation for the paragon pagination fix
Also adds conditional for variant in card items to account for programs and pathway card styling.

![Screen Shot 2022-12-23 at 9 59 55 AM](https://user-images.githubusercontent.com/82611798/209357020-f9f30fd5-4099-4367-9ab5-9d457583b0c5.png)
![Screen Shot 2022-12-23 at 10 06 33 AM](https://user-images.githubusercontent.com/82611798/209357182-0ef32997-f08d-4ce8-86ef-56266c76087d.png)


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
