### PR TITLE
fix: do not require change password to change reporting configuration

### DIFF
--- a/src/components/ReportingConfig/ReportingConfigForm.jsx
+++ b/src/components/ReportingConfig/ReportingConfigForm.jsx
@@ -55,7 +55,7 @@ class ReportingConfigForm extends React.Component {
    * @param {FormData} formData
    * @param {[String]} requiredFields
    */
-  validateReportingForm = (formData, requiredFields) => {
+  validateReportingForm = (config, formData, requiredFields) => {
     const invalidFields = requiredFields
       .filter(field => !formData.get(field))
       .reduce((prevFields, currField) => ({ ...prevFields, [currField]: true }), {});
@@ -63,7 +63,7 @@ class ReportingConfigForm extends React.Component {
     // Password is conditionally required only when pgp key will not be present
     // and delivery method is email
     if (!formData.get('pgpEncryptionKey') && formData.get('deliveryMethod') === 'email') {
-      if (!formData.get('encryptedPassword')) {
+      if (!formData.get('encryptedPassword') && !config?.encryptedPassword) {
         invalidFields.encryptedPassword = true;
       }
     }
@@ -131,7 +131,7 @@ class ReportingConfigForm extends React.Component {
       requiredFields = config ? [...REQUIRED_SFTP_FIELDS] : [...REQUIRED_NEW_SFTP_FEILDS];
     }
     // validate the form
-    const invalidFields = this.validateReportingForm(formData, requiredFields);
+    const invalidFields = this.validateReportingForm(config, formData, requiredFields);
     // if there are invalid fields, reflect that in the UI
     if (!isEmpty(invalidFields)) {
       this.setState((state) => ({

--- a/src/components/ReportingConfig/ReportingConfigForm.test.jsx
+++ b/src/components/ReportingConfig/ReportingConfigForm.test.jsx
@@ -384,6 +384,38 @@ describe('<ReportingConfigForm />', () => {
     wrapper.find('.form-control').forEach(input => input.simulate('blur'));
     expect(wrapper.find('input#encryptedPassword').hasClass('is-invalid')).toBeTruthy();
   });
+  it('Password is not required while updating if it is already present and delivery method is email', async () => {
+    const updateConfigMock = jest.fn().mockResolvedValue();
+    const initialConfig = {
+      ...defaultConfig,
+    };
+    initialConfig.encryptedPassword = 'some_pass';
+    initialConfig.pgpEncryptionKey = '';
+    initialConfig.hourOfDay = 4;
+    const requiredFields = ['hourOfDay', 'emailRaw'];
+    const wrapper = mount(
+      <ReportingConfigForm
+        config={initialConfig}
+        createConfig={createConfig}
+        updateConfig={updateConfigMock}
+        availableCatalogs={availableCatalogs}
+        reportingConfigTypes={reportingConfigTypes}
+        enterpriseCustomerUuid={enterpriseCustomerUuid}
+      />,
+    );
+
+    const updatedFormData = new FormData();
+    updatedFormData.append('deliveryMethod', 'email');
+    updatedFormData.append('pgpEncryptionKey', '');
+    updatedFormData.append('encryptedPassword', '');
+
+    const invalidFields = await wrapper.instance().validateReportingForm(
+      initialConfig,
+      updatedFormData,
+      requiredFields,
+    );
+    expect('encryptedPassword' in invalidFields).toBe(false);
+  });
   it('Submit enterprise uuid upon report config creation', async () => {
     const wrapper = mount((
       <ReportingConfigForm


### PR DESCRIPTION
**Description**

***Problem***: 
When we try to update a configuration report then the password is required even if I did not want to update it.

***Solution***: 
I make the password field conditionally required while updating a report.


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
