### PR TITLE
feat: add "Refresh" CTA to the "Assigned" table; remove "Product" column from "Spent" table

### DIFF
--- a/src/components/learner-credit-management/AssignmentsTableRefreshAction.jsx
+++ b/src/components/learner-credit-management/AssignmentsTableRefreshAction.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Button } from '@edx/paragon';
+import PropTypes from 'prop-types';
+
+const AssignmentsTableRefreshAction = ({ tableInstance, refresh }) => {
+  const { state } = tableInstance;
+
+  const handleRefresh = () => {
+    const {
+      pageIndex,
+      pageSize,
+      sortBy,
+      filters,
+    } = state;
+    const dataTableArgs = {
+      pageIndex,
+      pageSize,
+      sortBy,
+      filters,
+    };
+    refresh(dataTableArgs);
+  };
+
+  return (
+    <Button
+      variant="outline-primary"
+      onClick={handleRefresh}
+    >
+      Refresh
+    </Button>
+  );
+};
+
+AssignmentsTableRefreshAction.propTypes = {
+  refresh: PropTypes.func.isRequired,
+  tableInstance: PropTypes.shape({
+    state: PropTypes.shape({
+      pageIndex: PropTypes.number,
+      pageSize: PropTypes.number,
+      sortBy: PropTypes.arrayOf(PropTypes.shape({
+        id: PropTypes.string,
+        desc: PropTypes.bool,
+      })),
+      filters: PropTypes.arrayOf(PropTypes.shape({
+        id: PropTypes.string,
+        value: PropTypes.string,
+      })),
+    }),
+  }),
+};
+
+export default AssignmentsTableRefreshAction;

