### PR TITLE
fix: remove broken usage of useCache from getSubsidyRequestConfiguration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 
 # emacs
 *~
+.projectile
 
 # edx
 .env.private

--- a/src/components/subsidy-requests/data/hooks.js
+++ b/src/components/subsidy-requests/data/hooks.js
@@ -57,21 +57,18 @@ export const useSubsidyRequestConfiguration = ({
     }
   }, [enterpriseId]);
 
-  const loadSubsidyRequestConfiguration = useCallback(
-    async ({ clearCacheEntry = false } = { clearCacheEntry: false }) => {
-      try {
-        const response = await EnterpriseAccessApiService.getSubsidyRequestConfiguration(
-          { enterpriseId, clearCacheEntry },
-        );
-        const customerConfiguration = camelCaseObject(response.data);
-        setSubsidyRequestConfiguration(customerConfiguration);
-      } catch (error) {
-        logError(error);
-        throw error;
-      }
-    },
-    [enterpriseId],
-  );
+  const loadSubsidyRequestConfiguration = useCallback(async () => {
+    try {
+      const response = await EnterpriseAccessApiService.getSubsidyRequestConfiguration(
+        { enterpriseId },
+      );
+      const customerConfiguration = camelCaseObject(response.data);
+      setSubsidyRequestConfiguration(customerConfiguration);
+    } catch (error) {
+      logError(error);
+      throw error;
+    }
+  }, [enterpriseId]);
 
   useEffect(() => {
     if (!enterpriseId) {
@@ -111,7 +108,7 @@ export const useSubsidyRequestConfiguration = ({
         enterpriseId,
         options,
       );
-      loadSubsidyRequestConfiguration({ clearCacheEntry: true });
+      loadSubsidyRequestConfiguration();
     } catch (err) {
       logError(err);
       throw err;

--- a/src/components/subsidy-requests/data/tests/hooks.test.js
+++ b/src/components/subsidy-requests/data/tests/hooks.test.js
@@ -64,7 +64,7 @@ describe('useSubsidyRequestConfiguration', () => {
     await waitForNextUpdate();
 
     expect(EnterpriseAccessApiService.getSubsidyRequestConfiguration).toHaveBeenCalledWith(
-      { clearCacheEntry: false, enterpriseId: TEST_ENTERPRISE_UUID },
+      { enterpriseId: TEST_ENTERPRISE_UUID },
     );
     expect(result.current.subsidyRequestConfiguration).toEqual(
       camelCaseObject(TEST_CONFIGURATION_RESPONSE.data),
@@ -230,7 +230,7 @@ describe('useSubsidyRequestConfiguration', () => {
       });
 
       expect(EnterpriseAccessApiService.getSubsidyRequestConfiguration).toHaveBeenCalledWith(
-        { clearCacheEntry: true, enterpriseId: TEST_ENTERPRISE_UUID },
+        { enterpriseId: TEST_ENTERPRISE_UUID },
       );
     });
 

--- a/src/data/services/EnterpriseAccessApiService.js
+++ b/src/data/services/EnterpriseAccessApiService.js
@@ -7,11 +7,9 @@ class EnterpriseAccessApiService {
 
   static apiClient = getAuthenticatedHttpClient;
 
-  static getSubsidyRequestConfiguration({ enterpriseId, clearCacheEntry = false }) {
+  static getSubsidyRequestConfiguration({ enterpriseId }) {
     const url = `${EnterpriseAccessApiService.baseUrl}/customer-configurations/${enterpriseId}/`;
-    return EnterpriseAccessApiService.apiClient({
-      useCache: configuration.USE_API_CACHE,
-    }).get(url, { clearCacheEntry });
+    return EnterpriseAccessApiService.apiClient().get(url);
   }
 
   static createSubsidyRequestConfiguration({

--- a/src/data/services/tests/EnterpriseAccessApiService.test.js
+++ b/src/data/services/tests/EnterpriseAccessApiService.test.js
@@ -103,7 +103,6 @@ describe('EnterpriseAccessApiService', () => {
     EnterpriseAccessApiService.getSubsidyRequestConfiguration({ enterpriseId: mockEnterpriseUUID });
     expect(axios.get).toBeCalledWith(
       `${enterpriseAccessBaseUrl}/api/v1/customer-configurations/${mockEnterpriseUUID}/`,
-      { clearCacheEntry: false },
     );
   });
 


### PR DESCRIPTION
Fixes an issue where updates to course requests settings weren't reflected in the Settings/Access page.  We were previously setting `useCache` to always be true in the call to fetch subsidy request configs.

Broken behavior was possibly related to this change? https://github.com/openedx/frontend-platform/pull/361 

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
