### PR TITLE
fix: use top placement, not auto

### DIFF
--- a/src/components/learner-credit-management/assignments-status-chips/BaseModalPopup.jsx
+++ b/src/components/learner-credit-management/assignments-status-chips/BaseModalPopup.jsx
@@ -75,7 +75,7 @@ BaseModalPopup.propTypes = {
 };
 
 BaseModalPopup.defaultProps = {
-  placement: 'auto',
+  placement: 'top',
   positionRef: null,
 };
 


### PR DESCRIPTION
Resolves `ModalPopup` arrow placement issue by enforcing it to always open on top of trigger element, which will place the arrow at the bottom.

<img width="1838" alt="image" src="https://github.com/openedx/frontend-app-admin-portal/assets/2828721/8d2e7d4f-96ff-4d8f-846d-eb8c0e80cad4">

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
