### PR TITLE
feat: ENT-7445 Added support for picking first active subsidy when multiple available

### DIFF
--- a/src/components/EnterpriseSubsidiesContext/data/hooks.js
+++ b/src/components/EnterpriseSubsidiesContext/data/hooks.js
@@ -38,25 +38,29 @@ export const useEnterpriseOffers = ({ enablePortalLearnerCreditManagementScreen,
           results = camelCaseObject(ecommerceApiResponse.data.results);
           source = 'ecommerceApi';
         }
-
+        let activeSubsidyFound = false;
         if (results.length !== 0) {
-          const subsidy = results[0];
-          const isCurrent = source === 'ecommerceApi'
-            ? subsidy.isCurrent
-            : dayjs().isSameOrBefore(subsidy.expirationDatetime)
-            && dayjs().isSameOrAfter(subsidy.activeDatetime);
-          const offerData = {
-            id: subsidy.uuid || subsidy.id,
-            name: subsidy.title || subsidy.displayName,
-            start: subsidy.activeDatetime || subsidy.startDatetime,
-            end: subsidy.expirationDatetime || subsidy.endDatetime,
-            isCurrent,
-          };
-          setOffers([offerData]);
-        }
-        // We only released learner credit management to customers with 1 offer for the MVP.
-        if (results.length === 1) {
-          setCanManageLearnerCredit(true);
+          let subsidy = results[0];
+          for (let i = 0; i < results.length; i++) {
+            subsidy = results[i];
+            activeSubsidyFound = source === 'ecommerceApi'
+              ? subsidy.isCurrent
+              : subsidy.isActive;
+            if (activeSubsidyFound === true) {
+              break;
+            }
+          }
+          if (activeSubsidyFound === true) {
+            const offerData = {
+              id: subsidy.uuid || subsidy.id,
+              name: subsidy.title || subsidy.displayName,
+              start: subsidy.activeDatetime || subsidy.startDatetime,
+              end: subsidy.expirationDatetime || subsidy.endDatetime,
+              isCurrent: activeSubsidyFound,
+            };
+            setOffers([offerData]);
+            setCanManageLearnerCredit(true);
+          }
         }
       } catch (error) {
         logError(error);


### PR DESCRIPTION
**Description**: This PR adds support for picking the first active subsidy when multiple are available.

**JIRA**: [ENT-7445](https://2u-internal.atlassian.net/browse/ENT-7445)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
