### PR TITLE
fix: integrate with `allocate` API for creating assignments, update global retry behavior on queries, handle 404 subsidy access policy

### DIFF
--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -23,25 +23,18 @@ import { SystemWideWarningBanner } from '../system-wide-banner';
 
 import store from '../../data/store';
 import { ROUTE_NAMES } from '../EnterpriseApp/data/constants';
+import { defaultQueryClientRetryHandler } from '../../utils';
 
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
+      retry: defaultQueryClientRetryHandler,
       // Specifying a longer `staleTime` of 20 seconds means queries will not refetch their data
       // as often; mitigates making duplicate queries when within the `staleTime` window, instead
       // relying on the cached data until the `staleTime` window has exceeded. This may be modified
       // per-query, as needed, if certain queries expect to be more up-to-date than others. Allows
       // `useQuery` to be used as a state manager.
       staleTime: 1000 * 20,
-      // Globally modifying the retry behavior of queries to retry up to max 3 times (default) or if
-      // if the error returned by the query is a 404 HTTP status code (not found). This configuration
-      // may be overridden per-query, as needed.
-      retry: (failureCount, err) => {
-        if (failureCount === 3 || err?.customAttributes?.httpErrorStatus === 404) {
-          return false;
-        }
-        return true;
-      },
     },
   },
 });

--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -33,6 +33,15 @@ const queryClient = new QueryClient({
       // per-query, as needed, if certain queries expect to be more up-to-date than others. Allows
       // `useQuery` to be used as a state manager.
       staleTime: 1000 * 20,
+      // Globally modifying the retry behavior of queries to retry up to max 3 times (default) or if
+      // if the error returned by the query is a 404 HTTP status code (not found). This configuration
+      // may be overridden per-query, as needed.
+      retry: (failureCount, err) => {
+        if (failureCount === 3 || err?.customAttributes?.httpErrorStatus === 404) {
+          return false;
+        }
+        return true;
+      },
     },
   },
 });

--- a/src/components/learner-credit-management/BudgetDetailActivityTabContents.jsx
+++ b/src/components/learner-credit-management/BudgetDetailActivityTabContents.jsx
@@ -14,13 +14,16 @@ const BudgetDetailActivityTabContents = ({ enterpriseUUID, enterpriseFeatures })
   const { data: subsidyAccessPolicy } = useSubsidyAccessPolicy(subsidyAccessPolicyId);
   const {
     isLoading: isBudgetActivityOverviewLoading,
+    isFetching: isBudgetActivityOverviewFetching,
     data: budgetActivityOverview,
   } = useBudgetDetailActivityOverview({
     enterpriseUUID,
     isTopDownAssignmentEnabled,
   });
 
