### PR TITLE
chore: remove browsing on demand expiration statement

### DIFF
--- a/src/components/settings/SettingsAccessTab/index.jsx
+++ b/src/components/settings/SettingsAccessTab/index.jsx
@@ -67,7 +67,6 @@ const SettingsAccessTab = ({
         <Col lg={8} xl={9}>
           <p>
             Allow learners without a subsidy to browse the catalog and request enrollment to courses.
-            Browsing on demand will expire at the end of your latest purchase.
           </p>
         </Col>
         <Col md="auto">


### PR DESCRIPTION
Remove the sentence "Browsing on demand will expire at the end of your latest purchase" from the `Settings` page.

Before:
<img width="913" alt="Screenshot 2023-06-20 at 12 43 07 PM" src="https://github.com/openedx/frontend-app-admin-portal/assets/129111440/8d85f4ad-8562-4354-9300-20525c3b3dae">

After:
<img width="927" alt="Screenshot 2023-06-20 at 12 42 47 PM" src="https://github.com/openedx/frontend-app-admin-portal/assets/129111440/3ef4edcc-46ec-492b-90e6-69a4aab305ac">

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
