### PR TITLE
fix: pass course run id instead of key for bulk enroll

### DIFF
--- a/__mocks__/react-instantsearch-dom.jsx
+++ b/__mocks__/react-instantsearch-dom.jsx
@@ -15,8 +15,8 @@ const advertised_course_run = {
 
 /* eslint-disable camelcase */
 const fakeHits = [
-  { objectID: '1', title: 'bla', advertised_course_run, key: 'Bees101' },
-  { objectID: '2', title: 'blp', advertised_course_run, key: 'Wasps200' },
+  { objectID: '1', aggregation_key: 'course:Bees101', title: 'bla', advertised_course_run, key: 'Bees101' },
+  { objectID: '2', aggregation_key: 'course:Wasps200', title: 'blp', advertised_course_run, key: 'Wasps200' },
 ];
 /* eslint-enable camelcase */
 

--- a/src/components/BulkEnrollmentPage/CourseSearchResults.jsx
+++ b/src/components/BulkEnrollmentPage/CourseSearchResults.jsx
@@ -118,7 +118,6 @@ export const BaseCourseSearchResults = (props) => {
         id: rowId,
         values: {
           aggregationKey: rowId,
-          contentKey: rowId.split(':')[1],
         },
       }));
       coursesDispatch(setSelectedRowsAction(transformedSelectedFlatRowIds));

