### PR TITLE
feat: expose `enterpriseFeatures` from API in `portalConfiguration`

### DIFF
--- a/src/components/learner-credit-management/MultipleBudgetsPage.jsx
+++ b/src/components/learner-credit-management/MultipleBudgetsPage.jsx
@@ -77,7 +77,6 @@ const mapStateToProps = state => ({
   enterpriseUUID: state.portalConfiguration.enterpriseId,
   enterpriseSlug: state.portalConfiguration.enterpriseSlug,
   enableLearnerPortal: state.portalConfiguration.enableLearnerPortal,
-  enterpriseFeatures: state.portalConfiguration.enterpriseFeatures,
 });
 
 MultipleBudgetsPage.propTypes = {

--- a/src/components/learner-credit-management/MultipleBudgetsPage.jsx
+++ b/src/components/learner-credit-management/MultipleBudgetsPage.jsx
@@ -77,6 +77,7 @@ const mapStateToProps = state => ({
   enterpriseUUID: state.portalConfiguration.enterpriseId,
   enterpriseSlug: state.portalConfiguration.enterpriseSlug,
   enableLearnerPortal: state.portalConfiguration.enableLearnerPortal,
+  enterpriseFeatures: state.portalConfiguration.enterpriseFeatures,
 });
 
 MultipleBudgetsPage.propTypes = {

--- a/src/data/actions/portalConfiguration.js
+++ b/src/data/actions/portalConfiguration.js
@@ -37,6 +37,7 @@ const fetchPortalConfiguration = slug => (
     dispatch(fetchPortalConfigurationRequest());
     return LmsApiService.fetchEnterpriseBySlug(slug)
       .then((response) => {
+        console.log('fetchPortalConfiguration!!!', response);
         dispatch(fetchPortalConfigurationSuccess(response));
       })
       .catch((error) => {

--- a/src/data/actions/portalConfiguration.js
+++ b/src/data/actions/portalConfiguration.js
@@ -12,9 +12,12 @@ const fetchPortalConfigurationRequest = () => ({
   type: FETCH_PORTAL_CONFIGURATION_REQUEST,
 });
 
-const fetchPortalConfigurationSuccess = data => ({
+const fetchPortalConfigurationSuccess = response => ({
   type: FETCH_PORTAL_CONFIGURATION_SUCCESS,
-  payload: { data },
+  payload: {
+    data: response.data,
+    enterpriseFeatures: response.enterpriseFeatures,
+  },
 });
 
 const fetchPortalConfigurationFailure = error => ({
@@ -34,7 +37,7 @@ const fetchPortalConfiguration = slug => (
     dispatch(fetchPortalConfigurationRequest());
     return LmsApiService.fetchEnterpriseBySlug(slug)
       .then((response) => {
-        dispatch(fetchPortalConfigurationSuccess(response.data));
+        dispatch(fetchPortalConfigurationSuccess(response));
       })
       .catch((error) => {
         logError(error);

--- a/src/data/actions/portalConfiguration.js
+++ b/src/data/actions/portalConfiguration.js
@@ -37,7 +37,6 @@ const fetchPortalConfiguration = slug => (
     dispatch(fetchPortalConfigurationRequest());
     return LmsApiService.fetchEnterpriseBySlug(slug)
       .then((response) => {
-        console.log('fetchPortalConfiguration!!!', response);
         dispatch(fetchPortalConfigurationSuccess(response));
       })
       .catch((error) => {

--- a/src/data/actions/portalConfiguration.test.js
+++ b/src/data/actions/portalConfiguration.test.js
@@ -14,6 +14,18 @@ jest.mock('@edx/frontend-platform/logging');
 
 const mockStore = configureMockStore([thunk]);
 
+const mockEnterpriseCustomer = {
+  uuid: 'd749b244-dceb-47bb-951c-5184a6e6d36a',
+  name: 'Test Enterprise',
+  slug: 'test-enterprise',
+  branding_configuration: {
+    enterprise_customer: 'd749b244-dceb-47bb-951c-5184a6e6d36a',
+    enterprise_slug: 'test-enterprise',
+    logo: 'https://s3...',
+  },
+};
+const mockEnterpriseFeatures = { featureA: true };
+
 describe('actions', () => {
   afterEach(() => {
     axiosMock.reset();
@@ -21,20 +33,19 @@ describe('actions', () => {
 
   it('dispatches success action after fetching portalConfiguration', () => {
     const slug = 'test-enterprise';
-    const responseData = {
-      uuid: 'd749b244-dceb-47bb-951c-5184a6e6d36a',
-      name: 'Test Enterprise',
-      slug: 'test-enterprise',
-      branding_configuration: {
-        enterprise_customer: 'd749b244-dceb-47bb-951c-5184a6e6d36a',
-        enterprise_slug: 'test-enterprise',
-        logo: 'https://s3...',
-      },
+    const mockResponseData = {
+      data: mockEnterpriseCustomer,
+      enterpriseFeatures: mockEnterpriseFeatures,
     };
 
     const expectedActions = [
-      { type: FETCH_PORTAL_CONFIGURATION_REQUEST },
-      { type: FETCH_PORTAL_CONFIGURATION_SUCCESS, payload: { data: responseData } },
+      {
+        type: FETCH_PORTAL_CONFIGURATION_REQUEST,
+      },
+      {
+        type: FETCH_PORTAL_CONFIGURATION_SUCCESS,
+        payload: { data: mockResponseData.data, enterpriseFeatures: mockEnterpriseFeatures },
+      },
     ];
     const store = mockStore();
     const queryParams = new URLSearchParams({
@@ -43,7 +54,13 @@ describe('actions', () => {
       enterprise_slug: slug,
     });
     axiosMock.onGet(`http://localhost:18000/enterprise/api/v1/enterprise-customer/dashboard_list/?${queryParams.toString()}`)
-      .replyOnce(200, JSON.stringify({ results: [responseData] }));
+      .replyOnce(
+        200,
+        JSON.stringify({
+          results: [mockResponseData.data],
+          enterprise_features: mockResponseData.enterpriseFeatures,
+        }),
+      );
 
     return store.dispatch(fetchPortalConfiguration(slug)).then(() => {
       expect(store.getActions()).toEqual(expectedActions);

--- a/src/data/actions/portalConfiguration.test.js
+++ b/src/data/actions/portalConfiguration.test.js
@@ -1,5 +1,6 @@
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import { camelCaseObject } from '@edx/frontend-platform/utils';
 
 import { clearPortalConfiguration, fetchPortalConfiguration } from './portalConfiguration';
 import {
@@ -24,7 +25,7 @@ const mockEnterpriseCustomer = {
     logo: 'https://s3...',
   },
 };
-const mockEnterpriseFeatures = { featureA: true };
+const mockEnterpriseFeatures = { feature_a: true };
 
 describe('actions', () => {
   afterEach(() => {
@@ -44,7 +45,7 @@ describe('actions', () => {
       },
       {
         type: FETCH_PORTAL_CONFIGURATION_SUCCESS,
-        payload: { data: mockResponseData.data, enterpriseFeatures: mockEnterpriseFeatures },
+        payload: { data: mockResponseData.data, enterpriseFeatures: camelCaseObject(mockEnterpriseFeatures) },
       },
     ];
     const store = mockStore();

--- a/src/data/reducers/portalConfiguration.js
+++ b/src/data/reducers/portalConfiguration.js
@@ -26,6 +26,7 @@ const initialState = {
   enableUniversalLink: false,
   enablePortalLearnerCreditManagementScreen: false,
   enableApiCredentialGeneration: false,
+  enterpriseFeatures: {},
 };
 
 const portalConfiguration = (state = initialState, action) => {
@@ -58,6 +59,7 @@ const portalConfiguration = (state = initialState, action) => {
         enableUniversalLink: action.payload.data.enable_universal_link,
         enablePortalLearnerCreditManagementScreen: action.payload.data.enable_portal_learner_credit_management_screen,
         enableApiCredentialGeneration: action.payload.data.enable_generation_of_api_credentials,
+        enterpriseFeatures: action.payload.enterpriseFeatures,
       };
     case FETCH_PORTAL_CONFIGURATION_FAILURE:
       return {
@@ -81,6 +83,7 @@ const portalConfiguration = (state = initialState, action) => {
         enableUniversalLink: false,
         enablePortalLearnerCreditManagementScreen: false,
         enableApiCredentialGeneration: false,
+        enterpriseFeatures: {},
       };
     case CLEAR_PORTAL_CONFIGURATION:
       return {
@@ -102,6 +105,7 @@ const portalConfiguration = (state = initialState, action) => {
         enableUniversalLink: false,
         enablePortalLearnerCreditManagementScreen: false,
         enableApiCredentialGeneration: false,
+        enterpriseFeatures: {},
       };
     case UPDATE_PORTAL_CONFIGURATION:
       return {

--- a/src/data/reducers/portalConfiguration.test.js
+++ b/src/data/reducers/portalConfiguration.test.js
@@ -25,6 +25,7 @@ const initialState = {
   enableLmsConfigurationsScreen: false,
   enableUniversalLink: false,
   enablePortalLearnerCreditManagementScreen: false,
+  enterpriseFeatures: {},
 };
 
 const enterpriseData = {
@@ -52,6 +53,9 @@ const enterpriseData = {
   enable_universal_link: true,
   enable_browse_and_request: true,
   enable_generation_of_api_credentials: true,
+};
+const mockEnterpriseFeatures = {
+  feature_A: true,
 };
 
 describe('portalConfiguration reducer', () => {
@@ -81,10 +85,11 @@ describe('portalConfiguration reducer', () => {
       enableUniversalLink: enterpriseData.enable_universal_link,
       enablePortalLearnerCreditManagementScreen: enterpriseData.enable_portal_learner_credit_management_screen,
       enableApiCredentialGeneration: enterpriseData.enable_generation_of_api_credentials,
+      enterpriseFeatures: mockEnterpriseFeatures,
     };
     expect(portalConfiguration(undefined, {
       type: FETCH_PORTAL_CONFIGURATION_SUCCESS,
-      payload: { data: enterpriseData },
+      payload: { data: enterpriseData, enterpriseFeatures: mockEnterpriseFeatures },
     })).toEqual(expected);
   });
 

--- a/src/data/reducers/portalConfiguration.test.js
+++ b/src/data/reducers/portalConfiguration.test.js
@@ -54,9 +54,7 @@ const enterpriseData = {
   enable_browse_and_request: true,
   enable_generation_of_api_credentials: true,
 };
-const mockEnterpriseFeatures = {
-  feature_A: true,
-};
+const mockEnterpriseFeatures = { featureA: true };
 
 describe('portalConfiguration reducer', () => {
   it('has initial state', () => {

--- a/src/data/services/LmsApiService.js
+++ b/src/data/services/LmsApiService.js
@@ -1,4 +1,5 @@
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
 import { configuration } from '../../config';
 import generateFormattedStatusUrl from './apiServiceUtils';
 
@@ -53,8 +54,10 @@ class LmsApiService {
       .then((response) => {
         const { data } = response;
         const results = data?.results;
+        const enterpriseFeatures = data?.enterprise_features;
         return {
-          data: results?.length && results[0],
+          data: results?.[0],
+          enterpriseFeatures,
         };
       });
   }

--- a/src/data/services/LmsApiService.js
+++ b/src/data/services/LmsApiService.js
@@ -1,4 +1,5 @@
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { camelCaseObject } from '@edx/frontend-platform/utils';
 
 import { configuration } from '../../config';
 import generateFormattedStatusUrl from './apiServiceUtils';
@@ -54,7 +55,7 @@ class LmsApiService {
       .then((response) => {
         const { data } = response;
         const results = data?.results;
-        const enterpriseFeatures = data?.enterprise_features;
+        const enterpriseFeatures = camelCaseObject(data?.enterprise_features);
         return {
           data: results?.[0],
           enterpriseFeatures,


### PR DESCRIPTION
Stores `enterpriseFeatures` from existing API integration in the `portalConfiguration` reducer within the application's Redux store. To retrieve the `enterpriseFeatures` within one of the child components of `EnterprisePage`:

```jsx
const mapStateToProps = state => ({
  // existing
  enterpriseId: state.portalConfiguration.enterpriseId,
  enterpriseSlug: state.portalConfiguration.enterpriseSlug,

  // new
  enterpriseFeatures: state.portalConfiguration.enterpriseFeatures,
});

MyComponent.propTypes = {
  enterpriseId: PropTypes.string.isRequired,
  enterpriseSlug: PropTypes.STRING.isRequired,
  enterpriseFeatures: PropTypes.shape().isRequired,
};

export default connect(mapStateToProps)(MyComponent);
```

**Example `enterpriseFeatures` object**

https://courses.stage.edx.org/enterprise/api/v1/enterprise-customer/dashboard_list/?page=1&page_size=50&enterprise_slug=exec-ed-2u-integration-qa

```js
{ 'top_down_assignment_real_time_lcm': true }
```

**Example API response:**

```js
{
	"next": null,
	"previous": null,
	"count": 1,
	"num_pages": 1,
	"current_page": 1,
	"start": 0,
	"results": [{
		"uuid": "d0224477-4903-404a-b3c4-9edfce728d37",
		"name": "Executive Education (2U) Integration QA",
		"slug": "exec-ed-2u-integration-qa",
		"active": true,
		// ...
	}],
	"enterprise_features": {
		"top_down_assignment_real_time_lcm": true
	}
}
```

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