--- a/src/components/learner-credit-management/AssignmentsTableRefreshAction.jsx
+++ b/src/components/learner-credit-management/AssignmentsTableRefreshAction.jsx
@@ -3,22 +3,9 @@ import { Button } from '@edx/paragon';
 import PropTypes from 'prop-types';
 
 const AssignmentsTableRefreshAction = ({ tableInstance, refresh }) => {
-  const { state } = tableInstance;
-
   const handleRefresh = () => {
-    const {
-      pageIndex,
-      pageSize,
-      sortBy,
-      filters,
-    } = state;
-    const dataTableArgs = {
-      pageIndex,
-      pageSize,
-      sortBy,
-      filters,
-    };
-    refresh(dataTableArgs);
+    const { state: dataTableState } = tableInstance;
+    refresh(dataTableState);
   };
 
   return (
@@ -34,18 +21,7 @@ const AssignmentsTableRefreshAction = ({ tableInstance, refresh }) => {
 AssignmentsTableRefreshAction.propTypes = {
   refresh: PropTypes.func.isRequired,
   tableInstance: PropTypes.shape({
-    state: PropTypes.shape({
-      pageIndex: PropTypes.number,
-      pageSize: PropTypes.number,
-      sortBy: PropTypes.arrayOf(PropTypes.shape({
-        id: PropTypes.string,
-        desc: PropTypes.bool,
-      })),
-      filters: PropTypes.arrayOf(PropTypes.shape({
-        id: PropTypes.string,
-        value: PropTypes.string,
-      })),
-    }),
+    state: PropTypes.shape(),
   }),
 };
 

--- a/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
+++ b/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
@@ -8,6 +8,7 @@ import AssignmentDetailsTableCell from './AssignmentDetailsTableCell';
 import AssignmentStatusTableCell from './AssignmentStatusTableCell';
 import { DEFAULT_PAGE, PAGE_SIZE, formatPrice } from './data';
 import AssignmentRecentActionTableCell from './AssignmentRecentActionTableCell';
+import AssignmentsTableRefreshAction from './AssignmentsTableRefreshAction';
 
 const FilterStatus = (rest) => <DataTable.FilterStatus showFilteredFields={false} {...rest} />;
 
@@ -35,7 +36,8 @@ const BudgetAssignmentsTable = ({
       },
       {
         Header: 'Amount',
-        Cell: ({ row }) => `-${formatPrice(row.original.contentQuantity / 100, { maximumFractionDigits: 0 })}`,
+        accessor: 'amount',
+        Cell: ({ row }) => `-${formatPrice(row.original.contentQuantity / 100)}`,
         disableFilters: true,
       },
       {
@@ -48,6 +50,9 @@ const BudgetAssignmentsTable = ({
         Cell: AssignmentRecentActionTableCell,
         disableFilters: true,
       },
+    ]}
+    tableActions={[
+      <AssignmentsTableRefreshAction refresh={fetchTableData} />,
     ]}
     initialTableOptions={{
       getRowId: row => row?.uuid?.toString(),

--- a/src/components/learner-credit-management/LearnerCreditAllocationTable.jsx
+++ b/src/components/learner-credit-management/LearnerCreditAllocationTable.jsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import dayjs from 'dayjs';
 import { DataTable } from '@edx/paragon';
 
 import TableTextFilter from './TableTextFilter';
 import CustomDataTableEmptyState from './CustomDataTableEmptyState';
 import SpendTableEnrollmentDetails from './SpendTableEnrollmentDetails';
-import { getCourseProductLineText } from '../../utils';
-import { PAGE_SIZE, DEFAULT_PAGE } from './data';
+import {
+  PAGE_SIZE,
+  DEFAULT_PAGE,
+  formatDate,
+  formatPrice,
+} from './data';
 
 const FilterStatus = (rest) => <DataTable.FilterStatus showFilteredFields={false} {...rest} />;
 
@@ -30,7 +33,7 @@ const LearnerCreditAllocationTable = ({
       {
         Header: 'Date',
         accessor: 'enrollmentDate',
-        Cell: ({ row }) => dayjs(row.values.enrollmentDate).format('MMM D, YYYY'),
+        Cell: ({ row }) => formatDate(row.values.enrollmentDate),
         disableFilters: true,
       },
       {
@@ -42,13 +45,7 @@ const LearnerCreditAllocationTable = ({
       {
         Header: 'Amount',
         accessor: 'courseListPrice',
-        Cell: ({ row }) => `$${row.values.courseListPrice}`,
-        disableFilters: true,
-      },
-      {
-        Header: 'Product',
-        accessor: 'courseProductLine',
-        Cell: ({ row }) => getCourseProductLineText(row.values.courseProductLine),
+        Cell: ({ row }) => formatPrice(row.values.courseListPrice),
         disableFilters: true,
       },
     ]}

--- a/src/components/learner-credit-management/search/CatalogSearchResults.jsx
+++ b/src/components/learner-credit-management/search/CatalogSearchResults.jsx
@@ -9,7 +9,7 @@ import {
 } from '@edx/paragon';
 
 import CourseCard from '../cards/CourseCard';
-import { SEARCH_RESULT_PAGE_SIZE } from '../data';
+import { DEFAULT_PAGE, SEARCH_RESULT_PAGE_SIZE } from '../data';
 
 export const ERROR_MESSAGE = 'An error occurred while retrieving data';
 
@@ -87,7 +87,7 @@ export const BaseCatalogSearchResults = ({
         defaultColumnValues={{ Filter: TextFilter }}
         initialState={{
           pageSize: SEARCH_RESULT_PAGE_SIZE,
-          pageIndex: 0,
+          pageIndex: DEFAULT_PAGE,
         }}
         isLoading={isSearchStalled}
         isPaginated

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -19,6 +19,8 @@ import {
   useBudgetDetailActivityOverview,
   useIsLargeOrGreater,
   formatDate,
+  DEFAULT_PAGE,
+  PAGE_SIZE,
 } from '../data';
 import { EnterpriseSubsidiesContext } from '../../EnterpriseSubsidiesContext';
 import {
@@ -269,7 +271,7 @@ describe('<BudgetDetailPage />', () => {
     expect(screen.getByText('Catalog').getAttribute('aria-selected')).toBe('false');
   });
 
-  it('renders with assigned table data', () => {
+  it('renders with assigned table data and handles table refresh', () => {
     useParams.mockReturnValue({
       budgetId: mockSubsidyAccessPolicyUUID,
       activeTabKey: 'activity',
@@ -285,6 +287,7 @@ describe('<BudgetDetailPage />', () => {
         spentTransactions: { count: 0 },
       },
     });
+    const mockFetchContentAssignments = jest.fn();
     useBudgetContentAssignments.mockReturnValue({
       isLoading: false,
       contentAssignments: {
@@ -304,7 +307,7 @@ describe('<BudgetDetailPage />', () => {
         numPages: 1,
         currentPage: 1,
       },
-      fetchContentAssignments: jest.fn(),
+      fetchContentAssignments: mockFetchContentAssignments,
     });
     useOfferRedemptions.mockReturnValue({
       isLoading: false,
@@ -323,6 +326,21 @@ describe('<BudgetDetailPage />', () => {
     expect(assignedSection.getByText('-$199')).toBeInTheDocument();
     expect(assignedSection.getByText('Waiting for learner')).toBeInTheDocument();
     expect(assignedSection.getByText(`Assigned: ${formatDate('2023-10-27')}`)).toBeInTheDocument();
+
+    // Verify "Refresh" behavior
+    const expectedRefreshArgs = {
+      pageIndex: DEFAULT_PAGE,
+      pageSize: PAGE_SIZE,
+      filters: [],
+      sortBy: [],
+    };
+    expect(mockFetchContentAssignments).toHaveBeenCalledTimes(1); // called once on initial render
+    expect(mockFetchContentAssignments).toHaveBeenCalledWith(expect.objectContaining(expectedRefreshArgs));
+    const refreshCTA = assignedSection.getByText('Refresh', { selector: 'button' });
+    expect(refreshCTA).toBeInTheDocument();
+    userEvent.click(refreshCTA);
+    expect(mockFetchContentAssignments).toHaveBeenCalledTimes(2); // should be called again on refresh
+    expect(mockFetchContentAssignments).toHaveBeenLastCalledWith(expect.objectContaining(expectedRefreshArgs));
   });
 
   it('renders with assigned table data "View Course" hyperlink default when content title is null', () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -400,18 +400,6 @@ const pollAsync = async (pollFunc, timeout, interval, checkFunc) => {
   return false;
 };
 
-const getCourseProductLineText = (courseProductLine) => {
-  let courseProductLineText = '';
-  courseProductLineText = courseProductLine === 'OCM' ? 'Open Courses' : courseProductLine;
-  return courseProductLineText;
-};
-
-const getCourseProductLineAbbreviation = (courseProductLine) => {
-  let courseProductLineText = '';
-  courseProductLineText = courseProductLine === 'Open Courses Marketplace' ? 'OCM' : 'Executive Education';
-  return courseProductLineText;
-};
-
 export {
   camelCaseDict,
   camelCaseDictArray,
@@ -445,6 +433,4 @@ export {
   capitalizeFirstLetter,
   pollAsync,
   isNotValidNumberString,
-  getCourseProductLineText,
-  getCourseProductLineAbbreviation,
 };


### PR DESCRIPTION
# Description

[ENT-7902](https://2u-internal.atlassian.net/browse/ENT-7902)

* Adds "Refresh" CTA interaction to the "Assigned" table. Refreshes whatever the current table is displaying.
* Removes the existing "Product" column from the "Spent" table (confirmed with UX).

https://github.com/openedx/frontend-app-admin-portal/assets/2828721/b93cbc6d-ae3d-4736-9f2d-33f13033bd9f

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [x] Ensure to have UX team confirm screenshots
