### PR TITLE
chore: upgrade to latest paragon, removed filter criteria and updated test Id constant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@edx/frontend-enterprise-logistration": "2.1.0",
         "@edx/frontend-enterprise-utils": "2.1.0",
         "@edx/frontend-platform": "2.4.0",
-        "@edx/paragon": "20.21.1",
+        "@edx/paragon": "20.24.1",
         "@fortawesome/fontawesome-svg-core": "1.2.35",
         "@fortawesome/free-brands-svg-icons": "5.15.3",
         "@fortawesome/free-regular-svg-icons": "5.15.3",
@@ -3790,9 +3790,9 @@
       }
     },
     "node_modules/@edx/paragon": {
-      "version": "20.21.1",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.21.1.tgz",
-      "integrity": "sha512-bSpwdIfWZtipN3NH2eJ+8lWpA576vL/87iHpJCIcrOq5OiH49Fm0Q7kGI+t0s+fMZJboBxJ+eMtC2Nv7Op4Cmg==",
+      "version": "20.24.1",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.24.1.tgz",
+      "integrity": "sha512-FDkAiqfFR+dgxvKYIQs2C8p1ruYd2dy3aQrTtf1Ck6V2FDUywQrPeqmbmkcqUmQDcP4hBwwRCotPY32EX/Pe5g==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",
@@ -28901,9 +28901,9 @@
       }
     },
     "@edx/paragon": {
-      "version": "20.21.1",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.21.1.tgz",
-      "integrity": "sha512-bSpwdIfWZtipN3NH2eJ+8lWpA576vL/87iHpJCIcrOq5OiH49Fm0Q7kGI+t0s+fMZJboBxJ+eMtC2Nv7Op4Cmg==",
+      "version": "20.24.1",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.24.1.tgz",
+      "integrity": "sha512-FDkAiqfFR+dgxvKYIQs2C8p1ruYd2dy3aQrTtf1Ck6V2FDUywQrPeqmbmkcqUmQDcP4hBwwRCotPY32EX/Pe5g==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@edx/frontend-enterprise-logistration": "2.1.0",
     "@edx/frontend-enterprise-utils": "2.1.0",
     "@edx/frontend-platform": "2.4.0",
-    "@edx/paragon": "20.21.1",
+    "@edx/paragon": "20.24.1",
     "@fortawesome/fontawesome-svg-core": "1.2.35",
     "@fortawesome/free-brands-svg-icons": "5.15.3",
     "@fortawesome/free-regular-svg-icons": "5.15.3",

--- a/src/components/CodeManagement/tests/__snapshots__/ManageCodesTab.test.jsx.snap
+++ b/src/components/CodeManagement/tests/__snapshots__/ManageCodesTab.test.jsx.snap
@@ -152,11 +152,11 @@ Array [
           >
             <path
               d="M12 2L1 21h22L12 2z"
-              fill="#F0CC00"
+              fill="currentColor"
             />
             <path
               d="M13 16h-2v2h2v-2zM13 10h-2v4h2v-4z"
-              fill="#111"
+              fill="currentColor"
             />
           </svg>
         </span>

--- a/src/components/ContentHighlights/HighlightStepper/HighlightStepperSelectContentSearch.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/HighlightStepperSelectContentSearch.jsx
@@ -26,8 +26,6 @@ const selectColumn = {
   disableSortBy: true,
 };
 
-const currentEpoch = Math.round((new Date()).getTime() / 1000);
-
 const HighlightStepperSelectContent = ({ enterpriseId }) => {
   const { setCurrentSelectedRowIds } = useContentHighlightsContext();
   const currentSelectedRowIds = useContextSelector(
@@ -40,7 +38,7 @@ const HighlightStepperSelectContent = ({ enterpriseId }) => {
   );
     // TODO: replace testEnterpriseId with enterpriseID before push,
     // uncomment out import and replace with testEnterpriseId to test
-  const searchFilters = `enterprise_customer_uuids:${enterpriseId} AND advertised_course_run.upgrade_deadline > ${currentEpoch}`;
+  const searchFilters = `enterprise_customer_uuids:${enterpriseId}`;
 
   return (
     <SearchData>

--- a/src/components/ContentHighlights/data/constants.js
+++ b/src/components/ContentHighlights/data/constants.js
@@ -46,7 +46,8 @@ export const FOOTER_TEXT_BY_CONTENT_TYPE = {
 
 // Test Data for Content Highlights From this point onwards
 // Test entepriseId for Content Highlights to display card selections and confirmation
-export const testEnterpriseId = 'e783bb19-277f-479e-9c41-8b0ed31b4060';
+export const testEnterpriseId = 'f23ccd7d-fbbb-411a-824e-c2861942aac0';
+
 // Test Content Highlights data
 export const TEST_COURSE_HIGHLIGHTS_DATA = [
   {


### PR DESCRIPTION
Verified Paragon UI changes for highlights when upgrading from `20.21.1` to `20.24.1`
Updated testEnterpriseId constant to one with a more extensive catalog for a comprehensive dataset for local environments. 
Removed filter criteria from algolia search to return values that represent programs and pathways, not just courses.

![Screen Shot 2022-12-23 at 1 50 16 PM](https://user-images.githubusercontent.com/82611798/209394584-b1b11c2e-5b05-43c5-9370-27e377cbfb2f.png)
![Screen Shot 2022-12-23 at 1 51 31 PM](https://user-images.githubusercontent.com/82611798/209394609-4bb8d880-60bb-4a9b-b09b-f7dd6d81bea4.png)

# For all changes


- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
