### PR TITLE
feat: show all enterprise budgets regardless of plan and route correctly

### DIFF
--- a/src/components/EnterpriseApp/EnterpriseAppRoutes.jsx
+++ b/src/components/EnterpriseApp/EnterpriseAppRoutes.jsx
@@ -13,9 +13,9 @@ import { SubscriptionManagementPage } from '../subscriptions';
 import { PlotlyAnalyticsPage } from '../PlotlyAnalytics';
 import { ROUTE_NAMES } from './data/constants';
 import BulkEnrollmentResultsDownloadPage from '../BulkEnrollmentResultsDownloadPage';
-import LearnerCreditManagement from '../learner-credit-management';
 import { EnterpriseSubsidiesContext } from '../EnterpriseSubsidiesContext';
 import ContentHighlights from '../ContentHighlights';
+import LearnerCreditManagementRoutes from '../learner-credit-management';
 
 const EnterpriseAppRoutes = ({
   baseUrl,
@@ -98,10 +98,8 @@ const EnterpriseAppRoutes = ({
       />
 
       {canManageLearnerCredit && (
-        <Route
-          exact
-          path={`${baseUrl}/admin/${ROUTE_NAMES.learnerCredit}`}
-          component={LearnerCreditManagement}
+        <LearnerCreditManagementRoutes
+          baseUrl={baseUrl}
         />
       )}
 

--- a/src/components/EnterpriseApp/data/constants.js
+++ b/src/components/EnterpriseApp/data/constants.js
@@ -13,3 +13,14 @@ export const ROUTE_NAMES = {
   subscriptionManagement: 'subscriptions',
   contentHighlights: 'content-highlights',
 };
+
+export const BUDGET_STATUSES = {
+  active: 'Active',
+  expired: 'Expired',
+  upcoming: 'Upcoming',
+};
+
+export const BUDGET_TYPES = {
+  ecommerce: 'ecommerce',
+  subsidy: 'subsidy',
+};

--- a/src/components/EnterpriseSubsidiesContext/data/tests/BudgetDetailPage.test.jsx
+++ b/src/components/EnterpriseSubsidiesContext/data/tests/BudgetDetailPage.test.jsx
@@ -1,0 +1,138 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
+import configureMockStore from 'redux-mock-store';
+import {
+  screen,
+  render,
+} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { MemoryRouter } from 'react-router-dom';
+import BudgetDetailPage from '../../../learner-credit-management/BudgetDetailPage';
+import { useOfferSummary, useOfferRedemptions } from '../../../learner-credit-management/data/hooks';
+import { EXEC_ED_OFFER_TYPE } from '../../../learner-credit-management/data/constants';
+import { EnterpriseSubsidiesContext } from '../..';
+
+jest.mock('../../../learner-credit-management/data/hooks');
+
+useOfferSummary.mockReturnValue({
+  isLoading: false,
+  offerSummary: null,
+});
+useOfferRedemptions.mockReturnValue({
+  isLoading: false,
+  offerRedemptions: {
+    itemCount: 0,
+    pageCount: 0,
+    results: [],
+  },
+  fetchOfferRedemptions: jest.fn(),
+});
+
+const mockStore = configureMockStore([thunk]);
+const getMockStore = store => mockStore(store);
+const enterpriseId = 'test-enterprise';
+const enterpriseUUID = '1234';
+const initialStore = {
+  portalConfiguration: {
+    enterpriseId,
+    enterpriseSlug: enterpriseId,
+
+  },
+};
+const store = getMockStore({ ...initialStore });
+
+const mockEnterpriseOfferId = '123';
+
+const mockOfferDisplayName = 'Test Enterprise Offer';
+const mockOfferSummary = {
+  totalFunds: 5000,
+  redeemedFunds: 200,
+  remainingFunds: 4800,
+  percentUtilized: 0.04,
+  offerType: EXEC_ED_OFFER_TYPE,
+};
+
+const defaultEnterpriseSubsidiesContextValue = {
+  isLoading: false,
+};
+
+const BudgetDetailPageWrapper = ({
+  enterpriseSubsidiesContextValue = defaultEnterpriseSubsidiesContextValue,
+  ...rest
+}) => (
+  <MemoryRouter initialEntries={['/test-enterprise/admin/learner-credit/1234']}>
+
+    <Provider store={store}>
+      <IntlProvider locale="en">
+        <EnterpriseSubsidiesContext.Provider value={enterpriseSubsidiesContextValue}>
+          <BudgetDetailPage {...rest} />
+        </EnterpriseSubsidiesContext.Provider>
+      </IntlProvider>
+    </Provider>
+  </MemoryRouter>
+);
+
+describe('<BudgetDetailPage />', () => {
+  describe('with enterprise offer', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('displays table on clicking view budget', async () => {
+      const mockOffer = {
+        id: mockEnterpriseOfferId,
+        name: mockOfferDisplayName,
+        start: '2022-01-01',
+        end: '2023-01-01',
+      };
+      useOfferSummary.mockReturnValue({
+        isLoading: false,
+        offerSummary: mockOfferSummary,
+      });
+      useOfferRedemptions.mockReturnValue({
+        isLoading: false,
+        offerRedemptions: {
+          itemCount: 0,
+          pageCount: 0,
+          results: [],
+        },
+        fetchOfferRedemptions: jest.fn(),
+      });
+      render(<BudgetDetailPageWrapper
+        enterpriseUUID={enterpriseUUID}
+        enterpriseSlug={enterpriseId}
+        offer={mockOffer}
+      />);
+      expect(screen.getByText('Learner Credit Management'));
+      expect(screen.getByText('Overview'));
+      expect(screen.getByText('No results found'));
+    });
+
+    it('displays loading message while loading data', async () => {
+      useOfferSummary.mockReturnValue({
+        isLoading: true,
+        offerSummary: null,
+      });
+      useOfferRedemptions.mockReturnValue({
+        isLoading: true,
+        offerRedemptions: {
+          itemCount: 0,
+          pageCount: 0,
+          results: [],
+        },
+        fetchOfferRedemptions: jest.fn(),
+      });
+
+      render(<BudgetDetailPageWrapper
+        enterpriseUUID={enterpriseUUID}
+        enterpriseSlug={enterpriseId}
+      />);
+
+      expect(screen.getByText('loading'));
+    });
+  });
+});

--- a/src/components/learner-credit-management/BudgetCard-V2.jsx
+++ b/src/components/learner-credit-management/BudgetCard-V2.jsx
@@ -1,25 +1,17 @@
-import React, { useState } from 'react';
+/* eslint-disable react/jsx-no-useless-fragment */
+/* eslint-disable no-nested-ternary */
+import React from 'react';
 import PropTypes from 'prop-types';
-import dayjs from 'dayjs';
-import {
-  Card,
-  Button,
-  Stack,
-  Row,
-  Col,
-  Breadcrumb,
-} from '@edx/paragon';
-
-import { useOfferRedemptions, useOfferSummary } from './data/hooks';
-import LearnerCreditAggregateCards from './LearnerCreditAggregateCards';
-import LearnerCreditAllocationTable from './LearnerCreditAllocationTable';
-import { ROUTE_NAMES } from '../EnterpriseApp/data/constants';
+import { useOfferSummary } from './data/hooks';
+import SubBudgetCard from './SubBudgetCard';
+import { BUDGET_TYPES } from '../EnterpriseApp/data/constants';
 
 const BudgetCard = ({
   offer,
   enterpriseUUID,
   enterpriseSlug,
-  enableLearnerPortal,
+  offerType,
+  displayName,
 }) => {
   const {
     start,
@@ -31,124 +23,37 @@ const BudgetCard = ({
     offerSummary,
   } = useOfferSummary(enterpriseUUID, offer);
 
-  const {
-    isLoading: isLoadingOfferRedemptions,
-    offerRedemptions,
-    fetchOfferRedemptions,
-  } = useOfferRedemptions(enterpriseUUID, offer?.id);
-  const [detailPage, setDetailPage] = useState(false);
-  const [activeLabel, setActiveLabel] = useState('');
-  const links = [
-    { label: 'Budgets', url: `/${enterpriseSlug}/admin/${ROUTE_NAMES.learnerCredit}` },
-  ];
-  const formattedStartDate = dayjs(start).format('MMMM D, YYYY');
-  const formattedExpirationDate = dayjs(end).format('MMMM D, YYYY');
-  const navigateToBudgetRedemptions = (budgetType) => {
-    setDetailPage(true);
-    links.push({ label: budgetType, url: `/${enterpriseSlug}/admin/learner-credit` });
-    setActiveLabel(budgetType);
-  };
-
-  const renderActions = (budgetType) => (
-    <Button
-      data-testid="view-budget"
-      onClick={() => navigateToBudgetRedemptions(budgetType)}
-    >
-      View Budget
-    </Button>
-  );
-
-  const renderCardHeader = (budgetType) => {
-    const subtitle = (
-      <div className="d-flex flex-wrap align-items-center">
-        <span data-testid="offer-date">
-          {formattedStartDate} - {formattedExpirationDate}
-        </span>
-      </div>
-    );
-
-    return (
-      <Card.Header
-        title={budgetType}
-        subtitle={subtitle}
-        actions={(
-          <div>
-            {renderActions(budgetType)}
-          </div>
-                )}
-      />
-    );
-  };
-
-  const renderCardSection = (available, spent) => (
-    <Card.Section
-      title="Balance"
-      muted
-    >
-      <Row className="d-flex flex-row justify-content-start w-md-75">
-        <Col xs="6" md="auto" className="d-flex flex-column mb-3 mb-md-0">
-          <span className="small">Available</span>
-          <span>{available}</span>
-        </Col>
-        <Col xs="6" md="auto" className="d-flex flex-column mb-3 mb-md-0">
-          <span className="small">Spent</span>
-          <span>{spent}</span>
-        </Col>
-      </Row>
-    </Card.Section>
-  );
-
-  const renderCardAggregate = () => (
-    <div className="mb-4.5 d-flex flex-wrap mx-n3">
-      <LearnerCreditAggregateCards
-        isLoading={isLoadingOfferSummary}
-        totalFunds={offerSummary?.totalFunds}
-        redeemedFunds={offerSummary?.redeemedFunds}
-        remainingFunds={offerSummary?.remainingFunds}
-        percentUtilized={offerSummary?.percentUtilized}
-      />
-    </div>
-  );
-
   return (
-    <Stack>
-      <Row className="m-3">
-        <Col xs="12">
-          <Breadcrumb
-            ariaLabel="Breadcrumb"
-            links={links}
-            activeLabel={activeLabel}
-          />
-        </Col>
-      </Row>
-      {!detailPage
-        ? (
-          <>
-            {renderCardAggregate()}
-            <h2>Budgets</h2>
-            <Card
-              orientation="horizontal"
-            >
-              <Card.Body>
-                <Stack gap={4}>
-                  {renderCardHeader('Overview')}
-                  {renderCardSection(offerSummary?.remainingFunds, offerSummary?.redeemedFunds)}
-                </Stack>
-              </Card.Body>
-            </Card>
-          </>
-        )
-        : (
-          <LearnerCreditAllocationTable
-            isLoading={isLoadingOfferRedemptions}
-            tableData={offerRedemptions}
-            fetchTableData={fetchOfferRedemptions}
-            enterpriseUUID={enterpriseUUID}
-            enterpriseSlug={enterpriseSlug}
-            enableLearnerPortal={enableLearnerPortal}
-          />
-        )}
-    </Stack>
+    <>
+      {offerType === BUDGET_TYPES.ecommerce ? (
+        <SubBudgetCard
+          isLoading={isLoadingOfferSummary}
+          id={offerSummary?.offerId}
+          start={start}
+          end={end}
+          available={offerSummary?.remainingFunds}
+          spent={offerSummary?.redeemedFunds}
+          displayName={displayName}
+          enterpriseSlug={enterpriseSlug}
+        />
+      ) : (
+        <>
+          {offerSummary?.budgetsSummary?.map((budget) => (
+            <SubBudgetCard
+              isLoading={isLoadingOfferSummary}
+              key={budget?.subsidyAccessPolicyUuid}
+              id={budget?.subsidyAccessPolicyUuid}
+              start={start}
+              end={end}
+              available={budget?.remainingFunds}
+              spent={budget?.redeemedFunds}
+              displayName={budget?.subsidyAccessPolicyDisplayName}
+              enterpriseSlug={enterpriseSlug}
+            />
+          ))}
+        </>
+      )}
+    </>
   );
 };
 
@@ -161,7 +66,8 @@ BudgetCard.propTypes = {
   }).isRequired,
   enterpriseUUID: PropTypes.string.isRequired,
   enterpriseSlug: PropTypes.string.isRequired,
-  enableLearnerPortal: PropTypes.bool.isRequired,
+  offerType: PropTypes.string.isRequired,
+  displayName: PropTypes.string,
 };
 
 export default BudgetCard;

--- a/src/components/learner-credit-management/BudgetDetailPage.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPage.jsx
@@ -1,0 +1,85 @@
+import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Row,
+  Col,
+  Breadcrumb,
+  Container,
+} from '@edx/paragon';
+import { connect } from 'react-redux';
+import { Helmet } from 'react-helmet';
+import { useParams, Link } from 'react-router-dom';
+import Hero from '../Hero';
+
+import LoadingMessage from '../LoadingMessage';
+import { EnterpriseSubsidiesContext } from '../EnterpriseSubsidiesContext';
+
+import LearnerCreditAllocationTable from './LearnerCreditAllocationTable';
+import { useOfferRedemptions } from './data/hooks';
+import { isUUID } from './data/utils';
+import { ROUTE_NAMES } from '../EnterpriseApp/data/constants';
+
+const PAGE_TITLE = 'Learner Credit Management';
+
+const BudgetDetailPage = ({
+  enterpriseUUID,
+  enterpriseSlug,
+  enableLearnerPortal,
+}) => {
+  const { budgetId } = useParams();
+  const enterpriseOfferId = isUUID(budgetId) ? null : budgetId;
+  const subsidyAccessPolicyId = isUUID(budgetId) ? budgetId : null;
+
+  const { isLoading } = useContext(EnterpriseSubsidiesContext);
+  const {
+    isLoading: isLoadingOfferRedemptions,
+    offerRedemptions,
+    fetchOfferRedemptions,
+  } = useOfferRedemptions(enterpriseUUID, enterpriseOfferId, subsidyAccessPolicyId);
+  if (isLoading) {
+    return <LoadingMessage className="offers" />;
+  }
+  const links = [
+    { label: 'Budgets', to: `/${enterpriseSlug}/admin/${ROUTE_NAMES.learnerCredit}` },
+  ];
+  return (
+    <>
+      <Helmet title={PAGE_TITLE} />
+      <Hero title={PAGE_TITLE} />
+      <Container className="py-3" fluid>
+        <Row className="m-3">
+          <Col xs="12">
+            <Breadcrumb
+              ariaLabel="Learner Credit Management breadcrumb navigation"
+              links={links}
+              linkAs={Link}
+              activeLabel="Overview"
+            />
+          </Col>
+        </Row>
+        <LearnerCreditAllocationTable
+          isLoading={isLoadingOfferRedemptions}
+          tableData={offerRedemptions}
+          fetchTableData={fetchOfferRedemptions}
+          enterpriseUUID={enterpriseUUID}
+          enterpriseSlug={enterpriseSlug}
+          enableLearnerPortal={enableLearnerPortal}
+        />
+      </Container>
+    </>
+  );
+};
+
+const mapStateToProps = state => ({
+  enterpriseUUID: state.portalConfiguration.enterpriseId,
+  enterpriseSlug: state.portalConfiguration.enterpriseSlug,
+  enableLearnerPortal: state.portalConfiguration.enableLearnerPortal,
+});
+
+BudgetDetailPage.propTypes = {
+  enterpriseUUID: PropTypes.string.isRequired,
+  enterpriseSlug: PropTypes.string.isRequired,
+  enableLearnerPortal: PropTypes.bool.isRequired,
+};
+
+export default connect(mapStateToProps)(BudgetDetailPage);

--- a/src/components/learner-credit-management/MultipleBudgetsPage.jsx
+++ b/src/components/learner-credit-management/MultipleBudgetsPage.jsx
@@ -6,6 +6,7 @@ import {
   Col,
   Card,
   Hyperlink,
+  Container,
 } from '@edx/paragon';
 import { connect } from 'react-redux';
 import { Helmet } from 'react-helmet';
@@ -17,7 +18,7 @@ import { EnterpriseSubsidiesContext } from '../EnterpriseSubsidiesContext';
 
 import { configuration } from '../../config';
 
-const PAGE_TITLE = 'Learner Credit';
+const PAGE_TITLE = 'Learner Credit Management';
 
 const MultipleBudgetsPage = ({
   enterpriseUUID,
@@ -63,12 +64,14 @@ const MultipleBudgetsPage = ({
     <>
       <Helmet title={PAGE_TITLE} />
       <Hero title={PAGE_TITLE} />
-      <MultipleBudgetsPicker
-        offers={offers}
-        enterpriseUUID={enterpriseUUID}
-        enterpriseSlug={enterpriseSlug}
-        enableLearnerPortal={enableLearnerPortal}
-      />
+      <Container className="py-3" fluid>
+        <MultipleBudgetsPicker
+          offers={offers}
+          enterpriseUUID={enterpriseUUID}
+          enterpriseSlug={enterpriseSlug}
+          enableLearnerPortal={enableLearnerPortal}
+        />
+      </Container>
     </>
   );
 };

--- a/src/components/learner-credit-management/MultipleBudgetsPicker.jsx
+++ b/src/components/learner-credit-management/MultipleBudgetsPicker.jsx
@@ -14,18 +14,25 @@ const MultipleBudgetsPicker = ({
   enterpriseSlug,
   enableLearnerPortal,
 }) => (
-  <Stack>
+  <Stack gap={4}>
     <Row>
-      <Col lg="10">
-        {offers.map(offer => (
-          <BudgetCard
-            key={offer.id}
-            offer={offer}
-            enterpriseUUID={enterpriseUUID}
-            enterpriseSlug={enterpriseSlug}
-            enableLearnerPortal={enableLearnerPortal}
-          />
-        ))}
+      <Col lg="12"><h2>Budgets</h2></Col>
+    </Row>
+    <Row>
+      <Col lg="12">
+        <Stack gap={4}>
+          {offers.map(offer => (
+            <BudgetCard
+              key={offer.id}
+              offer={offer}
+              enterpriseUUID={enterpriseUUID}
+              enterpriseSlug={enterpriseSlug}
+              enableLearnerPortal={enableLearnerPortal}
+              offerType={offer.source}
+              displayName={offer.name}
+            />
+          ))}
+        </Stack>
       </Col>
     </Row>
   </Stack>

--- a/src/components/learner-credit-management/SubBudgetCard.jsx
+++ b/src/components/learner-credit-management/SubBudgetCard.jsx
@@ -1,0 +1,103 @@
+import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import dayjs from 'dayjs';
+import {
+  Card,
+  Button,
+  Row,
+  Col,
+} from '@edx/paragon';
+
+import { BUDGET_STATUSES, ROUTE_NAMES } from '../EnterpriseApp/data/constants';
+import { formatPrice, getBudgetStatus } from './data/utils';
+
+const SubBudgetCard = ({
+  id,
+  start,
+  end,
+  available,
+  spent,
+  displayName,
+  enterpriseSlug,
+  isLoading,
+}) => {
+  const formattedStartDate = dayjs(start).format('MMMM D, YYYY');
+  const formattedExpirationDate = dayjs(end).format('MMMM D, YYYY');
+  const budgetStatus = getBudgetStatus(start, end);
+
+  const renderActions = (budgetId) => (
+    <Button
+      data-testid="view-budget"
+      as={Link}
+      to={`/${enterpriseSlug}/admin/${ROUTE_NAMES.learnerCredit}/${budgetId}`}
+    >
+      View budget
+    </Button>
+  );
+
+  const renderCardHeader = (budgetType, budgetId) => {
+    const subtitle = (
+      <div className="d-flex flex-wrap align-items-center">
+        <span data-testid="offer-date">
+          {formattedStartDate} - {formattedExpirationDate}
+        </span>
+      </div>
+    );
+
+    return (
+      <Card.Header
+        title={budgetType}
+        subtitle={subtitle}
+        className="mb-3"
+        actions={
+                    budgetStatus !== BUDGET_STATUSES.upcoming
+                      ? renderActions(budgetId)
+                      : undefined
+                }
+      />
+    );
+  };
+
+  const renderCardSection = (availableBalance, spentBalance) => (
+    <Card.Section
+      title="Balance"
+      muted
+    >
+      <Row className="d-flex flex-row justify-content-start w-md-75">
+        <Col xs="6" md="auto" className="d-flex flex-column mb-3 mb-md-0">
+          <span className="small">Available</span>
+          <span>{formatPrice(availableBalance)}</span>
+        </Col>
+        <Col xs="6" md="auto" className="d-flex flex-column mb-3 mb-md-0">
+          <span className="small">Spent</span>
+          <span>{formatPrice(spentBalance)}</span>
+        </Col>
+      </Row>
+    </Card.Section>
+  );
+
+  return (
+    <Card
+      orientation="horizontal"
+      isLoading={isLoading}
+    >
+      <Card.Body>
+        {renderCardHeader(displayName || 'Overview', id)}
+        {budgetStatus !== BUDGET_STATUSES.upcoming && renderCardSection(available, spent)}
+      </Card.Body>
+    </Card>
+  );
+};
+
+SubBudgetCard.propTypes = {
+  enterpriseSlug: PropTypes.string.isRequired,
+  id: PropTypes.string,
+  start: PropTypes.string,
+  end: PropTypes.string,
+  spent: PropTypes.number,
+  isLoading: PropTypes.bool,
+  available: PropTypes.number,
+  displayName: PropTypes.string,
+};
+
+export default SubBudgetCard;

--- a/src/components/learner-credit-management/data/hooks.js
+++ b/src/components/learner-credit-management/data/hooks.js
@@ -74,7 +74,7 @@ const applyFiltersToOptions = (filters, options) => {
   }
 };
 
-export const useOfferRedemptions = (enterpriseUUID, offerId) => {
+export const useOfferRedemptions = (enterpriseUUID, offerId = null, budgetId = null) => {
   const shouldTrackFetchEvents = useRef(false);
   const [isLoading, setIsLoading] = useState(true);
   const [offerRedemptions, setOfferRedemptions] = useState({
@@ -90,9 +90,14 @@ export const useOfferRedemptions = (enterpriseUUID, offerId) => {
         const options = {
           page: args.pageIndex + 1, // `DataTable` uses zero-indexed array
           pageSize: args.pageSize,
-          offerId,
           ignoreNullCourseListPrice: true,
         };
+        if (budgetId !== null) {
+          options.budgetId = budgetId;
+        }
+        if (offerId !== null) {
+          options.offerId = offerId;
+        }
         if (args.sortBy?.length > 0) {
           applySortByToOptions(args.sortBy, options);
         }
@@ -129,10 +134,10 @@ export const useOfferRedemptions = (enterpriseUUID, offerId) => {
         setIsLoading(false);
       }
     };
-    if (offerId) {
+    if (offerId || budgetId) {
       fetch();
     }
-  }, [enterpriseUUID, offerId, shouldTrackFetchEvents]);
+  }, [enterpriseUUID, offerId, budgetId, shouldTrackFetchEvents]);
 
   const debouncedFetchOfferRedemptions = useMemo(() => debounce(fetchOfferRedemptions, 300), [fetchOfferRedemptions]);
 

--- a/src/components/learner-credit-management/data/tests/hooks.test.js
+++ b/src/components/learner-credit-management/data/tests/hooks.test.js
@@ -72,6 +72,9 @@ describe('useOfferSummary', () => {
       redeemedFundsOcm: NaN,
       remainingFunds: 4800,
       percentUtilized: 0.04,
+      offerId: 1,
+      budgetsSummary: [],
+      offerType: undefined,
     };
     expect(result.current).toEqual({
       offerSummary: expectedResult,
@@ -83,9 +86,11 @@ describe('useOfferSummary', () => {
 describe('useOfferRedemptions', () => {
   it('should fetch enrollment/redemptions metadata for enterprise offer', async () => {
     EnterpriseDataApiService.fetchCourseEnrollments.mockResolvedValueOnce({ data: mockOfferEnrollmentsResponse });
+    const budgetId = 'test-budget-id';
     const { result, waitForNextUpdate } = renderHook(() => useOfferRedemptions(
       TEST_ENTERPRISE_UUID,
       mockEnterpriseOffer.id,
+      budgetId,
     ));
 
     expect(result.current).toMatchObject({
@@ -119,6 +124,7 @@ describe('useOfferRedemptions', () => {
       ordering: '-enrollment_date', // default sort order
       searchAll: mockOfferEnrollments[0].user_email,
       ignoreNullCourseListPrice: true,
+      budgetId,
     };
     expect(EnterpriseDataApiService.fetchCourseEnrollments).toHaveBeenCalledWith(
       TEST_ENTERPRISE_UUID,
@@ -133,5 +139,7 @@ describe('useOfferRedemptions', () => {
       isLoading: false,
       fetchOfferRedemptions: expect.any(Function),
     });
+
+    expect(expectedApiOptions.budgetId).toBe(budgetId);
   });
 });

--- a/src/components/learner-credit-management/data/tests/utils.test.js
+++ b/src/components/learner-credit-management/data/tests/utils.test.js
@@ -1,4 +1,4 @@
-import { transformOfferSummary } from '../utils';
+import { transformOfferSummary, getBudgetStatus } from '../utils';
 import { EXEC_ED_OFFER_TYPE } from '../constants';
 
 describe('transformOfferSummary', () => {
@@ -23,6 +23,8 @@ describe('transformOfferSummary', () => {
       remainingFunds: 0.0,
       percentUtilized: 1.0,
       offerType: EXEC_ED_OFFER_TYPE,
+      budgetsSummary: [],
+      offerId: undefined,
     });
   });
 
@@ -33,6 +35,8 @@ describe('transformOfferSummary', () => {
       remainingBalance: null,
       percentOfOfferSpent: null,
       offerType: 'Site',
+      offerId: '123',
+      budgetsSummary: [],
     };
 
     expect(transformOfferSummary(offerSummary)).toEqual({
@@ -41,6 +45,72 @@ describe('transformOfferSummary', () => {
       remainingFunds: null,
       percentUtilized: null,
       offerType: 'Site',
+      redeemedFundsExecEd: undefined,
+      redeemedFundsOcm: undefined,
+      offerId: '123',
+      budgetsSummary: [],
     });
+  });
+
+  it('should handle when budgetsSummary is provided', () => {
+    const offerSummary = {
+      maxDiscount: 1000,
+      amountOfOfferSpent: 500,
+      remainingBalance: 500,
+      percentOfOfferSpent: 0.5,
+      offerType: 'Site',
+      offerId: '123',
+      budgets: [
+        {
+          id: 123,
+          start: '2022-01-01',
+          end: '2022-01-01',
+          available: 200,
+          spent: 100,
+          enterpriseSlug: 'test-enterprise',
+        }],
+    };
+
+    expect(transformOfferSummary(offerSummary)).toEqual({
+      totalFunds: 1000,
+      redeemedFunds: 500,
+      remainingFunds: 500,
+      percentUtilized: 0.5,
+      offerType: 'Site',
+      redeemedFundsExecEd: NaN,
+      redeemedFundsOcm: NaN,
+      offerId: '123',
+      budgetsSummary: [{
+        id: 123,
+        start: '2022-01-01',
+        end: '2022-01-01',
+        available: 200,
+        spent: 100,
+        enterpriseSlug: 'test-enterprise',
+      }],
+    });
+  });
+});
+
+describe('getBudgetStatus', () => {
+  it('should return "upcoming" when the current date is before the start date', () => {
+    const startDateStr = '2023-09-30';
+    const endDateStr = '2023-10-30';
+    const result = getBudgetStatus(startDateStr, endDateStr);
+    expect(result).toEqual('Upcoming');
+  });
+
+  it('should return "active" when the current date is between the start and end dates', () => {
+    const startDateStr = '2023-09-01';
+    const endDateStr = '2023-09-30';
+    const result = getBudgetStatus(startDateStr, endDateStr);
+    expect(result).toEqual('Active');
+  });
+
+  it('should return "expired" when the current date is after the end date', () => {
+    const startDateStr = '2023-08-01';
+    const endDateStr = '2023-08-31';
+    const result = getBudgetStatus(startDateStr, endDateStr);
+    expect(result).toEqual('Expired');
   });
 });

--- a/src/components/learner-credit-management/data/utils.js
+++ b/src/components/learner-credit-management/data/utils.js
@@ -3,6 +3,7 @@ import {
   LOW_REMAINING_BALANCE_PERCENT_THRESHOLD,
   NO_BALANCE_REMAINING_DOLLAR_THRESHOLD,
 } from './constants';
+import { BUDGET_STATUSES } from '../../EnterpriseApp/data/constants';
 /**
  * Transforms offer summary from API for display in the UI, guarding
  * against bad data (e.g., accounting for refunds).
@@ -12,6 +13,20 @@ import {
  */
 export const transformOfferSummary = (offerSummary) => {
   if (!offerSummary) { return null; }
+  const budgetsSummary = [];
+  if (offerSummary?.budgets) {
+    const budgets = offerSummary?.budgets;
+    for (let i = 0; i < budgets.length; i++) {
+      const redeemedFunds = budgets[i].amountOfPolicySpent && parseFloat(budgets[i].amountOfPolicySpent);
+      const remainingFunds = budgets[i].remainingBalance && parseFloat(budgets[i].remainingBalance);
+      const updatedBudgetDetail = {
+        redeemedFunds,
+        remainingFunds,
+        ...budgets[i],
+      };
+      budgetsSummary.push(updatedBudgetDetail);
+    }
+  }
 
   const totalFunds = offerSummary.maxDiscount && parseFloat(offerSummary.maxDiscount);
   let redeemedFunds = offerSummary.amountOfOfferSpent && parseFloat(offerSummary.amountOfOfferSpent);
@@ -38,7 +53,7 @@ export const transformOfferSummary = (offerSummary) => {
     percentUtilized = Math.min(percentUtilized, 1.0);
   }
   const { offerType } = offerSummary;
-
+  const { offerId } = offerSummary;
   return {
     totalFunds,
     redeemedFunds,
@@ -47,6 +62,8 @@ export const transformOfferSummary = (offerSummary) => {
     remainingFunds,
     percentUtilized,
     offerType,
+    offerId,
+    budgetsSummary,
   };
 };
 
@@ -90,4 +107,30 @@ export const getProgressBarVariant = ({ percentUtilized, remainingFunds }) => {
     variant = 'error'; // red
   }
   return variant;
+};
+
+//  Utility function to check if the ID is a UUID
+export const isUUID = (id) => /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(id);
+
+//  Utility function to check the budget status
+export const getBudgetStatus = (startDateStr, endDateStr) => {
+  const currentDate = new Date();
+  const startDate = new Date(startDateStr);
+  const endDate = new Date(endDateStr);
+
+  if (currentDate < startDate) {
+    return BUDGET_STATUSES.upcoming;
+  }
+  if (currentDate >= startDate && currentDate <= endDate) {
+    return BUDGET_STATUSES.active;
+  }
+  return BUDGET_STATUSES.expired;
+};
+
+export const formatPrice = (price) => {
+  const USDollar = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  });
+  return USDollar.format(Math.abs(price));
 };

--- a/src/components/learner-credit-management/index.js
+++ b/src/components/learner-credit-management/index.js
@@ -1,3 +1,0 @@
-import MultipleBudgetsPage from './MultipleBudgetsPage';
-
-export default MultipleBudgetsPage;

--- a/src/components/learner-credit-management/index.jsx
+++ b/src/components/learner-credit-management/index.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Route } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import { ROUTE_NAMES } from '../EnterpriseApp/data/constants';
+import MultipleBudgetsPage from './MultipleBudgetsPage';
+import BudgetDetailPage from './BudgetDetailPage';
+
+const LearnerCreditManagementRoutes = ({ baseUrl }) => (
+  <>
+    <Route
+      exact
+      path={`${baseUrl}/admin/${ROUTE_NAMES.learnerCredit}`}
+      component={MultipleBudgetsPage}
+    />
+
+    <Route
+      exact
+      path={`${baseUrl}/admin/${ROUTE_NAMES.learnerCredit}/:budgetId`}
+      component={BudgetDetailPage}
+    />
+  </>
+);
+
+LearnerCreditManagementRoutes.propTypes = {
+  baseUrl: PropTypes.string.isRequired,
+};
+
+export default LearnerCreditManagementRoutes;


### PR DESCRIPTION
**Description**
This PR covers up the following points

- All budgets of ecommerce offers and learner-credit offers are showing regardless of plan.
- View Budget button takes the learner to the detail page along with offerId/budgetId
- Create two new routes  
  - for e-commerce /:enterpriseSlug/admin/learner-credit/:offerId 
  - for learner_credit budget  /:enterpriseSlug/admin/learner-credit/:budgetId
- Fetch the enrollments on the basis of budget_id if present otherwise, fetch enrollments on the base of offer_id on the detail page
- The “Budgets” link in the breadcrumbs on the LCM UI relies on react-router’s Link component and avoids a full-page refresh.
- Ensure dollar amounts are displayed as monetary (e.g., $18,500.25) rather than just floats without any formatting.
- Ensure LCM is wrapped in a fluid container for more left/right whitespace padding in the page contents. It should be consistent with other page’s throughout the MFE (e.g., see “Highlights” page’s left/right padding).

JIRA -> [[ENT-7672](https://2u-internal.atlassian.net/browse/ENT-7672), [ENT-7673](https://2u-internal.atlassian.net/browse/ENT-7673), [ENT-7674](https://2u-internal.atlassian.net/browse/ENT-7674), [ENT-7565](https://2u-internal.atlassian.net/browse/ENT-7565)]

Here is the updated screen short
![screencapture-localhost-1991-test-enterprise-admin-learner-credit-2023-09-25-19_13_50](https://github.com/openedx/frontend-app-admin-portal/assets/86868918/af7480db-0aaa-498e-bcd6-fce516eccaa5)


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