--- a/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.jsx
@@ -93,8 +93,9 @@ const BulkEnrollmentSubmit = ({
   const [toastMessage, setToastMessage] = useState('');
 
   const courseKeys = selectedCourses.map(
-    ({ values }) => values.contentKey,
+    ({ values, id }) => values.advertisedCourseRun?.key || id,
   );
+
   const emails = selectedEmails.map(({ values }) => values.userEmail);
   const [isErrorModalOpen, toggleErrorModalOpen, toggleErrorModalClose] = useToggle();
   const hasSelectedCoursesAndEmails = selectedEmails.length > 0 && selectedCourses.length > 0;

--- a/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.test.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.test.jsx
@@ -63,7 +63,14 @@ const selectedEmails = userEmails.map(
   (email, index) => ({ id: index, values: { userEmail: email } }),
 );
 const selectedCourses = courseNames.map(
-  (course) => ({ values: { contentKey: course } }),
+  (course) => ({
+    values: {
+      contentKey: course,
+      advertisedCourseRun: {
+        key: course,
+      },
+    },
+  }),
 );
 const bulkEnrollWithAllSelectedRows = {
   emails: [selectedEmails, emailsDispatch],
@@ -165,8 +172,7 @@ describe('BulkEnrollmentSubmit', () => {
   });
 
   it('tests button is disabled when courses are not selected but emails are', async () => {
-    const mockPromiseResolve = Promise.resolve({ data: {} });
-    LicenseManagerApiService.licenseBulkEnroll.mockReturnValue(mockPromiseResolve);
+    LicenseManagerApiService.licenseBulkEnroll.mockResolvedValue({ data: {} });
 
     render(
       <BulkEnrollmentSubmitWrapper
@@ -176,12 +182,10 @@ describe('BulkEnrollmentSubmit', () => {
     );
     const button = screen.getByTestId(FINAL_BUTTON_TEST_ID);
     expect(button).toBeDisabled();
-    await act(() => mockPromiseResolve);
   });
 
   it('tests button is disabled when emails are not selected but courses are', async () => {
-    const mockPromiseResolve = Promise.resolve({ data: {} });
-    LicenseManagerApiService.licenseBulkEnroll.mockReturnValue(mockPromiseResolve);
+    LicenseManagerApiService.licenseBulkEnroll.mockResolvedValue({ data: {} });
 
     render(
       <BulkEnrollmentSubmitWrapper
@@ -191,12 +195,10 @@ describe('BulkEnrollmentSubmit', () => {
     );
     const button = screen.getByTestId(FINAL_BUTTON_TEST_ID);
     expect(button).toBeDisabled();
-    await act(() => mockPromiseResolve);
   });
 
   it('tests passing correct data to api call', async () => {
-    const mockPromiseResolve = Promise.resolve({ data: {} });
-    LicenseManagerApiService.licenseBulkEnroll.mockReturnValue(mockPromiseResolve);
+    LicenseManagerApiService.licenseBulkEnroll.mockResolvedValue({ data: {} });
 
     render(
       <BulkEnrollmentSubmitWrapper
@@ -213,18 +215,18 @@ describe('BulkEnrollmentSubmit', () => {
       notify: true,
     };
 
-    expect(LicenseManagerApiService.licenseBulkEnroll).toHaveBeenCalledWith(
-      defaultProps.enterpriseId,
-      defaultProps.subscription.uuid,
-      expectedParams,
-    );
-    expect(logError).toBeCalledTimes(0);
-    await act(() => mockPromiseResolve);
+    await waitFor(() => {
+      expect(LicenseManagerApiService.licenseBulkEnroll).toHaveBeenCalledWith(
+        defaultProps.enterpriseId,
+        defaultProps.subscription.uuid,
+        expectedParams,
+      );
+      expect(logError).toBeCalledTimes(0);
+    });
   });
 
   it('tests notify toggle disables param to api service', async () => {
-    const mockPromiseResolve = Promise.resolve({ data: {} });
-    LicenseManagerApiService.licenseBulkEnroll.mockReturnValue(mockPromiseResolve);
+    LicenseManagerApiService.licenseBulkEnroll.mockResolvedValue({ data: {} });
 
     render(
       <BulkEnrollmentSubmitWrapper
@@ -242,18 +244,19 @@ describe('BulkEnrollmentSubmit', () => {
       course_run_keys: courseNames,
       notify: false,
     };
-    expect(LicenseManagerApiService.licenseBulkEnroll).toHaveBeenCalledWith(
-      defaultProps.enterpriseId,
-      defaultProps.subscription.uuid,
-      expectedParams,
-    );
-    expect(logError).toBeCalledTimes(0);
-    await act(() => mockPromiseResolve);
+
+    await waitFor(() => {
+      expect(LicenseManagerApiService.licenseBulkEnroll).toHaveBeenCalledWith(
+        defaultProps.enterpriseId,
+        defaultProps.subscription.uuid,
+        expectedParams,
+      );
+      expect(logError).toBeCalledTimes(0);
+    });
   });
 
   it('test component clears selected emails and courses after successful submit', async () => {
-    const mockPromiseResolve = Promise.resolve({ data: {} });
-    LicenseManagerApiService.licenseBulkEnroll.mockReturnValue(mockPromiseResolve);
+    LicenseManagerApiService.licenseBulkEnroll.mockResolvedValue({ data: {} });
 
     render(
       <BulkEnrollmentSubmitWrapper
@@ -262,24 +265,23 @@ describe('BulkEnrollmentSubmit', () => {
       />,
     );
     const button = screen.getByTestId(FINAL_BUTTON_TEST_ID);
-    await userEvent.click(button);
+    userEvent.click(button);
 
-    expect(emailsDispatch).toBeCalledTimes(1);
-    expect(coursesDispatch).toBeCalledTimes(1);
-
-    expect(emailsDispatch).toHaveBeenCalledWith(
-      clearSelectionAction(),
-    );
-    expect(coursesDispatch).toHaveBeenCalledWith(
-      clearSelectionAction(),
-    );
-    expect(logError).toBeCalledTimes(0);
-    await act(() => mockPromiseResolve);
+    await waitFor(() => {
+      expect(emailsDispatch).toBeCalledTimes(1);
+      expect(coursesDispatch).toBeCalledTimes(1);
+      expect(emailsDispatch).toHaveBeenCalledWith(
+        clearSelectionAction(),
+      );
+      expect(coursesDispatch).toHaveBeenCalledWith(
+        clearSelectionAction(),
+      );
+      expect(logError).toBeCalledTimes(0);
+    });
   });
 
   it('tests component creates toast after successful submit', async () => {
-    const mockPromiseResolve = Promise.resolve({ data: {} });
-    LicenseManagerApiService.licenseBulkEnroll.mockReturnValue(mockPromiseResolve);
+    LicenseManagerApiService.licenseBulkEnroll.mockResolvedValue({ data: {} });
 
     render(
       <BulkEnrollmentSubmitWrapper
@@ -288,11 +290,12 @@ describe('BulkEnrollmentSubmit', () => {
       />,
     );
     const button = screen.getByTestId(FINAL_BUTTON_TEST_ID);
-    await userEvent.click(button);
+    userEvent.click(button);
 
-    expect(logError).toBeCalledTimes(0);
-    expect(screen.getByText('been enrolled', { exact: false })).toBeInTheDocument();
-    await act(() => mockPromiseResolve);
+    await waitFor(() => {
+      expect(logError).toBeCalledTimes(0);
+      expect(screen.getByText('been enrolled', { exact: false })).toBeInTheDocument();
+    });
   });
 
   it('tests component logs error response on unsuccessful api call', async () => {
@@ -361,7 +364,7 @@ describe('BulkEnrollmentSubmit', () => {
       />,
     );
     const button = screen.getByTestId(FINAL_BUTTON_TEST_ID);
-    await userEvent.click(button);
+    userEvent.click(button);
     await waitFor(() => {
       expect(screen.getByText('been enrolled', { exact: false })).toBeInTheDocument();
       expect(defaultProps.onEnrollComplete).toHaveBeenCalledTimes(1);

--- a/src/components/BulkEnrollmentPage/stepper/ReviewStepCourseList.test.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/ReviewStepCourseList.test.jsx
@@ -44,6 +44,28 @@ describe('ReviewStepCourseList', () => {
     expect(screen.getByTestId('algolia__Configure')).toBeInTheDocument();
     expect(screen.getByTestId('review-list')).toBeInTheDocument();
   });
+
+  it('updates `selectedCourses` in `BulkEnrollContext` with Algolia metadata', () => {
+    render(<ReviewStepCourseListWrapper />);
+
+    expect(mockCoursesDispatch).toHaveBeenCalledTimes(1);
+    const expectedCourseSelection = {
+      id: expect.any(String),
+      values: expect.objectContaining({
+        advertisedCourseRun: expect.any(Object),
+        aggregationKey: expect.any(String),
+        key: expect.any(String),
+        objectId: expect.any(String),
+        title: expect.any(String),
+      }),
+    };
+    expect(mockCoursesDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: [expectedCourseSelection, expectedCourseSelection],
+        type: 'SET SELECTED ROWS',
+      }),
+    );
+  });
 });
 
 describe('useSearchFiltersForSelectedCourses', () => {


### PR DESCRIPTION
# Description

For bulk enrollment, ensure the course run ID is passed instead of the course key. To do this, we take the Algolia results from the "Review step" and mutate the `selectedCourses` array in the `BulkEnrollContext` reducer to include the Algolia metadata such that `BulkEnrollmentSubmit` has access to `advertisedCourseRun` to get its course run key.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
