### PR TITLE
chore: portal appearance tab appears by default

### DIFF
--- a/src/components/settings/SettingsTabs.jsx
+++ b/src/components/settings/SettingsTabs.jsx
@@ -48,6 +48,21 @@ const SettingsTabs = ({
 
   const tabArray = useMemo(() => {
     const initialTabs = [];
+    if (SETTINGS_PAGE_APPEARANCE_TAB) {
+      initialTabs.push(
+        <Tab
+          key={SETTINGS_TABS_VALUES.appearance}
+          eventKey={SETTINGS_TABS_VALUES.appearance}
+          title={SETTINGS_TAB_LABELS.appearance}
+        >
+          <SettingsAppearanceTab
+            enterpriseId={enterpriseId}
+            enterpriseBranding={enterpriseBranding}
+            updatePortalConfiguration={updatePortalConfiguration}
+          />
+        </Tab>,
+      );
+    }
     if (enableLearnerPortal) {
       initialTabs.push(
         <Tab
@@ -94,21 +109,6 @@ const SettingsTabs = ({
             enableSamlConfigurationScreen={enableSamlConfigurationScreen}
             identityProvider={identityProvider}
             hasSSOConfig={hasSSOConfig}
-          />
-        </Tab>,
-      );
-    }
-    if (SETTINGS_PAGE_APPEARANCE_TAB) {
-      initialTabs.push(
-        <Tab
-          key={SETTINGS_TABS_VALUES.appearance}
-          eventKey={SETTINGS_TABS_VALUES.appearance}
-          title={SETTINGS_TAB_LABELS.appearance}
-        >
-          <SettingsAppearanceTab
-            enterpriseId={enterpriseId}
-            enterpriseBranding={enterpriseBranding}
-            updatePortalConfiguration={updatePortalConfiguration}
           />
         </Tab>,
       );

--- a/src/components/settings/data/constants.js
+++ b/src/components/settings/data/constants.js
@@ -71,7 +71,7 @@ export const SETTINGS_TAB_LABELS = {
 };
 
 /** Default tab when no parameter is given */
-export const DEFAULT_TAB = ACCESS_TAB;
+export const DEFAULT_TAB = APPEARANCE_TAB;
 
 /**
  * Url parameter that the set in the router

--- a/src/components/settings/tests/SettingsPage.test.jsx
+++ b/src/components/settings/tests/SettingsPage.test.jsx
@@ -36,10 +36,10 @@ describe('<SettingsPage />', () => {
     jest.clearAllMocks();
   });
 
-  it('Redirects to access tab when no param given', () => {
+  it('Redirects to appearance tab when no param given', () => {
     render(settingsPageWithRouter('/settings'));
     expect(screen.queryByText('404')).toBeFalsy();
-    expect(screen.queryByText('access')).toBeTruthy();
+    expect(screen.queryByText('appearance')).toBeTruthy();
   });
 
   it('Does not redirect when access is passed', () => {


### PR DESCRIPTION
When clicking Settings, the "Portal Appearance" tab is now the default, and the corresponding tab is furthest to the left.
<img width="1272" alt="Screenshot 2023-07-27 at 9 51 44 AM" src="https://github.com/openedx/frontend-app-admin-portal/assets/129111440/f5a72f7b-4ced-4b85-998c-83675dc237b1">

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
