### PR TITLE
fix: use multiple analytics card messages

### DIFF
--- a/src/components/Admin/AIAnalyticsSummary.jsx
+++ b/src/components/Admin/AIAnalyticsSummary.jsx
@@ -21,14 +21,20 @@ const AnalyticsDetailCard = ({
       </Badge>
       <Stack gap={1} direction="horizontal">
         <p className="card-text text-justify small">
+          {error && (
           <FormattedMessage
-            id="adminPortal.analyticsCardText"
-            defaultMessage={
-              error
-                ? `An error occurred: ${error.message}`
-                : data || 'Analytics not found.'
-            }
+            id="adminPortal.analyticsCardErrorText"
+            defaultMessage="An error occurred: {errorMessage}"
+            values={{ errorMessage: error.message }}
           />
+          )}
+          {!error && !data && (
+          <FormattedMessage
+            id="adminPortal.analyticsCardNotFoundText"
+            defaultMessage="Analytics not found."
+          />
+          )}
+          {data}
         </p>
         <Button variant="link" className="mb-4 ml-3" onClick={onClose}>
           <span className="small font-weight-bold text-gray-800">Dismiss</span>


### PR DESCRIPTION
The previous use of `adminPortal.analyticsCardText`was fully dynamic, and resulted in "Messages must be statically evaluate-able for extraction." errors when running `make extract_translations`. This splits the message up into separately translatable messages, and updates the logic for displaying them accordingly.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
