### PR TITLE
fix: disable delivery_method while updating report

### DIFF
--- a/src/components/ReportingConfig/ReportingConfigForm.jsx
+++ b/src/components/ReportingConfig/ReportingConfigForm.jsx
@@ -242,6 +242,8 @@ class ReportingConfigForm extends React.Component {
             <ValidationFormGroup
               for="deliveryMethod"
               helpText="The method in which the data should be sent"
+              invalid={!!APIErrors.deliveryMethod}
+              invalidMessage={APIErrors.deliveryMethod}
             >
               <label htmlFor="deliveryMethod">Delivery Method</label>
               <Input
@@ -251,6 +253,13 @@ class ReportingConfigForm extends React.Component {
                 defaultValue={config ? config.deliveryMethod : reportingConfigTypes.deliveryMethod[0][0]}
                 options={reportingConfigTypes.deliveryMethod.map(item => ({ label: item[1], value: item[0] }))}
                 onChange={e => this.setState({ deliveryMethod: e.target.value })}
+                disabled={config}
+              />
+              <input
+                type="hidden"
+                name="deliveryMethod"
+                value={config ? config.deliveryMethod : reportingConfigTypes.deliveryMethod[0][0]}
+                disabled={!config}
               />
             </ValidationFormGroup>
             <ValidationFormGroup


### PR DESCRIPTION
***Description***
when someone creates an EnterpriseCustomerReportingConfiguration (ECRC) using the delivery_method email and tries to update the delivery_method to sftp then sftp password is not required due to which that report could save in DB without that password. So when someone tried to inactivate that report from Django admin then 500 error occurred.

***Solution***
I disable the deliveryMethod field and applied validation on delivery_method in the backend. When someone tries to bypass this field, a proper message will be shown to the user that you cannot update the delivery method. 

here is the ticket [ENT-1689](https://2u-internal.atlassian.net/browse/ENT-1689)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirms screenshots
