### PR TITLE
fix: rely on new `error_reason` field to determine failed `learner_state` reason

### DIFF
--- a/src/components/EnterpriseApp/EnterpriseAppRoutes.jsx
+++ b/src/components/EnterpriseApp/EnterpriseAppRoutes.jsx
@@ -29,7 +29,6 @@ const EnterpriseAppRoutes = ({
   enableContentHighlightsPage,
 }) => {
   const { canManageLearnerCredit } = useContext(EnterpriseSubsidiesContext);
-  console.log('EnterpriseAppRoutes!!!');
   return (
     <Switch>
       <Route

--- a/src/components/EnterpriseApp/index.jsx
+++ b/src/components/EnterpriseApp/index.jsx
@@ -34,11 +34,9 @@ class EnterpriseApp extends React.Component {
     } = this.props;
     this.props.fetchPortalConfiguration(enterpriseSlug);
     this.props.toggleSidebarToggle(); // ensure sidebar toggle button is in header
-
-    console.log('EnterpriseApp componentDidMount!!!');
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(prevProps) {
     const {
       location: { pathname },
     } = this.props;
@@ -46,8 +44,6 @@ class EnterpriseApp extends React.Component {
     if (pathname !== prevProps.location.pathname) {
       this.handleSidebarMenuItemClick();
     }
-
-    console.log('EnterpriseApp componentDidUpdate!!!', { prevProps, prevState, currentProps: this.props, currentState: this.state });
   }
 
   componentWillUnmount() {

--- a/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
+++ b/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
@@ -32,9 +32,7 @@ const AssignmentStatusTableCell = ({ row }) => {
     // Determine the failure reason based on the actions.
     const { actions } = row.original;
     const mostRecentAction = actions[actions.length - 1]; // API returns actions in chronological order.
-
     const isBadEmailError = mostRecentAction.actionType === 'notified' && !!mostRecentAction.errorReason;
-
     if (isBadEmailError) {
       return (
         <FailedBadEmail learnerEmail={learnerEmail} />

--- a/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
+++ b/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
@@ -31,7 +31,8 @@ const AssignmentStatusTableCell = ({ row }) => {
   if (learnerState === 'failed') {
     // Determine the failure reason based on the actions.
     const { actions } = row.original;
-    const mostRecentAction = actions[0]; // API returns actions in reverse chronological order.
+    const mostRecentAction = actions[actions.length - 1]; // API returns actions in chronological order.
+
     const isBadEmailError = mostRecentAction.actionType === 'notified' && !!mostRecentAction.errorReason;
 
     if (isBadEmailError) {

--- a/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
+++ b/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
@@ -9,13 +9,19 @@ import FailedBadEmail from './assignments-status-chips/FailedBadEmail';
 import FailedSystem from './assignments-status-chips/FailedSystem';
 
 const AssignmentStatusTableCell = ({ row }) => {
-  const { original: { learnerEmail, learnerState } } = row;
+  const { original } = row;
+  const {
+    learnerEmail,
+    learnerState,
+    errorReason,
+  } = original;
 
   // Learner state is not available for this assignment, so don't display anything.
   if (!learnerState) {
     return null;
   }
 
+  // Display the appropriate status chip based on the learner state.
   if (learnerState === 'notifying') {
     return (
       <NotifyingLearner learnerEmail={learnerEmail} />
@@ -29,11 +35,8 @@ const AssignmentStatusTableCell = ({ row }) => {
   }
 
   if (learnerState === 'failed') {
-    // Determine the failure reason based on the actions.
-    const { actions } = row.original;
-    const mostRecentAction = actions[actions.length - 1]; // API returns actions in chronological order.
-    const isBadEmailError = mostRecentAction.actionType === 'notified' && !!mostRecentAction.errorReason;
-    if (isBadEmailError) {
+    // Determine which failure chip to display based on the error reason.
+    if (errorReason === 'email_error') {
       return (
         <FailedBadEmail learnerEmail={learnerEmail} />
       );
@@ -51,6 +54,7 @@ AssignmentStatusTableCell.propTypes = {
     original: PropTypes.shape({
       learnerEmail: PropTypes.string,
       learnerState: PropTypes.string.isRequired,
+      errorReason: PropTypes.string,
       actions: PropTypes.arrayOf(PropTypes.shape({
         actionType: PropTypes.string.isRequired,
         errorReason: PropTypes.string,

--- a/src/components/learner-credit-management/BudgetDetailPage.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPage.jsx
@@ -13,8 +13,6 @@ const BudgetDetailPage = () => {
     data: subsidyAccessPolicy,
   } = useSubsidyAccessPolicy(subsidyAccessPolicyId);
 
-  console.log('BudgetDetailPage!!!');
-
   if (isInitialLoadingSubsidyAccessPolicy) {
     return (
       <BudgetDetailPageWrapper>

--- a/src/components/learner-credit-management/BudgetDetailTabsAndRoutes.jsx
+++ b/src/components/learner-credit-management/BudgetDetailTabsAndRoutes.jsx
@@ -43,9 +43,6 @@ const BudgetDetailTabsAndRoutes = ({
   enterpriseSlug,
   enterpriseFeatures,
 }) => {
-
-  console.log('BudgetDetailTabsAndRoutes!!!');
-
   const { activeTabKey: routeActiveTabKey } = useParams();
   const { budgetId, subsidyAccessPolicyId } = useBudgetId();
   const { data: subsidyAccessPolicy } = useSubsidyAccessPolicy(subsidyAccessPolicyId);

--- a/src/components/learner-credit-management/cards/Collapsibles.jsx
+++ b/src/components/learner-credit-management/cards/Collapsibles.jsx
@@ -20,10 +20,6 @@ export const NextStepsForAssignedLearners = ({ course }) => (
           is calculated based on the course enrollment deadline or {ASSIGNMENT_ENROLLMENT_DEADLINE} days
           past the date of assignment, whichever is sooner.
         </li>
-        <li>
-          Learners will receive automated reminder emails every 10-15 days until the enrollment
-          deadline is reached.
-        </li>
       </ul>
     </div>
   </Collapsible>

--- a/src/components/learner-credit-management/search/CatalogSearchResults.jsx
+++ b/src/components/learner-credit-management/search/CatalogSearchResults.jsx
@@ -33,7 +33,6 @@ export const BaseCatalogSearchResults = ({
   error,
   setNoContent,
 }) => {
-  console.log('BaseCatalogSearchResults!!!', searchResults);
   const courseColumns = useMemo(
     () => [
       {

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -306,6 +306,7 @@ describe('<BudgetDetailPage />', () => {
             learnerState: 'waiting',
             recentAction: { actionType: 'assigned', timestamp: '2023-10-27' },
             actions: [mockSuccessfulNotifiedAction],
+            errorReason: null,
           },
         ],
         numPages: 1,
@@ -377,6 +378,7 @@ describe('<BudgetDetailPage />', () => {
             learnerState: 'waiting',
             recentAction: { actionType: 'assigned', timestamp: '2023-10-27' },
             actions: [mockSuccessfulNotifiedAction],
+            errorReason: null,
           },
         ],
         numPages: 1,
@@ -408,6 +410,7 @@ describe('<BudgetDetailPage />', () => {
       expectedModalPopupHeading: `Notifying ${mockLearnerEmail}`,
       expectedModalPopupContent: `Our system is busy emailing ${mockLearnerEmail}!`,
       actions: [],
+      errorReason: null,
     },
     {
       learnerState: 'notifying',
@@ -416,6 +419,7 @@ describe('<BudgetDetailPage />', () => {
       expectedModalPopupHeading: 'Notifying learner',
       expectedModalPopupContent: 'Our system is busy emailing the learner!',
       actions: [],
+      errorReason: null,
     },
     {
       learnerState: 'waiting',
@@ -424,6 +428,7 @@ describe('<BudgetDetailPage />', () => {
       expectedModalPopupHeading: `Waiting for ${mockLearnerEmail}`,
       expectedModalPopupContent: 'This learner must create an edX account and complete enrollment in the course',
       actions: [mockSuccessfulLinkedLearnerAction, mockSuccessfulNotifiedAction],
+      errorReason: null,
     },
     {
       learnerState: 'waiting',
@@ -432,6 +437,7 @@ describe('<BudgetDetailPage />', () => {
       expectedModalPopupHeading: 'Waiting for learner',
       expectedModalPopupContent: 'This learner must create an edX account and complete enrollment in the course',
       actions: [mockSuccessfulLinkedLearnerAction, mockSuccessfulNotifiedAction],
+      errorReason: null,
     },
     {
       learnerState: 'failed',
@@ -440,6 +446,7 @@ describe('<BudgetDetailPage />', () => {
       expectedModalPopupHeading: 'Failed: Bad email',
       expectedModalPopupContent: `This course assignment failed because a notification to ${mockLearnerEmail} could not be sent.`,
       actions: [mockSuccessfulLinkedLearnerAction, mockFailedNotifiedAction],
+      errorReason: 'email_error',
     },
     {
       learnerState: 'failed',
@@ -448,6 +455,7 @@ describe('<BudgetDetailPage />', () => {
       expectedModalPopupHeading: 'Failed: Bad email',
       expectedModalPopupContent: 'This course assignment failed because a notification to the learner could not be sent.',
       actions: [mockSuccessfulLinkedLearnerAction, mockFailedNotifiedAction],
+      errorReason: 'email_error',
     },
     {
       learnerState: 'failed',
@@ -456,6 +464,7 @@ describe('<BudgetDetailPage />', () => {
       expectedModalPopupHeading: 'Failed: System',
       expectedModalPopupContent: 'Something went wrong behind the scenes.',
       actions: [mockFailedLinkedLearnerAction],
+      errorReason: 'internal_api_error',
     },
   ])('renders correct status chips with assigned table data (%s)', ({
     learnerState,
@@ -464,6 +473,7 @@ describe('<BudgetDetailPage />', () => {
     expectedModalPopupHeading,
     expectedModalPopupContent,
     actions,
+    errorReason,
   }) => {
     useParams.mockReturnValue({
       budgetId: mockSubsidyAccessPolicyUUID,
@@ -493,6 +503,7 @@ describe('<BudgetDetailPage />', () => {
             learnerState,
             recentAction: { actionType: 'assigned', timestamp: '2023-10-27' },
             actions,
+            errorReason,
           },
         ],
         numPages: 1,
@@ -761,6 +772,7 @@ describe('<BudgetDetailPage />', () => {
             learnerState: 'active',
             recentAction: { actionType: 'assigned', timestamp: '2023-10-27' },
             actions: [],
+            errorReason: null,
             state: 'allocated',
           },
         ],

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -87,7 +87,7 @@ const mockSuccessfulLinkedLearnerAction = {
 const mockFailedNotifiedAction = {
   ...mockSuccessfulNotifiedAction,
   completedAt: null,
-  errorReason: 'bad_email',
+  errorReason: 'email_error',
 };
 const mockFailedLinkedLearnerAction = {
   ...mockFailedNotifiedAction,

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -78,13 +78,17 @@ const mockSuccessfulNotifiedAction = {
   completedAt: '2023-10-27',
   errorReason: null,
 };
-
+const mockSuccessfulLinkedLearnerAction = {
+  uuid: 'test-assignment-action-uuid',
+  actionType: 'notified',
+  completedAt: '2023-10-27',
+  errorReason: null,
+};
 const mockFailedNotifiedAction = {
   ...mockSuccessfulNotifiedAction,
   completedAt: null,
   errorReason: 'bad_email',
 };
-
 const mockFailedLinkedLearnerAction = {
   ...mockFailedNotifiedAction,
   actionType: 'learner_linked',
@@ -419,7 +423,7 @@ describe('<BudgetDetailPage />', () => {
       expectedChipStatus: 'Waiting for learner',
       expectedModalPopupHeading: `Waiting for ${mockLearnerEmail}`,
       expectedModalPopupContent: 'This learner must create an edX account and complete enrollment in the course',
-      actions: [mockSuccessfulNotifiedAction],
+      actions: [mockSuccessfulLinkedLearnerAction, mockSuccessfulNotifiedAction],
     },
     {
       learnerState: 'waiting',
@@ -427,7 +431,7 @@ describe('<BudgetDetailPage />', () => {
       expectedChipStatus: 'Waiting for learner',
       expectedModalPopupHeading: 'Waiting for learner',
       expectedModalPopupContent: 'This learner must create an edX account and complete enrollment in the course',
-      actions: [mockSuccessfulNotifiedAction],
+      actions: [mockSuccessfulLinkedLearnerAction, mockSuccessfulNotifiedAction],
     },
     {
       learnerState: 'failed',
@@ -435,7 +439,7 @@ describe('<BudgetDetailPage />', () => {
       expectedChipStatus: 'Failed: Bad email',
       expectedModalPopupHeading: 'Failed: Bad email',
       expectedModalPopupContent: `This course assignment failed because a notification to ${mockLearnerEmail} could not be sent.`,
-      actions: [mockFailedNotifiedAction],
+      actions: [mockSuccessfulLinkedLearnerAction, mockFailedNotifiedAction],
     },
     {
       learnerState: 'failed',
@@ -443,7 +447,7 @@ describe('<BudgetDetailPage />', () => {
       expectedChipStatus: 'Failed: Bad email',
       expectedModalPopupHeading: 'Failed: Bad email',
       expectedModalPopupContent: 'This course assignment failed because a notification to the learner could not be sent.',
-      actions: [mockFailedNotifiedAction],
+      actions: [mockSuccessfulLinkedLearnerAction, mockFailedNotifiedAction],
     },
     {
       learnerState: 'failed',


### PR DESCRIPTION
Related PR: https://github.com/openedx/enterprise-access/pull/314

Removes some business logic in the frontend in favor of relying on data returned by the API explicitly. That is, when an Assignment is an `errored` state, the API now returns the most recent `error_reason` from the associated Actions such that the frontend doesn't have to iterate through the list of Actions itself.

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
