### PR TITLE
fix: ensure highlights routes appear when learner credit is available

### DIFF
--- a/src/components/EnterpriseApp/EnterpriseAppRoutes.jsx
+++ b/src/components/EnterpriseApp/EnterpriseAppRoutes.jsx
@@ -98,8 +98,9 @@ const EnterpriseAppRoutes = ({
       />
 
       {canManageLearnerCredit && (
-        <LearnerCreditManagementRoutes
-          baseUrl={baseUrl}
+        <Route
+          path={`${baseUrl}/admin/${ROUTE_NAMES.learnerCredit}`}
+          component={LearnerCreditManagementRoutes}
         />
       )}
 
@@ -110,7 +111,7 @@ const EnterpriseAppRoutes = ({
         />
       )}
 
-      <Route path="" component={NotFoundPage} />
+      <Route path="*" component={NotFoundPage} />
     </Switch>
   );
 };

--- a/src/components/learner-credit-management/index.jsx
+++ b/src/components/learner-credit-management/index.jsx
@@ -1,28 +1,29 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { ROUTE_NAMES } from '../EnterpriseApp/data/constants';
 import MultipleBudgetsPage from './MultipleBudgetsPage';
 import BudgetDetailPage from './BudgetDetailPage';
 
-const LearnerCreditManagementRoutes = ({ baseUrl }) => (
+const LearnerCreditManagementRoutes = ({ match }) => (
   <>
     <Route
       exact
-      path={`${baseUrl}/admin/${ROUTE_NAMES.learnerCredit}`}
+      path={match.path}
       component={MultipleBudgetsPage}
     />
 
     <Route
       exact
-      path={`${baseUrl}/admin/${ROUTE_NAMES.learnerCredit}/:budgetId`}
+      path={`${match.path}/:budgetId`}
       component={BudgetDetailPage}
     />
   </>
 );
 
 LearnerCreditManagementRoutes.propTypes = {
-  baseUrl: PropTypes.string.isRequired,
+  match: PropTypes.shape({
+    path: PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 export default LearnerCreditManagementRoutes;


### PR DESCRIPTION
# Description

https://2u-internal.atlassian.net/browse/ENT-7759

The direct children of `Switch` must be `Route`. Previously, the `LearnerCreditManagementRoutes` component was rendered as the direct child instead of a `Route`, causing all `Route` definitions after `LearnerCreditManagementRoutes` to not work, which happened to only be `ContentHighlights` / `NotFoundPage`.

## Before

![image](https://github.com/openedx/frontend-app-admin-portal/assets/2828721/ab680214-8528-461a-83ac-a188faf70bad)

## After

![image](https://github.com/openedx/frontend-app-admin-portal/assets/2828721/66f5be45-e166-4ca9-a450-773c56e33e4e)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
