### PR TITLE
feat: testing framework POC

### DIFF
--- a/src/components/ContentHighlights/HighlightStepper/tests/HighlightStepperSelectContentSearch.test.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/tests/HighlightStepperSelectContentSearch.test.jsx
@@ -1,22 +1,16 @@
-import React, { useState } from 'react';
+/* eslint-disable react/prop-types */
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import algoliasearch from 'algoliasearch/lite';
 import { renderWithRouter, sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
-import configureMockStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-import { Provider } from 'react-redux';
-import { IntlProvider } from '@edx/frontend-platform/i18n';
 import userEvent from '@testing-library/user-event';
-import {
-  testCourseAggregation,
-  testCourseData,
-} from '../../data/constants';
-import { ContentHighlightsContext } from '../../ContentHighlightsContext';
-import { configuration } from '../../../../config';
 import HighlightStepperSelectContent from '../HighlightStepperSelectContentSearch';
+import {
+  testCourseData,
+  ContentHighlightsContext,
+  initialStateValue,
+} from '../../../../data/tests/ContentHighlightsTestData';
+import { testCourseAggregation } from '../../data/constants';
 
-const mockStore = configureMockStore([thunk]);
 jest.mock('@edx/frontend-enterprise-utils', () => {
   const originalModule = jest.requireActual('@edx/frontend-enterprise-utils');
   return ({
@@ -24,42 +18,16 @@ jest.mock('@edx/frontend-enterprise-utils', () => {
     sendEnterpriseTrackEvent: jest.fn(),
   });
 });
-const enterpriseId = 'test-enterprise-id';
-const initialState = {
-  portalConfiguration:
-    {
-      enterpriseSlug: 'test-enterprise',
-      enterpriseId,
-    },
-};
-
-const searchClient = algoliasearch(
-  configuration.ALGOLIA.APP_ID,
-  configuration.ALGOLIA.SEARCH_API_KEY,
-);
 
 // eslint-disable-next-line react/prop-types
-const HighlightStepperSelectContentSearchWrapper = ({ children, currentSelectedRowIds = [] }) => {
-  const contextValue = useState({
-    stepperModal: {
-      isOpen: false,
-      highlightTitle: null,
-      titleStepValidationError: null,
-      currentSelectedRowIds,
-    },
-    contentHighlights: [],
-    searchClient,
-  });
-  return (
-    <IntlProvider locale="en">
-      <Provider store={mockStore(initialState)}>
-        <ContentHighlightsContext.Provider value={contextValue}>
-          {children}
-        </ContentHighlightsContext.Provider>
-      </Provider>
-    </IntlProvider>
-  );
-};
+const HighlightStepperSelectContentSearchWrapper = ({
+  children,
+  value = initialStateValue,
+}) => (
+  <ContentHighlightsContext value={value}>
+    {children}
+  </ContentHighlightsContext>
+);
 
 const mockCourseData = [...testCourseData];
 
@@ -97,7 +65,16 @@ describe('HighlightStepperSelectContentSearch', () => {
   });
   test('renders the search results with all selected', async () => {
     renderWithRouter(
-      <HighlightStepperSelectContentSearchWrapper currentSelectedRowIds={testCourseAggregation}>
+      <HighlightStepperSelectContentSearchWrapper value={
+        {
+          ...initialStateValue,
+          stepperModal: {
+            ...initialStateValue.stepperModal,
+            currentSelectedRowIds: testCourseAggregation,
+          },
+        }
+      }
+      >
         <HighlightStepperSelectContent />
       </HighlightStepperSelectContentSearchWrapper>,
     );
@@ -106,7 +83,7 @@ describe('HighlightStepperSelectContentSearch', () => {
   });
   test('sends track event on click', async () => {
     renderWithRouter(
-      <HighlightStepperSelectContentSearchWrapper currentSelectedRowIds={testCourseAggregation}>
+      <HighlightStepperSelectContentSearchWrapper>
         <HighlightStepperSelectContent />
       </HighlightStepperSelectContentSearchWrapper>,
     );

--- a/src/components/ContentHighlights/data/constants.js
+++ b/src/components/ContentHighlights/data/constants.js
@@ -398,7 +398,6 @@ export const TEST_COURSE_HIGHLIGHTS_DATA = [
     ],
   },
 ];
-
 export const testCourseData = [
   {
     aggregationKey: 'course:HarvardX+CS50x',

--- a/src/data/tests/ContentHighlightsTestData/context.js
+++ b/src/data/tests/ContentHighlightsTestData/context.js
@@ -1,0 +1,49 @@
+/* eslint-disable react/jsx-filename-extension */
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { ContentHighlightsContext as NestedContentHighlightsContext } from '../../../components/ContentHighlights/ContentHighlightsContext';
+import { searchClient } from '../constants';
+import { initialStateValue as baseInitialStateValues, BaseContext } from '../context';
+
+export const initialStateValue = {
+  stepperModal: {
+    isOpen: false,
+    highlightTitle: null,
+    titleStepValidation: null,
+    currentSelectedRowIds: [],
+  },
+  contentHighlights: [],
+  searchClient,
+};
+
+export const ContentHighlightsContext = ({
+  children,
+  initialBaseState,
+  value,
+}) => {
+  const contextValue = useState(value);
+  return (
+    <BaseContext initialState={initialBaseState}>
+      <NestedContentHighlightsContext.Provider value={contextValue}>
+        {children}
+      </NestedContentHighlightsContext.Provider>
+    </BaseContext>
+  );
+};
+
+ContentHighlightsContext.propTypes = {
+  children: PropTypes.node.isRequired,
+  initialBaseState: PropTypes.shape({
+    portalConfiguration: PropTypes.shape({
+      enterpriseSlug: PropTypes.string,
+      enterpriseName: PropTypes.string,
+      enterpriseId: PropTypes.string,
+    }),
+  }),
+  value: PropTypes.shape(),
+};
+
+ContentHighlightsContext.defaultProps = {
+  initialBaseState: baseInitialStateValues,
+  value: initialStateValue,
+};

--- a/src/data/tests/ContentHighlightsTestData/index.js
+++ b/src/data/tests/ContentHighlightsTestData/index.js
@@ -1,0 +1,16 @@
+import { testCourseHighlightsData, testCourseData } from './utils';
+import { initialStateValue, ContentHighlightsContext } from './context';
+
+const rawTestCourseData = require('./testCourseData.json');
+const rawTestCourseHighlights = require('./testCourseHighlights.json');
+const testCourseAggregation = require('./testCourseAggregation.json');
+
+export {
+  initialStateValue,
+  ContentHighlightsContext,
+  rawTestCourseData,
+  rawTestCourseHighlights,
+  testCourseAggregation,
+  testCourseData,
+  testCourseHighlightsData,
+};

--- a/src/data/tests/ContentHighlightsTestData/testCourseAggregation.json
+++ b/src/data/tests/ContentHighlightsTestData/testCourseAggregation.json
@@ -1,0 +1,6 @@
+{
+    "course:HarvardX+CS50W": true,
+    "course:HarvardX+CS50AI": true,
+    "course:HarvardX+CS50P": true,
+    "course:HarvardX+CS50x": true
+}

--- a/src/data/tests/ContentHighlightsTestData/testCourseData.json
+++ b/src/data/tests/ContentHighlightsTestData/testCourseData.json
@@ -1,0 +1,57 @@
+[
+    {
+        "aggregationKey": "course:HarvardX+CS50x",
+        "title": "CS50s Introduction to Computer Science",
+        "contentType": "course",
+        "partners": [
+            {
+                "name": "Harvard University",
+                "logoImageUrl": "https://prod-discovery.edx-cdn.org/organization/logos/44022f13-20df-4666-9111-cede3e5dc5b6-2cc39992c67a.png"
+            }
+        ],
+        "cardImageUrl": "https://prod-discovery.edx-cdn.org/media/course/image/da1b2400-322b-459b-97b0-0c557f05d017-3b9fb73b5d5d.small.jpg",
+        "originalImageUrl": "https://prod-discovery.edx-cdn.org/media/course/image/da1b2400-322b-459b-97b0-0c557f05d017-a3d1899c3344.png",
+        "firstEnrollablePaidSeatPrice": 149
+    },
+    {
+        "aggregationKey": "course:HarvardX+CS50P",
+        "title": "CS50s Introduction to Programming with Python",
+        "contentType": "course",
+        "partners": [
+            {
+                "name": "Harvard University",
+                "logoImageUrl": "https://prod-discovery.edx-cdn.org/organization/logos/44022f13-20df-4666-9111-cede3e5dc5b6-2cc39992c67a.png"
+            }
+        ],
+        "originalImageUrl": "https://prod-discovery.edx-cdn.org/media/course/image/2cc794d0-316d-42f7-bbfd-25c34e4cd5df-033e46d516c0.png",
+        "firstEnrollablePaidSeatPrice": 200
+    },
+    {
+        "aggregationKey": "course:HarvardX+CS50W",
+        "title": "CS50s Web Programming with Python and JavaScript",
+        "contentType": "course",
+        "partners": [
+            {
+                "name": "Harvard University",
+                "logoImageUrl": "https://prod-discovery.edx-cdn.org/organization/logos/44022f13-20df-4666-9111-cede3e5dc5b6-2cc39992c67a.png"
+            }
+        ],
+        "cardImageUrl": "https://prod-discovery.edx-cdn.org/media/course/image/8f8e5124-1dab-47e6-8fa6-3fbdc0738f0a-762af069070e.small.jpg",
+        "originalImageUrl": "https://prod-discovery.edx-cdn.org/media/course/image/8f8e5124-1dab-47e6-8fa6-3fbdc0738f0a-4978ad93b1c3.png",
+        "firstEnrollablePaidSeatPrice": 249
+    },
+    {
+        "aggregationKey": "course:HarvardX+CS50AI",
+        "title": "CS50s Introduction to Artificial Intelligence with Python",
+        "contentType": "course",
+        "partners": [
+            {
+                "name": "Harvard University",
+                "logoImageUrl": "https://prod-discovery.edx-cdn.org/organization/logos/44022f13-20df-4666-9111-cede3e5dc5b6-2cc39992c67a.png"
+            }
+        ],
+        "cardImageUrl": "https://prod-discovery.edx-cdn.org/media/course/image/3a31db71-de8f-45f1-ae65-11981ed9d680-31634d40b3bb.small.png",
+        "originalImageUrl": "https://prod-discovery.edx-cdn.org/media/course/image/3a31db71-de8f-45f1-ae65-11981ed9d680-b801bb328333.png",
+        "firstEnrollablePaidSeatPrice": 199
+    }
+]

--- a/src/data/tests/ContentHighlightsTestData/testCourseHighlights.json
+++ b/src/data/tests/ContentHighlightsTestData/testCourseHighlights.json
@@ -1,0 +1,257 @@
+[
+    {
+        "uuid": "55371e4d-07ab-418b-b012-738cd0c748c9",
+        "title": "Dire Core",
+        "is_published": true,
+        "enterprise_curation": "321123",
+        "highlighted_content": [
+            {
+                "uuid": "b5e72316-b4eb-4175-ae9e-94bc7566ea9a",
+                "content_type": "Course",
+                "content_key": "edX+DemoX",
+                "title": "Math",
+                "card_image_url": "https://picsum.photos/360/200",
+                "authoring_organizations": [
+                    {
+                        "uuid": "2bdb75e7-8c82-49b6-a13d-25283a6dca2e",
+                        "name": "General Studies 1",
+                        "logo_image_url": "https://placekitten.com/200/100"
+                    },
+                    {
+                        "uuid": "666ff0d0-833f-4466-afd8-ad58507c9dcd",
+                        "logo_image_url": "https://placekitten.com/200/100",
+                        "name": "Super General Studies"
+                    }
+                ]
+            },
+            {
+                "title": "Science",
+                "content_type": "Learnerpathway",
+                "uuid": "10f78f34-cb3d-4be2-8611-3cc0ba5ea8b8",
+                "content_key": "edX+DemoX",
+                "card_image_url": "https://picsum.photos/360/200",
+                "authoring_organizations": [
+                    {
+                        "uuid": "7601a229-43ef-4fac-9b21-49c0fb6e7189",
+                        "logo_image_url": "https://placekitten.com/200/100",
+                        "name": "General Studies 2"
+                    }
+                ]
+            },
+            {
+                "title": "English",
+                "content_type": "Program",
+                "uuid": "53b80aaa-6813-4258-a5b2-77f41f54d4e7",
+                "content_key": "edX+DemoX",
+                "card_image_url": "https://picsum.photos/360/200",
+                "authoring_organizations": [
+                    {
+                        "uuid": "d4d97a50-86d1-4afa-b50d-de02038b16e2",
+                        "logo_image_url": "https://placekitten.com/200/100",
+                        "name": "General Studies 3"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "title": "Dire Math",
+        "uuid": "b9f33716-1c1a-499b-93b8-6e9ec44d9c0b",
+        "is_published": true,
+        "enterprise_curation": "321123",
+        "highlighted_content": [
+            {
+                "title": "Math Xtreme",
+                "content_type": "Course",
+                "uuid": "e8140829-96bd-4e56-b94b-0026672dcc9d",
+                "content_key": "edX+DemoX",
+                "card_image_url": "https://picsum.photos/360/200",
+                "authoring_organizations": [
+                    {
+                        "uuid": "faac4722-4078-43a7-ae6b-425db8271203",
+                        "logo_image_url": "https://placekitten.com/200/100",
+                        "name": "Matheletes"
+                    }
+                ]
+            },
+            {
+                "title": "Science for Math Majors",
+                "content_type": "Course",
+                "uuid": "1816754d-3baa-4502-9d65-570258aab231",
+                "content_key": "edX+DemoX",
+                "card_image_url": "https://picsum.photos/360/200",
+                "authoring_organizations": [
+                    {
+                        "uuid": "fa2dbcb6-579c-4853-8d69-6efed076e742",
+                        "logo_image_url": "https://placekitten.com/200/100",
+                        "name": "Matheletes"
+                    }
+                ]
+            },
+            {
+                "title": "English Divergence",
+                "content_type": "Course",
+                "uuid": "b5b8b224-c902-4fd6-9030-b282a5164050",
+                "content_key": "edX+DemoX",
+                "card_image_url": "https://picsum.photos/360/200",
+                "authoring_organizations": [
+                    {
+                        "uuid": "499b858a-bf74-4fed-9e23-99fc141715c9",
+                        "logo_image_url": "https://placekitten.com/200/100",
+                        "name": "Matheletes"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "title": "Dire Science",
+        "uuid": "064fb141-dcc3-4a31-88ea-00bd17898147",
+        "is_published": false,
+        "enterprise_curation": "321123",
+        "highlighted_content": [
+            {
+                "title": "Math for Science Majors",
+                "content_type": "Course",
+                "uuid": "7ca02c60-aea3-482b-b3c8-45fb762ff744",
+                "content_key": "edX+DemoX",
+                "card_image_url": "https://picsum.photos/360/200",
+                "authoring_organizations": [
+                    {
+                        "uuid": "c77c063b-dd82-49cc-bf15-b0aabcf92fb2",
+                        "logo_image_url": "https://placekitten.com/200/100",
+                        "name": "The Beakers"
+                    }
+                ]
+            },
+            {
+                "title": "Science Xtreme",
+                "content_type": "Course",
+                "uuid": "3ba38218-09c9-4a5e-a611-f7460065a5d3",
+                "content_key": "edX+DemoX",
+                "card_image_url": "https://picsum.photos/360/200",
+                "authoring_organizations": [
+                    {
+                        "uuid": "4e3fbd19-5faa-4998-9048-20416983d739",
+                        "logo_image_url": "https://placekitten.com/200/100",
+                        "name": "The Beakers"
+                    }
+                ]
+            },
+            {
+                "title": "English Obfuscation",
+                "content_type": "Course",
+                "uuid": "635667a6-1e9b-48a2-a409-58983a7963a6",
+                "content_key": "edX+DemoX",
+                "card_image_url": "https://picsum.photos/360/200",
+                "authoring_organizations": [
+                    {
+                        "uuid": "5b3c4a08-8ba2-44b6-9680-4a857dcfc751",
+                        "logo_image_url": "https://placekitten.com/200/100",
+                        "name": "The Beakers"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "title": "Dire English",
+        "uuid": "96c9254f-9640-4db8-87f1-b213020a811c",
+        "is_published": true,
+        "enterprise_curation": "321123",
+        "highlighted_content": [
+            {
+                "title": "To Math or not Math",
+                "content_type": "Course",
+                "uuid": "723089fd-5c71-4704-a5ce-fa0c8efd862a",
+                "content_key": "edX+DemoX",
+                "card_image_url": "https://picsum.photos/360/200",
+                "authoring_organizations": [
+                    {
+                        "uuid": "e935012d-6597-4ba1-8ffc-ce14a1a0a003",
+                        "logo_image_url": "https://placekitten.com/200/100",
+                        "name": "Extensive Etymology"
+                    }
+                ]
+            },
+            {
+                "title": "Science for English Majors",
+                "content_type": "Course",
+                "uuid": "3c1f423d-77ee-4af9-8708-cc6abf4b9117",
+                "content_key": "edX+DemoX",
+                "card_image_url": "https://picsum.photos/360/200",
+                "authoring_organizations": [
+                    {
+                        "uuid": "32ea4851-7fa7-47c0-9de6-19b0c17e3ffb",
+                        "logo_image_url": "https://placekitten.com/200/100",
+                        "name": "Extensive Etymology"
+                    }
+                ]
+            },
+            {
+                "title": "Moore English: Lawlessness Refined",
+                "content_type": "Course",
+                "uuid": "d6a61ba1-90fa-4dec-a55c-86da907a2710",
+                "content_key": "edX+DemoX",
+                "card_image_url": "https://picsum.photos/360/200",
+                "authoring_organizations": [
+                    {
+                        "uuid": "1940a030-4fcd-49e6-9cb3-f5e414b92f03",
+                        "logo_image_url": "https://placekitten.com/200/100",
+                        "name": "Extensive Etymology"
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "title": "Dire Engineering",
+        "uuid": "f220b6a5-b35d-41ce-a8c7-394e659defcc",
+        "is_published": true,
+        "enterprise_curation": "321123",
+        "highlighted_content": [
+            {
+                "title": "Math for Engineering Majors",
+                "content_type": "Course",
+                "uuid": "cfc9c0b1-ac7c-465d-a696-f6a4febed95f",
+                "content_key": "edX+DemoX",
+                "card_image_url": "https://picsum.photos/360/200",
+                "authoring_organizations": [
+                    {
+                        "uuid": "f27a7673-66af-4d4b-98cc-5441c2033929",
+                        "logo_image_url": "https://placekitten.com/200/100",
+                        "name": "Building Bridges"
+                    }
+                ]
+            },
+            {
+                "title": "Science for Engineering Majors",
+                "content_type": "Course",
+                "uuid": "d127b068-d2b5-4313-b0fb-00e0a9155d58",
+                "content_key": "edX+DemoX",
+                "card_image_url": "https://picsum.photos/360/200",
+                "authoring_organizations": [
+                    {
+                        "uuid": "30d1020c-b9c3-4a07-b683-911cf4c81ffc",
+                        "logo_image_url": "https://placekitten.com/200/100",
+                        "name": "Building Bridges"
+                    }
+                ]
+            },
+            {
+                "title": "English Instantiation",
+                "content_type": "Course",
+                "uuid": "96f3c8a2-060e-4621-ac26-94d55aa4ecf4",
+                "content_key": "edX+DemoX",
+                "card_image_url": "https://picsum.photos/360/200",
+                "authoring_organizations": [
+                    {
+                        "uuid": "3c4932ca-3843-4b96-90f6-efe857c0afba",
+                        "logo_image_url": "https://placekitten.com/200/100",
+                        "name": "Building Bridges"
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/src/data/tests/ContentHighlightsTestData/utils.js
+++ b/src/data/tests/ContentHighlightsTestData/utils.js
@@ -1,0 +1,12 @@
+import { camelCaseObject } from '@edx/frontend-platform';
+
+const rawTestCourseData = require('./testCourseData.json');
+const rawTestCourseHighlights = require('./testCourseHighlights.json');
+
+export const testCourseHighlightsData = camelCaseObject(rawTestCourseHighlights);
+rawTestCourseData.forEach((element, index) => {
+  if (!element.objectID) {
+    rawTestCourseData[index].objectId = index + 1;
+  }
+});
+export const testCourseData = rawTestCourseData.map(x => x);

--- a/src/data/tests/constants.js
+++ b/src/data/tests/constants.js
@@ -1,0 +1,12 @@
+import algoliasearch from 'algoliasearch/lite';
+import { configuration } from '../../config';
+
+export const TEST_ENTERPRISE_ID = 'test-enterprise-id';
+export const TEST_ENTERPRISE_NAME = 'Test Enterprise';
+export const TEST_ENTERPRISE_SLUG = 'test-enterprise-slug';
+
+// Algolia searchClient for
+export const searchClient = algoliasearch(
+  configuration.ALGOLIA_APP_ID,
+  configuration.ALGOLIA_SEARCH_KEY,
+);

--- a/src/data/tests/context.js
+++ b/src/data/tests/context.js
@@ -1,0 +1,44 @@
+/* eslint-disable react/jsx-filename-extension */
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
+import configureMockStore from 'redux-mock-store';
+import PropTypes from 'prop-types';
+import { TEST_ENTERPRISE_ID, TEST_ENTERPRISE_NAME, TEST_ENTERPRISE_SLUG } from './constants';
+
+const mockStore = configureMockStore([thunk]);
+
+export const initialStateValue = {
+  portalConfiguration:
+    {
+      enterpriseSlug: TEST_ENTERPRISE_SLUG,
+      enterpriseName: TEST_ENTERPRISE_NAME,
+      enterpriseId: TEST_ENTERPRISE_ID,
+    },
+};
+
+export const BaseContext = ({
+  children,
+  initialState,
+}) => (
+  <IntlProvider locale="en">
+    <Provider store={mockStore(initialState)}>
+      {children}
+    </Provider>
+  </IntlProvider>
+);
+
+BaseContext.propTypes = {
+  children: PropTypes.node.isRequired,
+  initialState: PropTypes.shape({
+    portalConfiguration: PropTypes.shape({
+      enterpriseSlug: PropTypes.string,
+      enterpriseName: PropTypes.string,
+      enterpriseId: PropTypes.string,
+    }),
+  }),
+};
+
+BaseContext.defaultProps = {
+  initialState: initialStateValue,
+};


### PR DESCRIPTION
Initial consolidation of testing framework POC. Consolidate contexts, constants and API structures. 

A reference tech is Pact that does a similar process with HTTP responses, while this frameworks hopes to mimic it with frontend context providers. It will allow for faster testing across features that have been consolidated. 

Current POC is using Content Highlights. Currently WIP. 

Pushes will look at the effect on test coverage and possible testing runtimes since we are reducing the overall amount of imports required per test.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