-  if (isBudgetActivityOverviewLoading || !budgetActivityOverview) {
+  // // If the budget activity overview data is loading (either the initial request OR any
+  // // background re-fetching), show a skeleton.
+  if (isBudgetActivityOverviewLoading || isBudgetActivityOverviewFetching || !budgetActivityOverview) {
     return (
       <>
         <Skeleton count={2} height={180} />

--- a/src/components/learner-credit-management/BudgetDetailPage.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPage.jsx
@@ -5,17 +5,19 @@ import { useBudgetId, useSubsidyAccessPolicy } from './data';
 import BudgetDetailTabsAndRoutes from './BudgetDetailTabsAndRoutes';
 import BudgetDetailPageWrapper from './BudgetDetailPageWrapper';
 import BudgetDetailPageHeader from './BudgetDetailPageHeader';
+import NotFoundPage from '../NotFoundPage';
 
 const BudgetDetailPage = () => {
   const { subsidyAccessPolicyId } = useBudgetId();
   const {
-    isInitialLoading: isInitialLoadingSubsidyAccessPolicy,
     data: subsidyAccessPolicy,
+    isInitialLoading: isSubsidyAccessPolicyInitialLoading,
+    isError: isSubsidyAccessPolicyError,
   } = useSubsidyAccessPolicy(subsidyAccessPolicyId);
 
-  if (isInitialLoadingSubsidyAccessPolicy) {
+  if (isSubsidyAccessPolicyInitialLoading) {
     return (
-      <BudgetDetailPageWrapper>
+      <BudgetDetailPageWrapper includeHero={false}>
         <Skeleton height={25} />
         <Skeleton height={50} />
         <Skeleton height={360} />
@@ -23,6 +25,10 @@ const BudgetDetailPage = () => {
         <span className="sr-only">loading budget details</span>
       </BudgetDetailPageWrapper>
     );
+  }
+
+  if (subsidyAccessPolicyId && isSubsidyAccessPolicyError) {
+    return <NotFoundPage />;
   }
 
   return (

--- a/src/components/learner-credit-management/BudgetDetailPage.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPage.jsx
@@ -13,6 +13,7 @@ const BudgetDetailPage = () => {
     data: subsidyAccessPolicy,
     isInitialLoading: isSubsidyAccessPolicyInitialLoading,
     isError: isSubsidyAccessPolicyError,
+    error,
   } = useSubsidyAccessPolicy(subsidyAccessPolicyId);
 
   if (isSubsidyAccessPolicyInitialLoading) {
@@ -27,7 +28,9 @@ const BudgetDetailPage = () => {
     );
   }
 
-  if (subsidyAccessPolicyId && isSubsidyAccessPolicyError) {
+  // If the budget is intended to be a subsidy access policy (by presence of a policy UUID),
+  // and the subsidy access policy is not found, show 404 messaging.
+  if (subsidyAccessPolicyId && isSubsidyAccessPolicyError && error?.customAttributes.httpErrorStatus === 404) {
     return <NotFoundPage />;
   }
 

--- a/src/components/learner-credit-management/BudgetDetailPageWrapper.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPageWrapper.jsx
@@ -7,7 +7,11 @@ import Hero from '../Hero';
 
 const PAGE_TITLE = 'Learner Credit Management';
 
-const BudgetDetailPageWrapper = ({ subsidyAccessPolicy, children }) => {
+const BudgetDetailPageWrapper = ({
+  subsidyAccessPolicy,
+  includeHero,
+  children,
+}) => {
   // display name is an optional field, and may not be set for all budgets so fallback to "Overview"
   // similar to the display name logic for budgets on the overview page route.
   const budgetDisplayName = subsidyAccessPolicy?.displayName || 'Overview';
@@ -15,7 +19,7 @@ const BudgetDetailPageWrapper = ({ subsidyAccessPolicy, children }) => {
   return (
     <>
       <Helmet title={helmetPageTitle} />
-      <Hero title={PAGE_TITLE} />
+      {includeHero && <Hero title={PAGE_TITLE} />}
       <Container className="py-3" fluid>
         {children}
       </Container>
@@ -26,6 +30,12 @@ const BudgetDetailPageWrapper = ({ subsidyAccessPolicy, children }) => {
 BudgetDetailPageWrapper.propTypes = {
   children: PropTypes.node.isRequired,
   subsidyAccessPolicy: PropTypes.shape(),
+  includeHero: PropTypes.bool,
+};
+
+BudgetDetailPageWrapper.defaultProps = {
+  includeHero: true,
+  subsidyAccessPolicy: undefined,
 };
 
 export default BudgetDetailPageWrapper;

--- a/src/components/learner-credit-management/cards/AssignmentModalContent.jsx
+++ b/src/components/learner-credit-management/cards/AssignmentModalContent.jsx
@@ -13,10 +13,17 @@ import BaseCourseCard from './BaseCourseCard';
 import { formatPrice, useBudgetId, useSubsidyAccessPolicy } from '../data';
 import { ImpactOnYourLearnerCreditBudget, ManagingThisAssignment, NextStepsForAssignedLearners } from './Collapsibles';
 
-const AssignmentModalContent = ({ course }) => {
-  const [emailAddresses, setEmailAddresses] = useState('');
+const AssignmentModalContent = ({ course, onEmailAddressesChange }) => {
+  const [emailAddressesInputValue, setEmailAddressesInputValue] = useState('');
   const { subsidyAccessPolicyId } = useBudgetId();
   const { data: subsidyAccessPolicy } = useSubsidyAccessPolicy(subsidyAccessPolicyId);
+
+  const handleEmailAddressInputChange = (e) => {
+    const inputValue = e.target.value;
+    const emailAddresses = inputValue.split('\n').filter((email) => email.trim().length > 0);
+    setEmailAddressesInputValue(inputValue);
+    onEmailAddressesChange(emailAddresses);
+  };
 
   return (
     <Container size="lg" className="py-3">
@@ -24,7 +31,7 @@ const AssignmentModalContent = ({ course }) => {
         <Row>
           <Col>
             <h3 className="mb-4">Use Learner Credit to assign this course</h3>
-            <BaseCourseCard original={course} className="rounded-0 shadow-none" />
+            <BaseCourseCard original={course} cardClassName="shadow-none" />
           </Col>
         </Row>
         <Row>
@@ -33,8 +40,8 @@ const AssignmentModalContent = ({ course }) => {
             <Form.Group className="mb-5">
               <Form.Control
                 as="textarea"
-                value={emailAddresses}
-                onChange={(e) => setEmailAddresses(e.target.value)}
+                value={emailAddressesInputValue}
+                onChange={handleEmailAddressInputChange}
                 floatingLabel="Learner email addresses"
                 rows={10}
                 data-hj-suppress
@@ -78,6 +85,7 @@ const AssignmentModalContent = ({ course }) => {
 
 AssignmentModalContent.propTypes = {
   course: PropTypes.shape().isRequired, // Pass-thru prop to `BaseCourseCard`
+  onEmailAddressesChange: PropTypes.func.isRequired,
 };
 
 export default AssignmentModalContent;

--- a/src/components/learner-credit-management/cards/BaseCourseCard.jsx
+++ b/src/components/learner-credit-management/cards/BaseCourseCard.jsx
@@ -67,7 +67,7 @@ const BaseCourseCard = ({
           orientation={isExtraSmall ? 'horizontal' : 'vertical'}
           textElement={isExecEdCourseType ? execEdEnrollmentInfo : courseEnrollmentInfo}
         >
-          {CardFooterActions && <CardFooterActions {...courseCardMetadata} />}
+          {CardFooterActions && <CardFooterActions course={courseCardMetadata} />}
         </Card.Footer>
       </Card.Body>
     </Card>

--- a/src/components/learner-credit-management/cards/CourseCard.jsx
+++ b/src/components/learner-credit-management/cards/CourseCard.jsx
@@ -8,7 +8,7 @@ import BaseCourseCard from './BaseCourseCard';
 
 const { BUTTON_ACTION } = CARD_TEXT;
 
-const CourseCardFooterActions = (course) => {
+const CourseCardFooterActions = ({ course }) => {
   const { linkToCourse } = course;
 
   return [

--- a/src/components/learner-credit-management/cards/NewAssignmentModalButton.jsx
+++ b/src/components/learner-credit-management/cards/NewAssignmentModalButton.jsx
@@ -52,7 +52,7 @@ const NewAssignmentModalButton = ({ course, children }) => {
       onSuccess: () => {
         setAssignButtonState('complete');
         queryClient.invalidateQueries({
-          queryKey: learnerCreditManagementQueryKeys.budgetActivityOverview(subsidyAccessPolicyId),
+          queryKey: learnerCreditManagementQueryKeys.budget(subsidyAccessPolicyId),
         });
         close();
         history.push(pathToActivityTab);

--- a/src/components/learner-credit-management/cards/NewAssignmentModalButton.jsx
+++ b/src/components/learner-credit-management/cards/NewAssignmentModalButton.jsx
@@ -28,6 +28,7 @@ const NewAssignmentModalButton = ({ course, children }) => {
   const routeMatch = useRouteMatch();
   const queryClient = useQueryClient();
   const { subsidyAccessPolicyId } = useBudgetId();
+
   const [isOpen, open, close] = useToggle(false);
   const [learnerEmails, setLearnerEmails] = useState([]);
   const [assignButtonState, setAssignButtonState] = useState('default');
@@ -49,10 +50,15 @@ const NewAssignmentModalButton = ({ course, children }) => {
     setAssignButtonState('pending');
     mutate(mutationArgs, {
       onSuccess: () => {
+        setAssignButtonState('complete');
         queryClient.invalidateQueries({
           queryKey: learnerCreditManagementQueryKeys.budgetActivityOverview(subsidyAccessPolicyId),
         });
+        close();
         history.push(pathToActivityTab);
+      },
+      onError: () => {
+        setAssignButtonState('error');
       },
     });
   };

--- a/src/components/learner-credit-management/cards/NewAssignmentModalButton.jsx
+++ b/src/components/learner-credit-management/cards/NewAssignmentModalButton.jsx
@@ -1,16 +1,61 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { useRouteMatch, useHistory, generatePath } from 'react-router-dom';
 import {
   FullscreenModal,
   ActionRow,
   Button,
   useToggle,
   Hyperlink,
+  StatefulButton,
 } from '@edx/paragon';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { snakeCaseObject } from '@edx/frontend-platform/utils';
+
 import AssignmentModalContent from './AssignmentModalContent';
+import EnterpriseAccessApiService from '../../../data/services/EnterpriseAccessApiService';
+import { learnerCreditManagementQueryKeys, useBudgetId } from '../data';
+
+const useAllocateContentAssignments = () => useMutation({
+  mutationFn: async ({
+    subsidyAccessPolicyId,
+    payload,
+  }) => EnterpriseAccessApiService.allocateContentAssignments(subsidyAccessPolicyId, payload),
+});
 
 const NewAssignmentModalButton = ({ course, children }) => {
+  const history = useHistory();
+  const routeMatch = useRouteMatch();
+  const queryClient = useQueryClient();
+  const { subsidyAccessPolicyId } = useBudgetId();
   const [isOpen, open, close] = useToggle(false);
+  const [learnerEmails, setLearnerEmails] = useState([]);
+  const [assignButtonState, setAssignButtonState] = useState('default');
+
+  const { mutate } = useAllocateContentAssignments();
+
+  const pathToActivityTab = generatePath(routeMatch.path, { budgetId: subsidyAccessPolicyId, activeTabKey: 'activity' });
+
+  const handleAllocateContentAssignments = () => {
+    const payload = snakeCaseObject({
+      contentPriceCents: course.normalizedMetadata.contentPrice * 100, // Convert to USD cents
+      contentKey: course.key,
+      learnerEmails,
+    });
+    const mutationArgs = {
+      subsidyAccessPolicyId,
+      payload,
+    };
+    setAssignButtonState('pending');
+    mutate(mutationArgs, {
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: learnerCreditManagementQueryKeys.budgetActivityOverview(subsidyAccessPolicyId),
+        });
+        history.push(pathToActivityTab);
+      },
+    });
+  };
 
   return (
     <>
@@ -27,12 +72,21 @@ const NewAssignmentModalButton = ({ course, children }) => {
             </Button>
             <ActionRow.Spacer />
             <Button variant="tertiary" onClick={close}>Cancel</Button>
-            {/* TODO: https://2u-internal.atlassian.net/browse/ENT-7826 */}
-            <Button>Assign</Button>
+            <StatefulButton
+              labels={{
+                default: 'Assign',
+                pending: 'Assigning...',
+                complete: 'Assigned',
+                error: 'Try again',
+              }}
+              variant="primary"
+              state={assignButtonState}
+              onClick={handleAllocateContentAssignments}
+            />
           </ActionRow>
         )}
       >
-        <AssignmentModalContent course={course} />
+        <AssignmentModalContent course={course} onEmailAddressesChange={setLearnerEmails} />
       </FullscreenModal>
     </>
   );

--- a/src/components/learner-credit-management/data/hooks/useBudgetDetailActivityOverview.test.jsx
+++ b/src/components/learner-credit-management/data/hooks/useBudgetDetailActivityOverview.test.jsx
@@ -1,4 +1,4 @@
-import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook } from '@testing-library/react-hooks';
 
 import useBudgetDetailActivityOverview from './useBudgetDetailActivityOverview';
@@ -12,22 +12,15 @@ import {
   mockEnterpriseOfferId,
   mockSubsidyAccessPolicyUUID,
 } from '../tests/constants';
+import { queryClient } from '../../../test/testUtils';
 
 jest.mock('./useBudgetId');
 jest.mock('./useSubsidyAccessPolicy');
 
 const mockEnterpriseUUID = 'mock-enterprise-uuid';
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: false,
-    },
-  },
-});
-
 const wrapper = ({ children }) => (
-  <QueryClientProvider client={queryClient}>
+  <QueryClientProvider client={queryClient()}>
     {children}
   </QueryClientProvider>
 );

--- a/src/components/learner-credit-management/data/hooks/useSubsidyAccessPolicy.test.jsx
+++ b/src/components/learner-credit-management/data/hooks/useSubsidyAccessPolicy.test.jsx
@@ -1,8 +1,9 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook } from '@testing-library/react-hooks';
 
 import useSubsidyAccessPolicy from './useSubsidyAccessPolicy'; // Import the hook
 import EnterpriseAccessApiService from '../../../../data/services/EnterpriseAccessApiService';
+import { queryClient } from '../../../test/testUtils';
 
 const mockSubsidyAccessPolicyUUID = '9af340a9-48de-4d94-976d-e2282b9eb7f3';
 const mockAssignmentConfiguration = { uuid: 'test-assignment-configuration-uuid' };
@@ -18,16 +19,8 @@ jest.mock('../../../../data/services/EnterpriseAccessApiService', () => ({
   }),
 }));
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: false,
-    },
-  },
-});
-
 const wrapper = ({ children }) => (
-  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  <QueryClientProvider client={queryClient()}>{children}</QueryClientProvider>
 );
 
 describe('useSubsidyAccessPolicy', () => {

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
@@ -29,6 +29,7 @@ import {
   mockSubsidyAccessPolicyUUID,
   mockEnterpriseOfferId,
 } from '../data/tests/constants';
+import { queryClient } from '../../test/testUtils';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -98,8 +99,6 @@ const defaultEnterpriseSubsidiesContextValue = {
   isLoading: false,
 };
 
-const queryClient = new QueryClient();
-
 const BudgetDetailPageWrapper = ({
   initialState = initialStoreState,
   enterpriseSubsidiesContextValue = defaultEnterpriseSubsidiesContextValue,
@@ -107,7 +106,7 @@ const BudgetDetailPageWrapper = ({
 }) => {
   const store = getMockStore({ ...initialState });
   return (
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={queryClient()}>
       <IntlProvider locale="en">
         <Provider store={store}>
           <EnterpriseSubsidiesContext.Provider value={enterpriseSubsidiesContextValue}>

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -123,6 +123,24 @@ describe('<BudgetDetailPage />', () => {
     jest.resetAllMocks();
   });
 
+  it('renders page not found messaging if budget is a subsidy access policy, but the REST API returns a 404', () => {
+    useParams.mockReturnValue({
+      budgetId: 'a52e6548-649f-4576-b73f-c5c2bee25e9c',
+      activeTabKey: 'activity',
+    });
+    useSubsidyAccessPolicy.mockReturnValue({
+      isInitialLoading: false,
+      isError: true,
+      error: { customAttributes: { httpStatusCode: 404 } },
+    });
+    useBudgetDetailActivityOverview.mockReturnValue({
+      isLoading: false,
+      data: mockEmptyStateBudgetDetailActivityOverview,
+    });
+    renderWithRouter(<BudgetDetailPageWrapper />);
+    expect(screen.getByText('404', { selector: 'h1' }));
+  });
+
   it.each([
     { displayName: null },
     { displayName: 'Test Budget Display Name' },

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -131,7 +131,7 @@ describe('<BudgetDetailPage />', () => {
     useSubsidyAccessPolicy.mockReturnValue({
       isInitialLoading: false,
       isError: true,
-      error: { customAttributes: { httpStatusCode: 404 } },
+      error: { customAttributes: { httpErrorStatus: 404 } },
     });
     useBudgetDetailActivityOverview.mockReturnValue({
       isLoading: false,

--- a/src/components/learner-credit-management/tests/CatalogSearch.test.jsx
+++ b/src/components/learner-credit-management/tests/CatalogSearch.test.jsx
@@ -6,8 +6,8 @@ import {
 } from '@edx/frontend-enterprise-catalog-search';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { screen } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderWithRouter } from '../../test/testUtils';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient, renderWithRouter } from '../../test/testUtils';
 import CatalogSearch from '../search/CatalogSearch';
 
 import { useBudgetId, useSubsidyAccessPolicy } from '../data';
@@ -21,10 +21,9 @@ jest.mock('react-instantsearch-dom', () => ({
 jest.mock('../data');
 
 const DEFAULT_SEARCH_CONTEXT_VALUE = { refinements: {} };
-const queryClient = new QueryClient();
 
 const SearchDataWrapper = ({ children, searchContextValue }) => (
-  <QueryClientProvider client={queryClient}>
+  <QueryClientProvider client={queryClient()}>
     <IntlProvider locale="en">
       <SearchContext.Provider
         value={searchContextValue}

--- a/src/components/learner-credit-management/tests/CatalogSearchResults.test.jsx
+++ b/src/components/learner-credit-management/tests/CatalogSearchResults.test.jsx
@@ -1,16 +1,17 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
-
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import { QueryClientProvider } from '@tanstack/react-query';
 
 import { BaseCatalogSearchResults } from '../search/CatalogSearchResults';
-
 import { CONTENT_TYPE_COURSE } from '../data/constants';
+import { queryClient } from '../../test/testUtils';
 
 // Mocking this connected component so as not to have to mock the algolia Api
 const PAGINATE_ME = 'PAGINATE ME :)';
@@ -39,11 +40,13 @@ const SearchDataWrapper = ({
 }) => {
   const store = getMockStore({ ...initialStoreState });
   return (
-    <Provider store={store}>
-      <SearchContext.Provider value={searchContextValue}>
-        {children}
-      </SearchContext.Provider>
-    </Provider>
+    <QueryClientProvider client={queryClient()}>
+      <Provider store={store}>
+        <SearchContext.Provider value={searchContextValue}>
+          {children}
+        </SearchContext.Provider>
+      </Provider>
+    </QueryClientProvider>
   );
 };
 
@@ -153,7 +156,7 @@ describe('Main Catalogs view works as expected', () => {
   });
 
   test('all courses rendered when search results available', async () => {
-    render(
+    renderWithRouter(
       <SearchDataWrapper>
         <IntlProvider locale="en">
           <BaseCatalogSearchResults {...defaultProps} />

--- a/src/components/settings/SettingsSSOTab/tests/NewExistingSSOConfigs.test.jsx
+++ b/src/components/settings/SettingsSSOTab/tests/NewExistingSSOConfigs.test.jsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
-import {
-  QueryClient,
-  QueryClientProvider,
-} from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import userEvent from '@testing-library/user-event';
 import {
   act,
@@ -19,12 +16,7 @@ import { features } from '../../../../config';
 import NewExistingSSOConfigs from '../NewExistingSSOConfigs';
 import { SSOConfigContext, SSO_INITIAL_STATE } from '../SSOConfigContext';
 import LmsApiService from '../../../../data/services/LmsApiService';
-
-const queryClient = new QueryClient({
-  queries: {
-    retry: true, // optional: you may disable automatic query retries for all queries or on a per-query basis.
-  },
-});
+import { queryClient } from '../../../test/testUtils';
 
 jest.mock('../../utils');
 jest.mock('../../../../data/services/LmsApiService');
@@ -152,7 +144,7 @@ const setupNewExistingSSOConfigs = (configs) => {
   features.AUTH0_SELF_SERVICE_INTEGRATION = true;
   return render(
     <IntlProvider locale="en">
-      <QueryClientProvider client={queryClient}>
+      <QueryClientProvider client={queryClient()}>
         <SSOConfigContext.Provider value={contextValue}>
           <Provider store={store}>
             <NewExistingSSOConfigs

--- a/src/components/settings/SettingsSSOTab/tests/SettingsSSOTab.test.jsx
+++ b/src/components/settings/SettingsSSOTab/tests/SettingsSSOTab.test.jsx
@@ -1,10 +1,7 @@
 import {
   act, render, screen, waitFor,
 } from '@testing-library/react';
-import {
-  QueryClient,
-  QueryClientProvider,
-} from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import '@testing-library/jest-dom/extend-expect';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -15,6 +12,7 @@ import { HELP_CENTER_SAML_LINK } from '../../data/constants';
 import { features } from '../../../../config';
 import SettingsSSOTab from '..';
 import LmsApiService from '../../../../data/services/LmsApiService';
+import { queryClient } from '../../../test/testUtils';
 
 const enterpriseId = 'an-id-1';
 jest.mock('../../../../data/services/LmsApiService');
@@ -28,11 +26,6 @@ const initialStore = {
     contactEmail: 'foobar',
   },
 };
-const queryClient = new QueryClient({
-  queries: {
-    retry: true, // optional: you may disable automatic query retries for all queries or on a per-query basis.
-  },
-});
 
 const mockStore = configureMockStore([thunk]);
 const getMockStore = aStore => mockStore(aStore);
@@ -102,7 +95,7 @@ describe('SAML Config Tab', () => {
     }));
     await waitFor(() => render(
       <IntlProvider locale="en">
-        <QueryClientProvider client={queryClient}>
+        <QueryClientProvider client={queryClient()}>
           <Provider store={store}>
             <SettingsSSOTab setHasSSOConfig={mockSetHasSSOConfig} enterpriseId={enterpriseId} />
           </Provider>,

--- a/src/components/test/testUtils.jsx
+++ b/src/components/test/testUtils.jsx
@@ -2,8 +2,10 @@
 import React from 'react';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
-import { render, screen } from '@testing-library/react';
+import { render, screen as rtlScreen } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
 
+// TODO: this could likely be replaced by `renderWithRouter` from `@edx/frontend-enterprise-utils`.
 export function renderWithRouter(
   ui,
   {
@@ -30,4 +32,25 @@ export function findElementWithText(container, type, text) {
   return [...elements].find((elem) => elem.innerHTML.includes(text));
 }
 
-export const getButtonElement = (buttonText) => screen.getByRole('button', { name: buttonText });
+export const getButtonElement = (buttonText, options = {}) => {
+  const {
+    screenOverride,
+    isQueryByRole,
+  } = options;
+  const screen = screenOverride || rtlScreen;
+  if (isQueryByRole) {
+    return screen.queryByRole('button', { name: buttonText });
+  }
+  return screen.getByRole('button', { name: buttonText });
+};
+
+export function queryClient(options = {}) {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+      ...options,
+    },
+  });
+}

--- a/src/data/services/EnterpriseAccessApiService.js
+++ b/src/data/services/EnterpriseAccessApiService.js
@@ -166,6 +166,11 @@ class EnterpriseAccessApiService {
     const url = `${EnterpriseAccessApiService.baseUrl}/subsidy-access-policies/${subsidyAccessPolicyUUID}/`;
     return EnterpriseAccessApiService.apiClient().get(url);
   }
+
+  static allocateContentAssignments(subsidyAccessPolicyUUID, payload) {
+    const url = `${EnterpriseAccessApiService.baseUrl}/policy-allocation/${subsidyAccessPolicyUUID}/allocate/`;
+    return EnterpriseAccessApiService.apiClient().post(url, payload);
+  }
 }
 
 export default EnterpriseAccessApiService;

--- a/src/data/services/tests/EnterpriseAccessApiService.test.js
+++ b/src/data/services/tests/EnterpriseAccessApiService.test.js
@@ -156,6 +156,8 @@ describe('EnterpriseAccessApiService', () => {
   test('allocateContentAssignments calls enterprise-access allocate POST API to create assignments', () => {
     const payload = {
       learner_emails: ['edx@example.com'],
+      content_key: 'edX+DemoX',
+      content_price_cents: 19900,
     };
     EnterpriseAccessApiService.allocateContentAssignments(mockSubsidyAccessPolicyUUID, payload);
     expect(axios.post).toBeCalledWith(

--- a/src/data/services/tests/EnterpriseAccessApiService.test.js
+++ b/src/data/services/tests/EnterpriseAccessApiService.test.js
@@ -152,4 +152,15 @@ describe('EnterpriseAccessApiService', () => {
       `${enterpriseAccessBaseUrl}/api/v1/subsidy-access-policies/${mockSubsidyAccessPolicyUUID}/`,
     );
   });
+
+  test('allocateContentAssignments calls enterprise-access allocate POST API to create assignments', () => {
+    const payload = {
+      learner_emails: ['edx@example.com'],
+    };
+    EnterpriseAccessApiService.allocateContentAssignments(mockSubsidyAccessPolicyUUID, payload);
+    expect(axios.post).toBeCalledWith(
+      `${enterpriseAccessBaseUrl}/api/v1/policy-allocation/${mockSubsidyAccessPolicyUUID}/allocate/`,
+      payload,
+    );
+  });
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -400,6 +400,18 @@ const pollAsync = async (pollFunc, timeout, interval, checkFunc) => {
   return false;
 };
 
+/**
+ * Modifies the retry behavior of queries to retry up to max 3 times (default) or if
+ * if the error returned by the query is a 404 HTTP status code (not found). This configuration
+ * may be overridden per-query, as needed.
+ */
+function defaultQueryClientRetryHandler(failureCount, err) {
+  if (failureCount >= 3 || err.customAttributes.httpErrorStatus === 404) {
+    return false;
+  }
+  return true;
+}
+
 export {
   camelCaseDict,
   camelCaseDictArray,
@@ -433,4 +445,5 @@ export {
   capitalizeFirstLetter,
   pollAsync,
   isNotValidNumberString,
+  defaultQueryClientRetryHandler,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -402,7 +402,7 @@ const pollAsync = async (pollFunc, timeout, interval, checkFunc) => {
 
 /**
  * Modifies the retry behavior of queries to retry up to max 3 times (default) or if
- * if the error returned by the query is a 404 HTTP status code (not found). This configuration
+ * the error returned by the query is a 404 HTTP status code (not found). This configuration
  * may be overridden per-query, as needed.
  */
 function defaultQueryClientRetryHandler(failureCount, err) {

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -5,6 +5,7 @@ import {
   snakeCaseFormData,
   pollAsync,
   isValidNumber,
+  defaultQueryClientRetryHandler,
 } from './utils';
 
 describe('utils', () => {
@@ -91,6 +92,26 @@ describe('utils', () => {
       expect(isValidNumber('One')).toEqual(false);
       expect(isValidNumber({})).toEqual(false);
       expect(isValidNumber(undefined)).toEqual(false);
+    });
+  });
+
+  describe('defaultQueryClientRetryHandler', () => {
+    const mockError404 = { customAttributes: { httpErrorStatus: 404 } };
+    const mockError500 = { customAttributes: { httpErrorStatus: 500 } };
+
+    it.each([3, 4])('return false if failureCount >= 3 (failureCount: %s)', (failureCount) => {
+      const result = defaultQueryClientRetryHandler(failureCount, mockError500);
+      expect(result).toEqual(false);
+    });
+
+    it('return false if error is a 404 HTTP status code', () => {
+      const result = defaultQueryClientRetryHandler(1, mockError404);
+      expect(result).toEqual(false);
+    });
+
+    it.each([1, 2])('return true if first failure and error is not a 404 (failureCount: %s)', (failureCount) => {
+      const result = defaultQueryClientRetryHandler(failureCount, mockError500);
+      expect(result).toEqual(true);
     });
   });
 });


### PR DESCRIPTION
# Description

First of at least two PRs for [ENT-7826](https://2u-internal.atlassian.net/browse/ENT-7826)

Includes:
* Integrates with the `allocate` POST API endpoint in enterprise-access. **Happy path only**, using whatever email(s) are input in the assignment modal.
* Modifies the global retry behavior for `@tanstack/react-query` to avoid retries when the query has thrown max 3 errors in a row (default behavior) or returns a 404 once.
* Displays skeleton loading state when doing background refetches of the budget detail activity overview data (spent table + assigned table, if applicable).
  * This is necessary for when an admin creates their first assignment(s) when the "Activity" tab previously displayed "No budget activity?" empty state such that the empty state doesn't briefly show immediately after creating new assignment(s) while the activity overview data refetches. The budget detail activity overview data refetches after an assignment was made due to invalidating the query cache for the overview data query, e.g.:

```jsx
queryClient.invalidateQueries({
  queryKey: learnerCreditManagementQueryKeys.budgetActivityOverview(subsidyAccessPolicyId),
});
```

* Ensures a "Page Not Found" screen is displayed if the budget detail page route includes an identifier for a subsidy access policy (i.e., a UUID), the data is not currently loading, and is in an error status.
* Ensures the initial loading of subsidy access policy metadata, if any, on the budget detail page does _not_ include the `Hero` component for improved handling of the above "Page Not Found" behavior.

## Demos

### Creating new assignments

https://github.com/openedx/frontend-app-admin-portal/assets/2828721/2637379d-5d29-42de-a63a-714d42cb4e0e

### Displaying Page Not Found when attempting to load data about a subsidy access policy that doesn't exist (404)

Instead of showing an indefinite loading spinner, the UI will now display "page not found" messaging, since the requested subsidy access policy does not exist.

<img width="1910" alt="image" src="https://github.com/openedx/frontend-app-admin-portal/assets/2828721/cb62c937-d8f1-49df-885b-d6d980cc0f5d">
 

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
