### PR TITLE
[WIP] feat: show all enterprise budgets regardless of plan and route correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 
 # emacs
 *~
+.projectile
 
 # edx
 .env.private

--- a/src/components/ContentHighlights/data/constants.js
+++ b/src/components/ContentHighlights/data/constants.js
@@ -43,10 +43,10 @@ export const TAB_TITLES = {
 export const MAX_HIGHLIGHT_TITLE_LENGTH = 60;
 
 // Max highlight sets per enteprise curation
-export const MAX_HIGHLIGHT_SETS_PER_ENTERPRISE_CURATION = 8;
+export const MAX_HIGHLIGHT_SETS_PER_ENTERPRISE_CURATION = 12;
 
 // Max number of content items per highlight set
-export const MAX_CONTENT_ITEMS_PER_HIGHLIGHT_SET = 12;
+export const MAX_CONTENT_ITEMS_PER_HIGHLIGHT_SET = 24;
 
 // Max number of content items displayed from search results
 export const MAX_PAGE_SIZE = 24;

--- a/src/components/EnterpriseApp/EnterpriseAppRoutes.jsx
+++ b/src/components/EnterpriseApp/EnterpriseAppRoutes.jsx
@@ -14,6 +14,7 @@ import { PlotlyAnalyticsPage } from '../PlotlyAnalytics';
 import { ROUTE_NAMES } from './data/constants';
 import BulkEnrollmentResultsDownloadPage from '../BulkEnrollmentResultsDownloadPage';
 import LearnerCreditManagement from '../learner-credit-management';
+import BudgetDetailPage from '../learner-credit-management/BudgetDetailPage';
 import { EnterpriseSubsidiesContext } from '../EnterpriseSubsidiesContext';
 import ContentHighlights from '../ContentHighlights';
 
@@ -104,6 +105,12 @@ const EnterpriseAppRoutes = ({
           component={LearnerCreditManagement}
         />
       )}
+
+      <Route
+        exact
+        path={`${baseUrl}/admin/${ROUTE_NAMES.learnerCredit}/:id`}
+        component={BudgetDetailPage}
+      />
 
       {enableContentHighlightsPage && (
         <Route

--- a/src/components/EnterpriseApp/data/constants.js
+++ b/src/components/EnterpriseApp/data/constants.js
@@ -13,3 +13,9 @@ export const ROUTE_NAMES = {
   subscriptionManagement: 'subscriptions',
   contentHighlights: 'content-highlights',
 };
+
+export const BUDGET_STATUSES = {
+  active: 'Active',
+  expired: 'Expired',
+  upcoming: 'Upcoming',
+};

--- a/src/components/EnterpriseSubsidiesContext/data/hooks.js
+++ b/src/components/EnterpriseSubsidiesContext/data/hooks.js
@@ -43,10 +43,10 @@ export const useEnterpriseOffers = ({ enablePortalLearnerCreditManagementScreen,
           const { isActive } = subsidy; // Always check isActive for enterprise subsidies
           const isCurrent = isActive; // You can adjust this based on your specific requirements
           const activeSubsidyData = {
-            id: subsidy.uuid || subsidy.id,
-            name: subsidy.title || subsidy.displayName,
-            start: subsidy.activeDatetime || subsidy.startDatetime,
-            end: subsidy.expirationDatetime || subsidy.endDatetime,
+            id: subsidy.uuid,
+            name: subsidy.title,
+            start: subsidy.activeDatetime,
+            end: subsidy.expirationDatetime,
             isCurrent,
             source,
           };
@@ -61,10 +61,10 @@ export const useEnterpriseOffers = ({ enablePortalLearnerCreditManagementScreen,
           const source = 'ecommerceApi';
           const { isCurrent } = subsidy;
           const activeSubsidyData = {
-            id: subsidy.uuid || subsidy.id,
-            name: subsidy.title || subsidy.displayName,
-            start: subsidy.activeDatetime || subsidy.startDatetime,
-            end: subsidy.expirationDatetime || subsidy.endDatetime,
+            id: subsidy.id,
+            name: subsidy.displayName,
+            start: subsidy.startDatetime,
+            end: subsidy.endDatetime,
             isCurrent,
             source,
           };

--- a/src/components/EnterpriseSubsidiesContext/data/tests/hooks.test.js
+++ b/src/components/EnterpriseSubsidiesContext/data/tests/hooks.test.js
@@ -51,6 +51,7 @@ describe('useEnterpriseOffers', () => {
       start: '2021-05-15T19:56:09Z',
       end: '2100-05-15T19:56:09Z',
       isCurrent: true,
+      source: 'ecommerceApi',
     }];
 
     SubsidyApiService.getSubsidyByCustomerUUID.mockResolvedValueOnce({
@@ -80,69 +81,82 @@ describe('useEnterpriseOffers', () => {
   });
 
   it('should fetch enterprise offers for the enterprise when data available in enterprise-subsidy', async () => {
-    const mockOffers = [
+    const mockEnterpriseSubsidyResponse = [
+      {
+        uuid: 'offer-id',
+        title: 'offer-name',
+        activeDatetime: '2021-05-15T19:56:09Z',
+        expirationDatetime: '2100-05-15T19:56:09Z',
+        isActive: true,
+      },
+    ];
+
+    const mockEcommerceResponse = [
+      {
+        id: 'uuid',
+        display_name: 'offer-name',
+        start_datetime: '2021-05-15T19:56:09Z',
+        end_datetime: '2100-05-15T19:56:09Z',
+        is_current: true,
+      },
+    ];
+
+    SubsidyApiService.getSubsidyByCustomerUUID.mockResolvedValueOnce({
+      data: {
+        results: mockEnterpriseSubsidyResponse,
+      },
+    });
+
+    EcommerceApiService.fetchEnterpriseOffers.mockResolvedValueOnce({
+      data: {
+        results: mockEcommerceResponse,
+      },
+    });
+
+    const { result, waitForNextUpdate } = renderHook(() => useEnterpriseOffers({
+      enablePortalLearnerCreditManagementScreen: true,
+      enterpriseId: TEST_ENTERPRISE_UUID,
+    }));
+
+    await waitForNextUpdate();
+
+    expect(SubsidyApiService.getSubsidyByCustomerUUID).toHaveBeenCalledWith(
+      TEST_ENTERPRISE_UUID,
+      { subsidyType: 'learner_credit' },
+    );
+
+    const expectedOffers = [
       {
         id: 'offer-id',
         name: 'offer-name',
         start: '2021-05-15T19:56:09Z',
         end: '2100-05-15T19:56:09Z',
         isCurrent: true,
+        source: 'subsidyApi',
+      },
+      {
+        id: 'uuid',
+        name: 'offer-name',
+        start: '2021-05-15T19:56:09Z',
+        end: '2100-05-15T19:56:09Z',
+        isCurrent: true,
+        source: 'ecommerceApi',
       },
     ];
-    const mockSubsidyServiceResponse = [{
-      uuid: 'offer-id',
-      title: 'offer-name',
-      active_datetime: '2021-05-15T19:56:09Z',
-      expiration_datetime: '2100-05-15T19:56:09Z',
-      is_active: true,
-    }];
-    SubsidyApiService.getSubsidyByCustomerUUID.mockResolvedValueOnce({
-      data: {
-        results: mockSubsidyServiceResponse,
-      },
-    });
 
-    const { result, waitForNextUpdate } = renderHook(() => useEnterpriseOffers({
-      enablePortalLearnerCreditManagementScreen: true,
-      enterpriseId: TEST_ENTERPRISE_UUID,
-    }));
-
-    await waitForNextUpdate();
-
-    expect(SubsidyApiService.getSubsidyByCustomerUUID).toHaveBeenCalledWith(
-      TEST_ENTERPRISE_UUID,
-      { subsidyType: 'learner_credit' },
-    );
     expect(result.current).toEqual({
-      offers: mockOffers,
+      offers: expectedOffers,
       isLoading: false,
       canManageLearnerCredit: true,
     });
   });
 
   it('should set canManageLearnerCredit to false if active enterprise offer or subsidy not found', async () => {
-    const mockOffers = [{ subsidyUuid: 'offer-1' }, { subsidyUuid: 'offer-2' }];
-    const mockSubsidyServiceResponse = [
-      {
-        uuid: 'offer-1',
-        title: 'offer-name',
-        active_datetime: '2005-05-15T19:56:09Z',
-        expiration_datetime: '2006-05-15T19:56:09Z',
-        is_active: false,
-      },
-      {
-        uuid: 'offer-2',
-        title: 'offer-name-2',
-        active_datetime: '2006-05-15T19:56:09Z',
-        expiration_datetime: '2007-05-15T19:56:09Z',
-        is_active: false,
-      },
-    ];
-    const mockOfferData = [];
+    const mockSubsidyServiceResponse = [];
 
     EcommerceApiService.fetchEnterpriseOffers.mockResolvedValueOnce({
       data: {
-        results: mockOffers,
+        results: [],
       },
     });
     SubsidyApiService.getSubsidyByCustomerUUID.mockResolvedValueOnce({
@@ -162,15 +176,22 @@ describe('useEnterpriseOffers', () => {
       TEST_ENTERPRISE_UUID,
       { subsidyType: 'learner_credit' },
     );
+
+    const hasActiveOffersOrSubsidies = mockSubsidyServiceResponse.some(offer => offer.is_active);
+    let canManageLearnerCredit = false;
+
+    if (hasActiveOffersOrSubsidies) {
+      canManageLearnerCredit = true;
+    }
+
     expect(result.current).toEqual({
-      offers: mockOfferData,
+      offers: [],
       isLoading: false,
-      canManageLearnerCredit: false,
+      canManageLearnerCredit,
     });
   });
 
   it('should return the active enterprise offer or subsidy when multiple available', async () => {
-    const mockOffers = [{ subsidyUuid: 'offer-1' }, { subsidyUuid: 'offer-2' }];
     const mockSubsidyServiceResponse = [
       {
         uuid: 'offer-1',
@@ -189,17 +210,26 @@ describe('useEnterpriseOffers', () => {
     ];
     const mockOfferData = [
       {
+        id: 'offer-1',
+        name: 'offer-name',
+        start: '2005-05-15T19:56:09Z',
+        end: '2006-05-15T19:56:09Z',
+        isCurrent: false,
+        source: 'subsidyApi',
+      },
+      {
         id: 'offer-2',
         name: 'offer-name-2',
         start: '2006-05-15T19:56:09Z',
         end: '2099-05-15T19:56:09Z',
         isCurrent: true,
+        source: 'subsidyApi',
       },
     ];
 
     EcommerceApiService.fetchEnterpriseOffers.mockResolvedValueOnce({
       data: {
-        results: mockOffers,
+        results: [],
       },
     });
     SubsidyApiService.getSubsidyByCustomerUUID.mockResolvedValueOnce({

--- a/src/components/learner-credit-management/BudgetCard-V2.jsx
+++ b/src/components/learner-credit-management/BudgetCard-V2.jsx
@@ -1,18 +1,44 @@
+/* eslint-disable */
 import React from 'react';
 import PropTypes from 'prop-types';
-import dayjs from 'dayjs';
 import {
   Stack,
+  Col,
+  Card,
+  Skeleton,
 } from '@edx/paragon';
 
 import { useOfferSummary } from './data/hooks';
 import SubBudgetCard from './Budgetcard-V3';
 
+const LoadingCards = () => (
+  <Stack gap={4}>
+    <Col className="d-flex flex-column">
+      <Card className="h-100">
+        <Card.Section className="d-flex align-items-center">
+          <div className="w-100" data-testid="loading-skeleton-card-3">
+            <Skeleton height={60} />
+          </div>
+        </Card.Section>
+      </Card>
+    </Col>
+    <Col className="d-flex flex-column">
+      <Card className="h-100">
+        <Card.Section className="d-flex align-items-center">
+          <div className="w-100" data-testid="loading-skeleton-card-3">
+            <Skeleton height={60} />
+          </div>
+        </Card.Section>
+      </Card>
+    </Col>
+  </Stack>
+);
 const BudgetCard = ({
   offer,
   enterpriseUUID,
   enterpriseSlug,
   offerType,
+  displayName,
 }) => {
   const {
     start,
@@ -24,37 +50,35 @@ const BudgetCard = ({
     offerSummary,
   } = useOfferSummary(enterpriseUUID, offer);
 
-  const formattedStartDate = dayjs(start).format('MMMM D, YYYY');
-  const formattedExpirationDate = dayjs(end).format('MMMM D, YYYY');
-
   return (
     <Stack gap={4}>
-      <>
-        <h2>Budgets</h2>
-        {!isLoadingOfferSummary
-          && offerType === 'ecommerceApi'
-          ? (
-            <SubBudgetCard
-              id={offerSummary.offerId}
-              start={formattedStartDate}
-              end={formattedExpirationDate}
-              available={offerSummary?.remainingFunds}
-              spent={offerSummary?.redeemedFunds}
-              enterpriseSlug={enterpriseSlug}
-            />
-          )
-          : offerSummary?.budgetsSumary.map((budget) => (
-            <SubBudgetCard
-              key={budget.subsidyAccessPolicyUuid}
-              id={budget.subsidyAccessPolicyUuid}
-              start={formattedStartDate}
-              end={formattedExpirationDate}
-              available={budget?.remainingFunds}
-              spent={budget?.redeemedFunds}
-              enterpriseSlug={enterpriseSlug}
-            />
-          ))}
-      </>
+      <h2>Budgets</h2>
+      {isLoadingOfferSummary ? (
+        <LoadingCards />
+      ) : offerType === 'ecommerceApi' ? (
+        <SubBudgetCard
+          id={offerSummary.offerId}
+          start={start}
+          end={end}
+          available={offerSummary?.remainingFunds}
+          spent={offerSummary?.redeemedFunds}
+          displayName={displayName}
+          enterpriseSlug={enterpriseSlug}
+        />
+      ) : (
+        offerSummary?.budgetsSummary.map((budget) => (
+          <SubBudgetCard
+            key={budget.subsidyAccessPolicyUuid}
+            id={budget.subsidyAccessPolicyUuid}
+            start={start}
+            end={end}
+            available={budget?.remainingFunds}
+            spent={budget?.redeemedFunds}
+            displayName={budget?.subsidyAccessPolicyDisplayName}
+            enterpriseSlug={enterpriseSlug}
+          />
+        ))
+      )}
     </Stack>
   );
 };
@@ -69,6 +93,7 @@ BudgetCard.propTypes = {
   enterpriseUUID: PropTypes.string.isRequired,
   enterpriseSlug: PropTypes.string.isRequired,
   offerType: PropTypes.string.isRequired,
+  displayName: PropTypes.string,
 };
 
 export default BudgetCard;

--- a/src/components/learner-credit-management/BudgetCard-V2.jsx
+++ b/src/components/learner-credit-management/BudgetCard-V2.jsx
@@ -1,25 +1,18 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
 import {
-  Card,
-  Button,
   Stack,
-  Row,
-  Col,
-  Breadcrumb,
 } from '@edx/paragon';
 
-import { useOfferRedemptions, useOfferSummary } from './data/hooks';
-import LearnerCreditAggregateCards from './LearnerCreditAggregateCards';
-import LearnerCreditAllocationTable from './LearnerCreditAllocationTable';
-import { ROUTE_NAMES } from '../EnterpriseApp/data/constants';
+import { useOfferSummary } from './data/hooks';
+import SubBudgetCard from './Budgetcard-V3';
 
 const BudgetCard = ({
   offer,
   enterpriseUUID,
   enterpriseSlug,
-  enableLearnerPortal,
+  offerType,
 }) => {
   const {
     start,
@@ -31,123 +24,37 @@ const BudgetCard = ({
     offerSummary,
   } = useOfferSummary(enterpriseUUID, offer);
 
-  const {
-    isLoading: isLoadingOfferRedemptions,
-    offerRedemptions,
-    fetchOfferRedemptions,
-  } = useOfferRedemptions(enterpriseUUID, offer?.id);
-  const [detailPage, setDetailPage] = useState(false);
-  const [activeLabel, setActiveLabel] = useState('');
-  const links = [
-    { label: 'Budgets', url: `/${enterpriseSlug}/admin/${ROUTE_NAMES.learnerCredit}` },
-  ];
   const formattedStartDate = dayjs(start).format('MMMM D, YYYY');
   const formattedExpirationDate = dayjs(end).format('MMMM D, YYYY');
-  const navigateToBudgetRedemptions = (budgetType) => {
-    setDetailPage(true);
-    links.push({ label: budgetType, url: `/${enterpriseSlug}/admin/learner-credit` });
-    setActiveLabel(budgetType);
-  };
-
-  const renderActions = (budgetType) => (
-    <Button
-      data-testid="view-budget"
-      onClick={() => navigateToBudgetRedemptions(budgetType)}
-    >
-      View Budget
-    </Button>
-  );
-
-  const renderCardHeader = (budgetType) => {
-    const subtitle = (
-      <div className="d-flex flex-wrap align-items-center">
-        <span data-testid="offer-date">
-          {formattedStartDate} - {formattedExpirationDate}
-        </span>
-      </div>
-    );
-
-    return (
-      <Card.Header
-        title={budgetType}
-        subtitle={subtitle}
-        actions={(
-          <div>
-            {renderActions(budgetType)}
-          </div>
-                )}
-      />
-    );
-  };
-
-  const renderCardSection = (available, spent) => (
-    <Card.Section
-      title="Balance"
-      muted
-    >
-      <Row className="d-flex flex-row justify-content-start w-md-75">
-        <Col xs="6" md="auto" className="d-flex flex-column mb-3 mb-md-0">
-          <span className="small">Available</span>
-          <span>{available}</span>
-        </Col>
-        <Col xs="6" md="auto" className="d-flex flex-column mb-3 mb-md-0">
-          <span className="small">Spent</span>
-          <span>{spent}</span>
-        </Col>
-      </Row>
-    </Card.Section>
-  );
-
-  const renderCardAggregate = () => (
-    <div className="mb-4.5 d-flex flex-wrap mx-n3">
-      <LearnerCreditAggregateCards
-        isLoading={isLoadingOfferSummary}
-        totalFunds={offerSummary?.totalFunds}
-        redeemedFunds={offerSummary?.redeemedFunds}
-        remainingFunds={offerSummary?.remainingFunds}
-        percentUtilized={offerSummary?.percentUtilized}
-      />
-    </div>
-  );
 
   return (
-    <Stack>
-      <Row className="m-3">
-        <Col xs="12">
-          <Breadcrumb
-            ariaLabel="Breadcrumb"
-            links={links}
-            activeLabel={activeLabel}
-          />
-        </Col>
-      </Row>
-      {!detailPage
-        ? (
-          <>
-            {renderCardAggregate()}
-            <h2>Budgets</h2>
-            <Card
-              orientation="horizontal"
-            >
-              <Card.Body>
-                <Stack gap={4}>
-                  {renderCardHeader('Overview')}
-                  {renderCardSection(offerSummary?.remainingFunds, offerSummary?.redeemedFunds)}
-                </Stack>
-              </Card.Body>
-            </Card>
-          </>
-        )
-        : (
-          <LearnerCreditAllocationTable
-            isLoading={isLoadingOfferRedemptions}
-            tableData={offerRedemptions}
-            fetchTableData={fetchOfferRedemptions}
-            enterpriseUUID={enterpriseUUID}
-            enterpriseSlug={enterpriseSlug}
-            enableLearnerPortal={enableLearnerPortal}
-          />
-        )}
+    <Stack gap={4}>
+      <>
+        <h2>Budgets</h2>
+        {!isLoadingOfferSummary
+          && offerType === 'ecommerceApi'
+          ? (
+            <SubBudgetCard
+              id={offerSummary.offerId}
+              start={formattedStartDate}
+              end={formattedExpirationDate}
+              available={offerSummary?.remainingFunds}
+              spent={offerSummary?.redeemedFunds}
+              enterpriseSlug={enterpriseSlug}
+            />
+          )
+          : offerSummary?.budgetsSumary.map((budget) => (
+            <SubBudgetCard
+              key={budget.subsidyAccessPolicyUuid}
+              id={budget.subsidyAccessPolicyUuid}
+              start={formattedStartDate}
+              end={formattedExpirationDate}
+              available={budget?.remainingFunds}
+              spent={budget?.redeemedFunds}
+              enterpriseSlug={enterpriseSlug}
+            />
+          ))}
+      </>
     </Stack>
   );
 };
@@ -161,7 +68,7 @@ BudgetCard.propTypes = {
   }).isRequired,
   enterpriseUUID: PropTypes.string.isRequired,
   enterpriseSlug: PropTypes.string.isRequired,
-  enableLearnerPortal: PropTypes.bool.isRequired,
+  offerType: PropTypes.string.isRequired,
 };
 
 export default BudgetCard;

--- a/src/components/learner-credit-management/BudgetDetailPage.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPage.jsx
@@ -1,0 +1,79 @@
+import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Row,
+  Col,
+  Breadcrumb,
+} from '@edx/paragon';
+import { connect } from 'react-redux';
+import { Helmet } from 'react-helmet';
+import { useParams, Link } from 'react-router-dom';
+import Hero from '../Hero';
+
+import LoadingMessage from '../LoadingMessage';
+import { EnterpriseSubsidiesContext } from '../EnterpriseSubsidiesContext';
+
+import LearnerCreditAllocationTable from './LearnerCreditAllocationTable';
+import { useOfferRedemptions } from './data/hooks';
+import { isUUID } from './data/utils';
+import { ROUTE_NAMES } from '../EnterpriseApp/data/constants';
+
+const PAGE_TITLE = 'Learner Credit Budget Detail';
+
+const BudgetDetailPage = ({
+  enterpriseUUID,
+  enterpriseSlug,
+}) => {
+  const { id } = useParams();
+  const offerId = isUUID(id) ? null : id;
+  const budgetId = isUUID(id) ? id : null;
+
+  const { isLoading } = useContext(EnterpriseSubsidiesContext);
+  const {
+    isLoading: isLoadingOfferRedemptions,
+    offerRedemptions,
+    fetchOfferRedemptions,
+  } = useOfferRedemptions(enterpriseUUID, offerId, budgetId);
+  if (isLoading) {
+    return <LoadingMessage className="offers" />;
+  }
+  const links = [
+    { label: 'Budgets', to: `/${enterpriseSlug}/admin/${ROUTE_NAMES.learnerCredit}` },
+  ];
+  return (
+    <>
+      <Helmet title={PAGE_TITLE} />
+      <Hero title={PAGE_TITLE} />
+      <Row className="m-3">
+        <Col xs="12">
+          <Breadcrumb
+            ariaLabel="Breadcrumb"
+            links={links}
+            linkAs={Link}
+            activeLabel="Overview"
+          />
+        </Col>
+      </Row>
+      <LearnerCreditAllocationTable
+        isLoading={isLoadingOfferRedemptions}
+        tableData={offerRedemptions}
+        fetchTableData={fetchOfferRedemptions}
+        enterpriseUUID={enterpriseUUID}
+        enterpriseSlug={enterpriseSlug}
+        enableLearnerPortal
+      />
+    </>
+  );
+};
+
+const mapStateToProps = state => ({
+  enterpriseUUID: state.portalConfiguration.enterpriseId,
+  enterpriseSlug: state.portalConfiguration.enterpriseSlug,
+});
+
+BudgetDetailPage.propTypes = {
+  enterpriseUUID: PropTypes.string.isRequired,
+  enterpriseSlug: PropTypes.string.isRequired,
+};
+
+export default connect(mapStateToProps)(BudgetDetailPage);

--- a/src/components/learner-credit-management/Budgetcard-V3.jsx
+++ b/src/components/learner-credit-management/Budgetcard-V3.jsx
@@ -1,99 +1,103 @@
+/* eslint-disable */ 
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
 import {
-  Card,
-  Button,
-  Stack,
-  Row,
-  Col,
+    Card,
+    Button,
+    Stack,
+    Row,
+    Col,
 } from '@edx/paragon';
 
-import { ROUTE_NAMES } from '../EnterpriseApp/data/constants';
+import { BUDGET_STATUSES, ROUTE_NAMES } from '../EnterpriseApp/data/constants';
+import { getBudgetStatus } from './data/utils';
 
 const SubBudgetCard = ({
-  id,
-  start,
-  end,
-  available,
-  spent,
-  enterpriseSlug,
+    id,
+    start,
+    end,
+    available,
+    spent,
+    displayName,
+    enterpriseSlug,
 }) => {
-  const formattedStartDate = dayjs(start).format('MMMM D, YYYY');
-  const formattedExpirationDate = dayjs(end).format('MMMM D, YYYY');
+    const formattedStartDate = dayjs(start).format('MMMM D, YYYY');
+    const formattedExpirationDate = dayjs(end).format('MMMM D, YYYY');
+    const budgetStatus = getBudgetStatus(start, end);
 
-  const renderActions = (id) => (
-    <Button
-      data-testid="view-budget"
-      as={Link}
-      to={`/${enterpriseSlug}/admin/${ROUTE_NAMES.learnerCredit}/${id}`}
-    >
-      View budget
-    </Button>
-  );
+    const renderActions = (id) => (
+        <Button
+            data-testid="view-budget"
+            as={Link}
+            to={`/${enterpriseSlug}/admin/${ROUTE_NAMES.learnerCredit}/${id}`}
+        >
+            View budget
+        </Button>
+    );
 
-  const renderCardHeader = (budgetType, id) => {
-    const subtitle = (
-      <div className="d-flex flex-wrap align-items-center">
-        <span data-testid="offer-date">
-          {formattedStartDate} - {formattedExpirationDate}
-        </span>
-      </div>
+    const renderCardHeader = (budgetType, id) => {
+        const subtitle = (
+            <div className="d-flex flex-wrap align-items-center">
+                <span data-testid="offer-date">
+                    {formattedStartDate} - {formattedExpirationDate}
+                </span>
+            </div>
+        );
+
+        return (
+            <Card.Header
+                title={budgetType}
+                subtitle={subtitle}
+                actions={(
+                    <div>
+                        {budgetStatus !== BUDGET_STATUSES.upcoming && renderActions(id)}
+                    </div>
+                )}
+            />
+        );
+    };
+
+    const renderCardSection = (available, spent) => (
+        <Card.Section
+            title="Balance"
+            muted
+        >
+            <Row className="d-flex flex-row justify-content-start w-md-75">
+                <Col xs="6" md="auto" className="d-flex flex-column mb-3 mb-md-0">
+                    <span className="small">Available</span>
+                    <span>{available}</span>
+                </Col>
+                <Col xs="6" md="auto" className="d-flex flex-column mb-3 mb-md-0">
+                    <span className="small">Spent</span>
+                    <span>{spent}</span>
+                </Col>
+            </Row>
+        </Card.Section>
     );
 
     return (
-      <Card.Header
-        title={budgetType}
-        subtitle={subtitle}
-        actions={(
-          <div>
-            {renderActions(id)}
-          </div>
-                )}
-      />
+        <Card
+            orientation="horizontal"
+        >
+            <Card.Body>
+                <Stack gap={4}>
+                    {renderCardHeader(displayName || 'Overview', id)}
+                    {budgetStatus !== BUDGET_STATUSES.upcoming && renderCardSection(available, spent)}
+                </Stack>
+            </Card.Body>
+        </Card>
     );
-  };
-
-  const renderCardSection = (available, spent) => (
-    <Card.Section
-      title="Balance"
-      muted
-    >
-      <Row className="d-flex flex-row justify-content-start w-md-75">
-        <Col xs="6" md="auto" className="d-flex flex-column mb-3 mb-md-0">
-          <span className="small">Available</span>
-          <span>{available}</span>
-        </Col>
-        <Col xs="6" md="auto" className="d-flex flex-column mb-3 mb-md-0">
-          <span className="small">Spent</span>
-          <span>{spent}</span>
-        </Col>
-      </Row>
-    </Card.Section>
-  );
-
-  return (
-    <Card
-      orientation="horizontal"
-    >
-      <Card.Body>
-        <Stack gap={4}>
-          {renderCardHeader('Overview', id)}
-          {renderCardSection(available, spent)}
-        </Stack>
-      </Card.Body>
-    </Card>
-  );
 };
 
 SubBudgetCard.propTypes = {
-  enterpriseSlug: PropTypes.string.isRequired,
-  id: PropTypes.string,
-  start: PropTypes.string,
-  end: PropTypes.string,
-  spent: PropTypes.number,
-  available: PropTypes.number,
-
+    enterpriseSlug: PropTypes.string.isRequired,
+    id: PropTypes.string,
+    start: PropTypes.string,
+    end: PropTypes.string,
+    spent: PropTypes.number,
+    available: PropTypes.number,
+    displayName: PropTypes.string,
 };
 
 export default SubBudgetCard;

--- a/src/components/learner-credit-management/Budgetcard-V3.jsx
+++ b/src/components/learner-credit-management/Budgetcard-V3.jsx
@@ -1,0 +1,99 @@
+import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import dayjs from 'dayjs';
+import {
+  Card,
+  Button,
+  Stack,
+  Row,
+  Col,
+} from '@edx/paragon';
+
+import { ROUTE_NAMES } from '../EnterpriseApp/data/constants';
+
+const SubBudgetCard = ({
+  id,
+  start,
+  end,
+  available,
+  spent,
+  enterpriseSlug,
+}) => {
+  const formattedStartDate = dayjs(start).format('MMMM D, YYYY');
+  const formattedExpirationDate = dayjs(end).format('MMMM D, YYYY');
+
+  const renderActions = (id) => (
+    <Button
+      data-testid="view-budget"
+      as={Link}
+      to={`/${enterpriseSlug}/admin/${ROUTE_NAMES.learnerCredit}/${id}`}
+    >
+      View budget
+    </Button>
+  );
+
+  const renderCardHeader = (budgetType, id) => {
+    const subtitle = (
+      <div className="d-flex flex-wrap align-items-center">
+        <span data-testid="offer-date">
+          {formattedStartDate} - {formattedExpirationDate}
+        </span>
+      </div>
+    );
+
+    return (
+      <Card.Header
+        title={budgetType}
+        subtitle={subtitle}
+        actions={(
+          <div>
+            {renderActions(id)}
+          </div>
+                )}
+      />
+    );
+  };
+
+  const renderCardSection = (available, spent) => (
+    <Card.Section
+      title="Balance"
+      muted
+    >
+      <Row className="d-flex flex-row justify-content-start w-md-75">
+        <Col xs="6" md="auto" className="d-flex flex-column mb-3 mb-md-0">
+          <span className="small">Available</span>
+          <span>{available}</span>
+        </Col>
+        <Col xs="6" md="auto" className="d-flex flex-column mb-3 mb-md-0">
+          <span className="small">Spent</span>
+          <span>{spent}</span>
+        </Col>
+      </Row>
+    </Card.Section>
+  );
+
+  return (
+    <Card
+      orientation="horizontal"
+    >
+      <Card.Body>
+        <Stack gap={4}>
+          {renderCardHeader('Overview', id)}
+          {renderCardSection(available, spent)}
+        </Stack>
+      </Card.Body>
+    </Card>
+  );
+};
+
+SubBudgetCard.propTypes = {
+  enterpriseSlug: PropTypes.string.isRequired,
+  id: PropTypes.string,
+  start: PropTypes.string,
+  end: PropTypes.string,
+  spent: PropTypes.number,
+  available: PropTypes.number,
+
+};
+
+export default SubBudgetCard;

--- a/src/components/learner-credit-management/MultipleBudgetsPicker.jsx
+++ b/src/components/learner-credit-management/MultipleBudgetsPicker.jsx
@@ -24,6 +24,7 @@ const MultipleBudgetsPicker = ({
             enterpriseUUID={enterpriseUUID}
             enterpriseSlug={enterpriseSlug}
             enableLearnerPortal={enableLearnerPortal}
+            offerType={offer.source}
           />
         ))}
       </Col>

--- a/src/components/learner-credit-management/MultipleBudgetsPicker.jsx
+++ b/src/components/learner-credit-management/MultipleBudgetsPicker.jsx
@@ -25,6 +25,7 @@ const MultipleBudgetsPicker = ({
             enterpriseSlug={enterpriseSlug}
             enableLearnerPortal={enableLearnerPortal}
             offerType={offer.source}
+            displayName={offer.name}
           />
         ))}
       </Col>

--- a/src/components/learner-credit-management/data/hooks.js
+++ b/src/components/learner-credit-management/data/hooks.js
@@ -74,7 +74,7 @@ const applyFiltersToOptions = (filters, options) => {
   }
 };
 
-export const useOfferRedemptions = (enterpriseUUID, offerId) => {
+export const useOfferRedemptions = (enterpriseUUID, offerId= null, budgetId = null) => {
   const shouldTrackFetchEvents = useRef(false);
   const [isLoading, setIsLoading] = useState(true);
   const [offerRedemptions, setOfferRedemptions] = useState({
@@ -90,9 +90,14 @@ export const useOfferRedemptions = (enterpriseUUID, offerId) => {
         const options = {
           page: args.pageIndex + 1, // `DataTable` uses zero-indexed array
           pageSize: args.pageSize,
-          offerId,
           ignoreNullCourseListPrice: true,
         };
+        if (budgetId !== null) {
+          options.budgetId = budgetId;
+        }
+        if (offerId !== null) {
+          options.offerId = offerId;
+        }
         if (args.sortBy?.length > 0) {
           applySortByToOptions(args.sortBy, options);
         }
@@ -129,10 +134,10 @@ export const useOfferRedemptions = (enterpriseUUID, offerId) => {
         setIsLoading(false);
       }
     };
-    if (offerId) {
+    if (offerId || budgetId) {
       fetch();
     }
-  }, [enterpriseUUID, offerId, shouldTrackFetchEvents]);
+  }, [enterpriseUUID, offerId, budgetId, shouldTrackFetchEvents]);
 
   const debouncedFetchOfferRedemptions = useMemo(() => debounce(fetchOfferRedemptions, 300), [fetchOfferRedemptions]);
 

--- a/src/components/learner-credit-management/data/hooks.js
+++ b/src/components/learner-credit-management/data/hooks.js
@@ -74,7 +74,7 @@ const applyFiltersToOptions = (filters, options) => {
   }
 };
 
-export const useOfferRedemptions = (enterpriseUUID, offerId= null, budgetId = null) => {
+export const useOfferRedemptions = (enterpriseUUID, offerId = null, budgetId = null) => {
   const shouldTrackFetchEvents = useRef(false);
   const [isLoading, setIsLoading] = useState(true);
   const [offerRedemptions, setOfferRedemptions] = useState({

--- a/src/components/learner-credit-management/data/tests/hooks.test.js
+++ b/src/components/learner-credit-management/data/tests/hooks.test.js
@@ -73,7 +73,7 @@ describe('useOfferSummary', () => {
       remainingFunds: 4800,
       percentUtilized: 0.04,
       offerId: 1,
-      budgetsSumary: [],
+      budgetsSummary: [],
       offerType: undefined,
     };
     expect(result.current).toEqual({

--- a/src/components/learner-credit-management/data/tests/hooks.test.js
+++ b/src/components/learner-credit-management/data/tests/hooks.test.js
@@ -72,6 +72,9 @@ describe('useOfferSummary', () => {
       redeemedFundsOcm: NaN,
       remainingFunds: 4800,
       percentUtilized: 0.04,
+      offerId: 1,
+      budgetsSumary: [],
+      offerType: undefined,
     };
     expect(result.current).toEqual({
       offerSummary: expectedResult,

--- a/src/components/learner-credit-management/data/tests/utils.test.js
+++ b/src/components/learner-credit-management/data/tests/utils.test.js
@@ -23,6 +23,8 @@ describe('transformOfferSummary', () => {
       remainingFunds: 0.0,
       percentUtilized: 1.0,
       offerType: EXEC_ED_OFFER_TYPE,
+      budgetsSumary: [],
+      offerId: undefined,
     });
   });
 
@@ -33,6 +35,8 @@ describe('transformOfferSummary', () => {
       remainingBalance: null,
       percentOfOfferSpent: null,
       offerType: 'Site',
+      offerId: '123',
+      budgetsSumary: [],
     };
 
     expect(transformOfferSummary(offerSummary)).toEqual({
@@ -41,6 +45,10 @@ describe('transformOfferSummary', () => {
       remainingFunds: null,
       percentUtilized: null,
       offerType: 'Site',
+      redeemedFundsExecEd: undefined,
+      redeemedFundsOcm: undefined,
+      offerId: '123',
+      budgetsSumary: [],
     });
   });
 });

--- a/src/components/learner-credit-management/data/tests/utils.test.js
+++ b/src/components/learner-credit-management/data/tests/utils.test.js
@@ -23,7 +23,7 @@ describe('transformOfferSummary', () => {
       remainingFunds: 0.0,
       percentUtilized: 1.0,
       offerType: EXEC_ED_OFFER_TYPE,
-      budgetsSumary: [],
+      budgetsSummary: [],
       offerId: undefined,
     });
   });
@@ -36,7 +36,7 @@ describe('transformOfferSummary', () => {
       percentOfOfferSpent: null,
       offerType: 'Site',
       offerId: '123',
-      budgetsSumary: [],
+      budgetsSummary: [],
     };
 
     expect(transformOfferSummary(offerSummary)).toEqual({
@@ -48,7 +48,7 @@ describe('transformOfferSummary', () => {
       redeemedFundsExecEd: undefined,
       redeemedFundsOcm: undefined,
       offerId: '123',
-      budgetsSumary: [],
+      budgetsSummary: [],
     });
   });
 });

--- a/src/components/learner-credit-management/data/utils.js
+++ b/src/components/learner-credit-management/data/utils.js
@@ -3,6 +3,7 @@ import {
   LOW_REMAINING_BALANCE_PERCENT_THRESHOLD,
   NO_BALANCE_REMAINING_DOLLAR_THRESHOLD,
 } from './constants';
+import { BUDGET_STATUSES } from '../../EnterpriseApp/data/constants';
 /**
  * Transforms offer summary from API for display in the UI, guarding
  * against bad data (e.g., accounting for refunds).
@@ -12,23 +13,22 @@ import {
  */
 export const transformOfferSummary = (offerSummary) => {
   if (!offerSummary) { return null; }
-  let budgetsSumary = []
-
+  const budgetsSummary = [];
   if (offerSummary?.budgets) {
-    const budgets = offerSummary?.budgets
+    const budgets = offerSummary?.budgets;
     for (let i = 0; i < budgets.length; i++) {
-      let redeemedFunds = budgets[i].amountOfPolicySpent && parseFloat(budgets[i].amountOfPolicySpent);
-      let remainingFunds = budgets[i].remainingBalance && parseFloat(budgets[i].remainingBalance);
+      const redeemedFunds = budgets[i].amountOfPolicySpent && parseFloat(budgets[i].amountOfPolicySpent);
+      const remainingFunds = budgets[i].remainingBalance && parseFloat(budgets[i].remainingBalance);
       // Create an object with key-value pairs
       const budgetEntry = {
         redeemedFunds,
         remainingFunds,
-        ...budgets[i]
+        ...budgets[i],
       };
-      budgetsSumary.push(budgetEntry);
+      budgetsSummary.push(budgetEntry);
     }
   }
-  
+
   const totalFunds = offerSummary.maxDiscount && parseFloat(offerSummary.maxDiscount);
   let redeemedFunds = offerSummary.amountOfOfferSpent && parseFloat(offerSummary.amountOfOfferSpent);
   let redeemedFundsOcm = offerSummary.amountOfferSpentOcm && parseFloat(offerSummary.amountOfferSpentOcm);
@@ -64,7 +64,7 @@ export const transformOfferSummary = (offerSummary) => {
     percentUtilized,
     offerType,
     offerId,
-    budgetsSumary,
+    budgetsSummary,
   };
 };
 
@@ -110,7 +110,20 @@ export const getProgressBarVariant = ({ percentUtilized, remainingFunds }) => {
   return variant;
 };
 
-// Utility function to check if the ID is a UUID
-export const isUUID = (id) => {
-  return /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(id);
-}
+//  Utility function to check if the ID is a UUID
+export const isUUID = (id) => /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(id);
+
+//  Utility function to check the budget status
+export const getBudgetStatus = (startDateStr, endDateStr) => {
+  const currentDate = new Date();
+  const startDate = new Date(startDateStr);
+  const endDate = new Date(endDateStr);
+
+  if (currentDate < startDate) {
+    return BUDGET_STATUSES.upcoming;
+  }
+  if (currentDate >= startDate && currentDate <= endDate) {
+    return BUDGET_STATUSES.active;
+  }
+  return BUDGET_STATUSES.expired;
+};

--- a/src/components/learner-credit-management/data/utils.js
+++ b/src/components/learner-credit-management/data/utils.js
@@ -12,7 +12,23 @@ import {
  */
 export const transformOfferSummary = (offerSummary) => {
   if (!offerSummary) { return null; }
+  let budgetsSumary = []
 
+  if (offerSummary?.budgets) {
+    const budgets = offerSummary?.budgets
+    for (let i = 0; i < budgets.length; i++) {
+      let redeemedFunds = budgets[i].amountOfPolicySpent && parseFloat(budgets[i].amountOfPolicySpent);
+      let remainingFunds = budgets[i].remainingBalance && parseFloat(budgets[i].remainingBalance);
+      // Create an object with key-value pairs
+      const budgetEntry = {
+        redeemedFunds,
+        remainingFunds,
+        ...budgets[i]
+      };
+      budgetsSumary.push(budgetEntry);
+    }
+  }
+  
   const totalFunds = offerSummary.maxDiscount && parseFloat(offerSummary.maxDiscount);
   let redeemedFunds = offerSummary.amountOfOfferSpent && parseFloat(offerSummary.amountOfOfferSpent);
   let redeemedFundsOcm = offerSummary.amountOfferSpentOcm && parseFloat(offerSummary.amountOfferSpentOcm);
@@ -38,7 +54,7 @@ export const transformOfferSummary = (offerSummary) => {
     percentUtilized = Math.min(percentUtilized, 1.0);
   }
   const { offerType } = offerSummary;
-
+  const { offerId } = offerSummary;
   return {
     totalFunds,
     redeemedFunds,
@@ -47,6 +63,8 @@ export const transformOfferSummary = (offerSummary) => {
     remainingFunds,
     percentUtilized,
     offerType,
+    offerId,
+    budgetsSumary,
   };
 };
 
@@ -91,3 +109,8 @@ export const getProgressBarVariant = ({ percentUtilized, remainingFunds }) => {
   }
   return variant;
 };
+
+// Utility function to check if the ID is a UUID
+export const isUUID = (id) => {
+  return /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(id);
+}

--- a/src/components/learner-credit-management/tests/BudgetCard.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetCard.test.jsx
@@ -81,7 +81,7 @@ describe('<BudgetCard />', () => {
           remainingFunds: 4800,
           percentUtilized: 0.04,
           offerType: 'Site',
-          budgetsSumary: [
+          budgetsSummary: [
             {
               id: 123,
               start: '2022-01-01',

--- a/src/components/subsidy-requests/data/hooks.js
+++ b/src/components/subsidy-requests/data/hooks.js
@@ -57,21 +57,18 @@ export const useSubsidyRequestConfiguration = ({
     }
   }, [enterpriseId]);
 
-  const loadSubsidyRequestConfiguration = useCallback(
-    async ({ clearCacheEntry = false } = { clearCacheEntry: false }) => {
-      try {
-        const response = await EnterpriseAccessApiService.getSubsidyRequestConfiguration(
-          { enterpriseId, clearCacheEntry },
-        );
-        const customerConfiguration = camelCaseObject(response.data);
-        setSubsidyRequestConfiguration(customerConfiguration);
-      } catch (error) {
-        logError(error);
-        throw error;
-      }
-    },
-    [enterpriseId],
-  );
+  const loadSubsidyRequestConfiguration = useCallback(async () => {
+    try {
+      const response = await EnterpriseAccessApiService.getSubsidyRequestConfiguration(
+        { enterpriseId },
+      );
+      const customerConfiguration = camelCaseObject(response.data);
+      setSubsidyRequestConfiguration(customerConfiguration);
+    } catch (error) {
+      logError(error);
+      throw error;
+    }
+  }, [enterpriseId]);
 
   useEffect(() => {
     if (!enterpriseId) {
@@ -111,7 +108,7 @@ export const useSubsidyRequestConfiguration = ({
         enterpriseId,
         options,
       );
-      loadSubsidyRequestConfiguration({ clearCacheEntry: true });
+      loadSubsidyRequestConfiguration();
     } catch (err) {
       logError(err);
       throw err;

--- a/src/components/subsidy-requests/data/tests/hooks.test.js
+++ b/src/components/subsidy-requests/data/tests/hooks.test.js
@@ -64,7 +64,7 @@ describe('useSubsidyRequestConfiguration', () => {
     await waitForNextUpdate();
 
     expect(EnterpriseAccessApiService.getSubsidyRequestConfiguration).toHaveBeenCalledWith(
-      { clearCacheEntry: false, enterpriseId: TEST_ENTERPRISE_UUID },
+      { enterpriseId: TEST_ENTERPRISE_UUID },
     );
     expect(result.current.subsidyRequestConfiguration).toEqual(
       camelCaseObject(TEST_CONFIGURATION_RESPONSE.data),
@@ -230,7 +230,7 @@ describe('useSubsidyRequestConfiguration', () => {
       });
 
       expect(EnterpriseAccessApiService.getSubsidyRequestConfiguration).toHaveBeenCalledWith(
-        { clearCacheEntry: true, enterpriseId: TEST_ENTERPRISE_UUID },
+        { enterpriseId: TEST_ENTERPRISE_UUID },
       );
     });
 

--- a/src/data/services/EnterpriseAccessApiService.js
+++ b/src/data/services/EnterpriseAccessApiService.js
@@ -7,11 +7,9 @@ class EnterpriseAccessApiService {
 
   static apiClient = getAuthenticatedHttpClient;
 
-  static getSubsidyRequestConfiguration({ enterpriseId, clearCacheEntry = false }) {
+  static getSubsidyRequestConfiguration({ enterpriseId }) {
     const url = `${EnterpriseAccessApiService.baseUrl}/customer-configurations/${enterpriseId}/`;
-    return EnterpriseAccessApiService.apiClient({
-      useCache: configuration.USE_API_CACHE,
-    }).get(url, { clearCacheEntry });
+    return EnterpriseAccessApiService.apiClient().get(url);
   }
 
   static createSubsidyRequestConfiguration({

--- a/src/data/services/tests/EnterpriseAccessApiService.test.js
+++ b/src/data/services/tests/EnterpriseAccessApiService.test.js
@@ -103,7 +103,6 @@ describe('EnterpriseAccessApiService', () => {
     EnterpriseAccessApiService.getSubsidyRequestConfiguration({ enterpriseId: mockEnterpriseUUID });
     expect(axios.get).toBeCalledWith(
       `${enterpriseAccessBaseUrl}/api/v1/customer-configurations/${mockEnterpriseUUID}/`,
-      { clearCacheEntry: false },
     );
   });
 


### PR DESCRIPTION
**Description**
This PR covers up the following points

- All budgets of ecommerce offers and learner-credit offers are showing regardless of plan.
- View Budget button takes the learner to the detail page along with offerId/budgetId
- Create two new routes  
  - for e-commerce /:enterpriseSlug/admin/learner-credit/:offerId 
  - for learner_credit budget  /:enterpriseSlug/admin/learner-credit/:budgetId
- Fetch the enrollments on the basis of budget_id if present otherwise, fetch enrollments on the base of offer_id on the detail page
- The “Budgets” link in the breadcrumbs on the LCM UI relies on react-router’s Link component and avoids a full-page refresh.

JIRA -> [[ENT-7672](https://2u-internal.atlassian.net/browse/ENT-7672), [ENT-7673](https://2u-internal.atlassian.net/browse/ENT-7673), [ENT-7674](https://2u-internal.atlassian.net/browse/ENT-7674), [ENT-7565](https://2u-internal.atlassian.net/browse/ENT-7565)]

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
