### PR TITLE
chore: remove logic to set expiration date on universal link

### DIFF
--- a/src/components/settings/SettingsAccessTab/SettingsAccessGenerateLinkButton.jsx
+++ b/src/components/settings/SettingsAccessTab/SettingsAccessGenerateLinkButton.jsx
@@ -8,6 +8,7 @@ import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
 import LmsApiService from '../../../data/services/LmsApiService';
 import { SETTINGS_ACCESS_EVENTS } from '../../../eventTracking';
+import { MAX_UNIVERSAL_LINKS } from '../data/constants';
 
 const BUTTON_PROPS = {
   labels: {
@@ -21,8 +22,8 @@ const BUTTON_PROPS = {
 
 const SettingsAccessGenerateLinkButton = ({
   enterpriseUUID,
-  formattedLinkExpirationDate,
   onSuccess,
+  linksCount,
   disabled,
 }) => {
   const [loadingLinkCreation, setLoadingLinkCreation] = useState(false);
@@ -32,10 +33,7 @@ const SettingsAccessGenerateLinkButton = ({
   const handleGenerateLink = async () => {
     setLoadingLinkCreation(true);
     try {
-      if (!formattedLinkExpirationDate) {
-        throw new Error('Attempted to generate universal link without an expiration date');
-      }
-      const response = await LmsApiService.createEnterpriseCustomerLink(enterpriseUUID, formattedLinkExpirationDate);
+      const response = await LmsApiService.createEnterpriseCustomerLink(enterpriseUUID);
       onSuccess(response);
     } catch (error) {
       logError(error);
@@ -50,7 +48,7 @@ const SettingsAccessGenerateLinkButton = ({
 
   return (
     <StatefulButton
-      disabled={disabled}
+      disabled={disabled || linksCount >= MAX_UNIVERSAL_LINKS}
       {...BUTTON_PROPS}
       state={buttonState}
       onClick={handleGenerateLink}
@@ -60,15 +58,11 @@ const SettingsAccessGenerateLinkButton = ({
 
 SettingsAccessGenerateLinkButton.defaultProps = {
   disabled: false,
-  formattedLinkExpirationDate: null,
+  linksCount: 0,
 };
 SettingsAccessGenerateLinkButton.propTypes = {
   enterpriseUUID: PropTypes.string.isRequired,
-  formattedLinkExpirationDate: (props) => {
-    if (!props.disabled && !props.formattedLinkExpirationDate) {
-      throw new Error('Please provide a formattedLinkExpirationDate if the button is not disabled!');
-    }
-  },
+  linksCount: PropTypes.number,
   disabled: PropTypes.bool,
   onSuccess: PropTypes.func.isRequired,
 };

--- a/src/components/settings/SettingsAccessTab/index.jsx
+++ b/src/components/settings/SettingsAccessTab/index.jsx
@@ -91,47 +91,43 @@ const SettingsAccessTab = ({
           )}
         </div>
       )}
-      {hasConfiguredSubsidyType && (
-        <>
-          <div className="mb-5">
-            <h3>Select access channel</h3>
-            <p>
-              Channels determine how learners access the catalog(s).
-              You can select one or both and change your selection at any time.
-            </p>
-            {isUniversalLinkEnabled && (
-              <div className="mb-4">
-                <SettingsAccessLinkManagement />
-              </div>
-            )}
-            {identityProvider && (
-              <SettingsAccessSSOManagement
-                enterpriseId={enterpriseId}
-                enableIntegratedCustomerLearnerPortalSearch={enableIntegratedCustomerLearnerPortalSearch}
-                identityProvider={identityProvider}
-                updatePortalConfiguration={updatePortalConfiguration}
-              />
-            )}
+      <div className="mb-5">
+        <h3>Select access channel</h3>
+        <p>
+          Channels determine how learners access the catalog(s).
+          You can select one or both and change your selection at any time.
+        </p>
+        {isUniversalLinkEnabled && (
+          <div className="mb-4">
+            <SettingsAccessLinkManagement />
           </div>
-          {subsidyTypeLabelAndRoute && (
-            <div>
-              <div className="d-flex justify-content-between">
-                <h3>Manage course requests</h3>
-                <SettingsAccessSubsidyRequestManagement
-                  subsidyRequestConfiguration={subsidyRequestConfiguration}
-                  updateSubsidyRequestConfiguration={updateSubsidyRequestConfiguration}
-                  disabled={!hasActiveAccessChannel}
-                />
-              </div>
-              <p>
-                Allow learners to request a {subsidyTypeLabelAndRoute.label} to access courses. You
-                will see the requests under{' '}
-                <Link to={subsidyTypeLabelAndRoute.route.path}>{subsidyTypeLabelAndRoute.route.label}</Link>.
-                Disabling this feature will not affect learners&apos; ability to browse.
-              </p>
-            </div>
-          )}
-        </>
+        )}
+        {identityProvider && (
+          <SettingsAccessSSOManagement
+            enterpriseId={enterpriseId}
+            enableIntegratedCustomerLearnerPortalSearch={enableIntegratedCustomerLearnerPortalSearch}
+            identityProvider={identityProvider}
+            updatePortalConfiguration={updatePortalConfiguration}
+          />
+        )}
+      </div>
+      {subsidyTypeLabelAndRoute && (
+        <div>
+          <div className="d-flex justify-content-between">
+            <h3>Manage course requests</h3>
+            <SettingsAccessSubsidyRequestManagement
+              subsidyRequestConfiguration={subsidyRequestConfiguration}
+              updateSubsidyRequestConfiguration={updateSubsidyRequestConfiguration}
+              disabled={!hasActiveAccessChannel}
+            />
+          </div>
+          <p>
+            Allow learners to request a {subsidyTypeLabelAndRoute.label} to access courses. You
+            will see the requests under{' '}
+            <Link to={subsidyTypeLabelAndRoute.route.path}>{subsidyTypeLabelAndRoute.route.label}</Link>.
+            Disabling this feature will not affect learners&apos; ability to browse.
+          </p>
+        </div>
       )}
     </div>
   );

--- a/src/components/settings/SettingsAccessTab/tests/SettingsAccessGenerateLinkButton.test.jsx
+++ b/src/components/settings/SettingsAccessTab/tests/SettingsAccessGenerateLinkButton.test.jsx
@@ -5,8 +5,6 @@ import {
   act,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import moment from 'moment';
-import { logError } from '@edx/frontend-platform/logging';
 
 import SettingsAccessGenerateLinkButton from '../SettingsAccessGenerateLinkButton';
 import LmsApiService from '../../../../data/services/LmsApiService';
@@ -23,7 +21,6 @@ const ENTERPRISE_ID = 'test-enterprise';
 describe('<SettingsAccessGenerateLinkButton />', () => {
   const basicProps = {
     enterpriseUUID: ENTERPRISE_ID,
-    formattedLinkExpirationDate: moment().format(),
     disabled: false,
     onSuccess: jest.fn(),
   };
@@ -44,14 +41,6 @@ describe('<SettingsAccessGenerateLinkButton />', () => {
     expect(button).toHaveProperty('disabled', true);
   });
 
-  it('throws an error if trying to generate a link and formattedLinkExpirationDate = null', async () => {
-    render(<SettingsAccessGenerateLinkButton {...basicProps} formattedLinkExpirationDate={null} />);
-    const button = screen.queryByText('Generate link').closest('button');
-    await act(async () => { userEvent.click(button); });
-    expect(LmsApiService.createEnterpriseCustomerLink).toHaveBeenCalledTimes(0);
-    expect(logError).toHaveBeenCalledWith(new Error('Attempted to generate universal link without an expiration date'));
-  });
-
   it('clicking button calls api', async () => {
     const mockHandleSuccess = jest.fn();
     render(<SettingsAccessGenerateLinkButton {...basicProps} onSuccess={mockHandleSuccess} />);
@@ -63,7 +52,6 @@ describe('<SettingsAccessGenerateLinkButton />', () => {
 
     expect(LmsApiService.createEnterpriseCustomerLink).toHaveBeenCalledWith(
       ENTERPRISE_ID,
-      basicProps.formattedLinkExpirationDate,
     );
     expect(mockHandleSuccess).toHaveBeenCalledTimes(1);
   });

--- a/src/components/settings/data/constants.js
+++ b/src/components/settings/data/constants.js
@@ -48,6 +48,8 @@ export const INVALID_API_ROOT_URL = 'OAuth API Root URL attribute must be a vali
 export const INVALID_SAPSF_OAUTH_ROOT_URL = 'SAPSF OAuth URL attribute must be a valid URL';
 export const INVALID_ODATA_API_TIMEOUT_INTERVAL = 'OData API timeout interval must be a number less than 30';
 
+export const MAX_UNIVERSAL_LINKS = 100;
+
 /**
  * Used as tab values and in router params
  */


### PR DESCRIPTION
The expiration date for a Universal Link was formerly tied to the expiration date of a coupon. This change removes that logic, and corresponds to the new default expiration date on the back-end ([EnterpriseCustomerInviteKey](https://github.com/openedx/edx-enterprise/pull/1769) will expire in 365 days). There is also now a limit of 100 links per enterprise customer. 
<img width="1601" alt="Screenshot 2023-06-12 at 3 22 36 PM" src="https://github.com/openedx/frontend-app-admin-portal/assets/129111440/6670ad50-0a6c-49e4-871e-caf794f7675e">
An alert is shown if the customer has reached 100 links, and the `Generate Link` button is disabled:
<img width="1592" alt="Screenshot 2023-06-12 at 3 26 32 PM" src="https://github.com/openedx/frontend-app-admin-portal/assets/129111440/9330a7a6-1010-4190-8a99-917531037097">

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
