### PR TITLE
chore: add i18n_extract to package.json for openedx-translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "build": "fedx-scripts webpack",
+    "i18n_extract": "BABEL_ENV=i18n fedx-scripts babel src --quiet > /dev/null",
     "build:with-theme": "THEME=npm:@edx/brand-edx.org@latest npm run install-theme && fedx-scripts webpack",
     "check-types": "tsc --noemit",
     "lint": "fedx-scripts eslint --ext .js --ext .jsx .; npm run check-types",


### PR DESCRIPTION
This step is needed for openedx-translations repo to extract source files.

This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

This fixes the error below:

- https://github.com/openedx/openedx-translations/actions/runs/5721017099/job/15502202718

```
make extract_translations
....
npm run-script i18n_extract
npm ERR! Missing script: "i18n_extract"
make: *** [Makefile:48: i18n.extract] Error 1
Error: Process completed with exit code 2.
```

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)
