### PR TITLE
feat: add file compression check and test

### DIFF
--- a/src/components/ReportingConfig/ReportingConfigForm.jsx
+++ b/src/components/ReportingConfig/ReportingConfigForm.jsx
@@ -45,6 +45,7 @@ class ReportingConfigForm extends React.Component {
     invalidFields: {},
     APIErrors: {},
     active: this.props.config ? this.props.config.active : false,
+    enableCompression: this.props.config ? this.props.config.enableCompression : true,
     submitState: SUBMIT_STATES.DEFAULT,
   };
 
@@ -174,6 +175,7 @@ class ReportingConfigForm extends React.Component {
       APIErrors,
       deliveryMethod,
       active,
+      enableCompression,
       submitState,
     } = this.state;
     const selectedCatalogs = (config?.enterpriseCustomerCatalogs || []).map(item => item.uuid);
@@ -353,6 +355,24 @@ class ReportingConfigForm extends React.Component {
         )}
         <div className="col">
           <ValidationFormGroup
+            for="enableCompression"
+            helpText="Specifies whether report should be compressed. Without compression files will not be password protected or encrypted."
+            invalid={!!APIErrors.enableCompression}
+            invalidMessage={APIErrors.enableCompression}
+          >
+            <label htmlFor="enableCompression">Enable Compression</label>
+            <Input
+              type="checkbox"
+              id="enableCompression"
+              name="enableCompression"
+              className="ml-3"
+              checked={enableCompression}
+              onChange={() => this.setState(prevState => ({ enableCompression: !prevState.enableCompression }))}
+            />
+          </ValidationFormGroup>
+        </div>
+        <div className="col">
+          <ValidationFormGroup
             for="enterpriseCustomerCatalogs"
             helpText="The catalogs that should be included in the report. No selection means all catalogs will be included."
           >
@@ -423,6 +443,7 @@ ReportingConfigForm.propTypes = {
   enterpriseCustomerUuid: PropTypes.string.isRequired,
   config: PropTypes.shape({
     active: PropTypes.bool,
+    enableCompression: PropTypes.bool,
     dataType: PropTypes.string,
     dayOfMonth: PropTypes.number,
     dayOfWeek: PropTypes.number,

--- a/src/components/ReportingConfig/ReportingConfigForm.test.jsx
+++ b/src/components/ReportingConfig/ReportingConfigForm.test.jsx
@@ -6,6 +6,7 @@ import ReportingConfigForm from './ReportingConfigForm';
 const defaultConfig = {
   enterpriseCustomerId: 'test-customer-uuid',
   active: true,
+  enableCompression: true,
   deliveryMethod: 'email',
   email: ['test_email@example.com'],
   emailRaw: 'test_email@example.com',
@@ -135,7 +136,24 @@ describe('<ReportingConfigForm />', () => {
     wrapper.find('.btn-outline-danger').at(0).simulate('click');
     expect(mock).toHaveBeenCalled();
   });
+  it('check the compression checkbox is render or not', () => {
+    const wrapper = mount((
+      <ReportingConfigForm
+        config={defaultConfig}
+        createConfig={createConfig}
+        updateConfig={updateConfig}
+        availableCatalogs={availableCatalogs}
+        reportingConfigTypes={reportingConfigTypes}
+        enterpriseCustomerUuid={enterpriseCustomerUuid}
+      />
+    ));
 
+    expect(wrapper.exists('#enableCompression')).toEqual(true);
+    expect(wrapper.find('#enableCompression').hostNodes().prop('checked')).toEqual(true);
+    wrapper.find('#enableCompression').hostNodes().simulate('change', { target: { checked: false } });
+    wrapper.update();
+    expect(wrapper.find('#enableCompression').hostNodes().prop('checked')).toEqual(false);
+  });
   it('renders the proper fields when changing the delivery method', () => {
     const wrapper = mount((
       <ReportingConfigForm
@@ -176,7 +194,6 @@ describe('<ReportingConfigForm />', () => {
     wrapper.find('textarea#email').simulate('blur');
     expect(wrapper.find('textarea#email').hasClass('is-invalid')).toBeTruthy();
   });
-
   it('Does not submit if hourOfDay is empty', () => {
     const config = { ...defaultConfig };
     config.hourOfDay = undefined;
@@ -193,7 +210,6 @@ describe('<ReportingConfigForm />', () => {
     wrapper.find('input#hourOfDay').simulate('blur');
     expect(wrapper.find('input#hourOfDay').hasClass('is-invalid')).toBeTruthy();
   });
-
   it('Does not submit if sftp fields are empty and deliveryMethod is sftp', () => {
     const config = { ...defaultConfig };
     config.deliveryMethod = 'sftp';


### PR DESCRIPTION
**Description**
Adding file compression option on Reporting Form. Initially, that option was only enabled by the Django admin. But now users will be able to Enable compression from UI.
Additionally, validation on the compression box is done from the backend to make it secure.

![image](https://user-images.githubusercontent.com/86868918/211327505-f53faed7-d5bb-4102-96c4-8d5a8108b17d.png)


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
