### PR TITLE
fix: handle additional case when not viewing assignable budget

### DIFF
--- a/src/components/learner-credit-management/BudgetDetailActivityTabContents.jsx
+++ b/src/components/learner-credit-management/BudgetDetailActivityTabContents.jsx
@@ -5,11 +5,13 @@ import { Stack, Skeleton } from '@edx/paragon';
 
 import BudgetDetailRedemptions from './BudgetDetailRedemptions';
 import BudgetDetailAssignments from './BudgetDetailAssignments';
-import { useBudgetDetailActivityOverview } from './data';
+import { useBudgetDetailActivityOverview, useBudgetId, useSubsidyAccessPolicy } from './data';
 import NoBudgetActivityEmptyState from './NoBudgetActivityEmptyState';
 
 const BudgetDetailActivityTabContents = ({ enterpriseUUID, enterpriseFeatures }) => {
   const isTopDownAssignmentEnabled = enterpriseFeatures.topDownAssignmentRealTimeLcm;
+  const { subsidyAccessPolicyId } = useBudgetId();
+  const { data: subsidyAccessPolicy } = useSubsidyAccessPolicy(subsidyAccessPolicyId);
   const {
     isLoading: isBudgetActivityOverviewLoading,
     data: budgetActivityOverview,
@@ -25,6 +27,10 @@ const BudgetDetailActivityTabContents = ({ enterpriseUUID, enterpriseFeatures })
         <span className="sr-only">loading budget activity overview</span>
       </>
     );
+  }
+
+  if (!isTopDownAssignmentEnabled || !subsidyAccessPolicy?.isAssignable) {
+    return <BudgetDetailRedemptions />;
   }
 
   const hasContentAssignments = !!budgetActivityOverview.contentAssignments?.count > 0;

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -280,6 +280,7 @@ describe('<BudgetDetailPage />', () => {
         numPages: 1,
         currentPage: 1,
       },
+      fetchContentAssignments: jest.fn(),
     });
     useOfferRedemptions.mockReturnValue({
       isLoading: false,
@@ -380,6 +381,11 @@ describe('<BudgetDetailPage />', () => {
         spentTransactions: { count: 0 },
       },
     });
+    useOfferRedemptions.mockReturnValue({
+      isLoading: false,
+      offerRedemptions: mockEmptyOfferRedemptions,
+      fetchOfferRedemptions: jest.fn(),
+    });
     renderWithRouter(<BudgetDetailPageWrapper />);
 
     // Catalog tab does NOT exist
@@ -410,10 +416,18 @@ describe('<BudgetDetailPage />', () => {
         spentTransactions: { count: 0 },
       },
     });
+    useOfferRedemptions.mockReturnValue({
+      isLoading: false,
+      offerRedemptions: mockEmptyOfferRedemptions,
+      fetchOfferRedemptions: jest.fn(),
+    });
     renderWithRouter(<BudgetDetailPageWrapper initialState={initialState} />);
 
     // Catalog tab does NOT exist
     expect(screen.queryByText('Catalog')).toBeFalsy();
+
+    // Ensure no assignments-related empty states are rendered
+    expect(screen.queryByText('No budget activity yet? Assign a course!')).not.toBeInTheDocument();
   });
 
   it('defaults to activity tab is no activeTabKey is provided', () => {

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -390,6 +390,9 @@ describe('<BudgetDetailPage />', () => {
 
     // Catalog tab does NOT exist
     expect(screen.queryByText('Catalog')).toBeFalsy();
+
+    // Ensure no assignments-related empty states are rendered
+    expect(screen.queryByText('No budget activity yet? Assign a course!')).not.toBeInTheDocument();
   });
 
   it('hides catalog tab when enterpriseFeatures.topDownAssignmentRealTimeLcm is disabled', () => {


### PR DESCRIPTION
# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
