### PR TITLE
feat: assignment error AlertModal variants

### DIFF
--- a/src/components/learner-credit-management/AssignmentRowActionTableCell.jsx
+++ b/src/components/learner-credit-management/AssignmentRowActionTableCell.jsx
@@ -9,7 +9,7 @@ const AssignmentRowActionTableCell = ({ row }) => {
   const isLearnerStateWaiting = row.original.learnerState === 'waiting';
   const emailAltText = row.original.learnerEmail ? `for ${row.original.learnerEmail}` : '';
   return (
-    <Stack direction="horizontal" gap="3" className="justify-content-end">
+    <Stack direction="horizontal" gap={2} className="justify-content-end">
       {isLearnerStateWaiting && (
         <OverlayTrigger
           key="Remind"

--- a/src/components/learner-credit-management/cards/BaseCourseCard.jsx
+++ b/src/components/learner-credit-management/cards/BaseCourseCard.jsx
@@ -10,7 +10,7 @@ import {
 } from '@edx/paragon';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 
-import useCourseCardMetadata from './data/useCourseCardMetadata';
+import { useCourseCardMetadata } from './data';
 import CARD_TEXT from '../constants';
 
 const BaseCourseCard = ({

--- a/src/components/learner-credit-management/cards/CreateAllocationErrorAlertModals.jsx
+++ b/src/components/learner-credit-management/cards/CreateAllocationErrorAlertModals.jsx
@@ -1,0 +1,84 @@
+import React, { useCallback, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { useToggle } from '@edx/paragon';
+import SystemErrorAlertModal from './status-modals/SystemErrorAlertModal';
+import ContentNotInCatalogErrorAlertModal from './status-modals/ContentNotInCatalogErrorAlertModal';
+import NotEnoughBalanceAlertModal from './status-modals/NotEnoughBalanceAlertModal';
+
+const CreateAllocationErrorAlertModals = ({
+  errorReason,
+  retry,
+  closeAssignmentModal,
+}) => {
+  const [isCatalogError, openCatalogErrorModal, closeCatalogErrorModal] = useToggle(false);
+  const [isSystemError, openSystemErrorModal, closeSystemErrorModal] = useToggle(false);
+  const [isBalanceError, openBalanceErrorModal, closeBalanceErrorModal] = useToggle(false);
+  
+  /**
+   * Close all error modals.
+   */
+  const closeAllErrorModals = useCallback(() => {
+    const closeFns = [closeCatalogErrorModal, closeBalanceErrorModal, closeSystemErrorModal];
+    closeFns.forEach((closeFn) => {
+      closeFn();
+    });
+  }, [closeCatalogErrorModal, closeBalanceErrorModal, closeSystemErrorModal]);
+
+  /**
+   * Retry the original action that caused the error.
+   */
+  const handleErrorRetry = () => {
+    retry();
+    closeAllErrorModals();
+  };
+
+  /**
+   * Whenever the `errorReason` prop changes, open the associated error modal to
+   * surface the error messaging to the user. If no `errorReason` exists, close
+   * any error modals that may be previously open.
+   */
+  useEffect(() => {
+    // Always ensure any open error modal is closed before opening a new one, OR when
+    // there is error reason.
+    closeAllErrorModals();
+
+    // Open specific error modal based on error reason.
+    if (errorReason === 'content_not_in_catalog') {
+      openCatalogErrorModal();
+    } else if (['not_enough_value_in_subsidy', 'policy_spend_limit_reached'].includes(errorReason)) {
+      openBalanceErrorModal();
+    } else if (errorReason) {
+      openSystemErrorModal();
+    }
+  }, [errorReason, closeAllErrorModals, openCatalogErrorModal, openBalanceErrorModal, openSystemErrorModal]);
+
+  return (
+    <>
+      <ContentNotInCatalogErrorAlertModal
+        isErrorModalOpen={isCatalogError}
+        closeErrorModal={closeCatalogErrorModal}
+        closeAssignmentModal={closeAssignmentModal}
+      />
+      <NotEnoughBalanceAlertModal
+        isErrorModalOpen={isBalanceError}
+        closeErrorModal={closeBalanceErrorModal}
+        closeAssignmentModal={closeAssignmentModal}
+        retry={handleErrorRetry}
+      />
+      <SystemErrorAlertModal
+        isErrorModalOpen={isSystemError}
+        closeErrorModal={closeSystemErrorModal}
+        closeAssignmentModal={closeAssignmentModal}
+        retry={handleErrorRetry}
+      />
+    </>
+  );
+};
+
+CreateAllocationErrorAlertModals.propTypes = {
+  closeAssignmentModal: PropTypes.func.isRequired,
+  retry: PropTypes.func.isRequired,
+  errorReason: PropTypes.string,
+};
+
+export default CreateAllocationErrorAlertModals;

--- a/src/components/learner-credit-management/cards/data/constants.js
+++ b/src/components/learner-credit-management/cards/data/constants.js
@@ -1,0 +1,9 @@
+/* eslint-disable import/prefer-default-export */
+
+import PropTypes from 'prop-types';
+
+export const commonErrorAlertModalPropTypes = {
+  isErrorModalOpen: PropTypes.bool.isRequired,
+  closeErrorModal: PropTypes.func.isRequired,
+  closeAssignmentModal: PropTypes.func.isRequired,
+};

--- a/src/components/learner-credit-management/cards/data/index.js
+++ b/src/components/learner-credit-management/cards/data/index.js
@@ -1,0 +1,3 @@
+export * from './constants';
+export * from './utils';
+export { default as useCourseCardMetadata } from './useCourseCardMetadata';

--- a/src/components/learner-credit-management/cards/data/utils.js
+++ b/src/components/learner-credit-management/cards/data/utils.js
@@ -1,0 +1,9 @@
+/* eslint-disable import/prefer-default-export */
+
+export const getBudgetDisplayName = (subsidyAccessPolicy) => {
+  let budgetDisplayName = 'budget';
+  if (subsidyAccessPolicy.displayName) {
+    budgetDisplayName = `${subsidyAccessPolicy.displayName} ${budgetDisplayName}`;
+  }
+  return budgetDisplayName;
+};

--- a/src/components/learner-credit-management/cards/status-modals/ContentNotInCatalogErrorAlertModal.jsx
+++ b/src/components/learner-credit-management/cards/status-modals/ContentNotInCatalogErrorAlertModal.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { AlertModal, ActionRow, Button } from '@edx/paragon';
+import { Error } from '@edx/paragon/icons';
+
+import { commonErrorAlertModalPropTypes, getBudgetDisplayName } from '../data';
+import { useBudgetId, useSubsidyAccessPolicy } from '../../data';
+
+const ContentNotInCatalogErrorAlertModal = ({
+  isErrorModalOpen,
+  closeErrorModal,
+  closeAssignmentModal,
+}) => {
+  const { subsidyAccessPolicyId } = useBudgetId();
+  const { data: subsidyAccessPolicy } = useSubsidyAccessPolicy(subsidyAccessPolicyId);
+
+  const budgetDisplayName = getBudgetDisplayName(subsidyAccessPolicy);
+
+  const handleClose = () => {
+    closeErrorModal();
+    closeAssignmentModal();
+  };
+
+  return (
+    <AlertModal
+      isBlocking
+      variant="danger"
+      icon={Error}
+      title={`This course is not in your ${budgetDisplayName}'s catalog`}
+      isOpen={isErrorModalOpen}
+      onClose={closeErrorModal}
+      footerNode={(
+        <ActionRow>
+          <Button onClick={handleClose}>Exit</Button>
+        </ActionRow>
+      )}
+    >
+      <p>
+        This course is not included in the catalog for your {budgetDisplayName}. Please try again with another course.
+      </p>
+    </AlertModal>
+  );
+};
+
+ContentNotInCatalogErrorAlertModal.propTypes = { ...commonErrorAlertModalPropTypes };
+
+export default ContentNotInCatalogErrorAlertModal;

--- a/src/components/learner-credit-management/cards/status-modals/NotEnoughBalanceAlertModal.jsx
+++ b/src/components/learner-credit-management/cards/status-modals/NotEnoughBalanceAlertModal.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { AlertModal, ActionRow, Button } from '@edx/paragon';
+import { Error } from '@edx/paragon/icons';
+
+import { commonErrorAlertModalPropTypes, getBudgetDisplayName } from '../data';
+import { formatPrice, useBudgetId, useSubsidyAccessPolicy } from '../../data';
+
+const NotEnoughBalanceAlertModal = ({
+  isErrorModalOpen,
+  closeErrorModal,
+  closeAssignmentModal,
+  retry,
+}) => {
+  const { subsidyAccessPolicyId } = useBudgetId();
+  const { data: subsidyAccessPolicy } = useSubsidyAccessPolicy(subsidyAccessPolicyId);
+
+  const budgetDisplayName = getBudgetDisplayName(subsidyAccessPolicy);
+
+  const handleClose = () => {
+    closeErrorModal();
+    closeAssignmentModal();
+  };
+
+  return (
+    <AlertModal
+      isBlocking
+      variant="danger"
+      icon={Error}
+      title="Not enough balance"
+      isOpen={isErrorModalOpen}
+      onClose={closeErrorModal}
+      footerNode={(
+        <ActionRow>
+          <Button variant="tertiary" onClick={handleClose}>Exit and discard changes</Button>
+          <Button onClick={retry} data-autofocus>Try again</Button>
+        </ActionRow>
+      )}
+    >
+      <p>
+        The total assignment cost exceeds your {`${budgetDisplayName}'s`} available balance
+        of {formatPrice(subsidyAccessPolicy.aggregates.spendAvailableUsd)}. Please
+        remove learners and try again.
+      </p>
+    </AlertModal>
+  );
+};
+
+NotEnoughBalanceAlertModal.propTypes = {
+  ...commonErrorAlertModalPropTypes,
+  retry: PropTypes.func.isRequired,
+};
+
+export default NotEnoughBalanceAlertModal;

--- a/src/components/learner-credit-management/cards/status-modals/SystemErrorAlertModal.jsx
+++ b/src/components/learner-credit-management/cards/status-modals/SystemErrorAlertModal.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ActionRow, AlertModal, Button } from '@edx/paragon';
+import { Error } from '@edx/paragon/icons';
+
+import { commonErrorAlertModalPropTypes } from '../data';
+
+const SystemErrorAlertModal = ({
+  isErrorModalOpen,
+  closeErrorModal,
+  closeAssignmentModal,
+  retry,
+}) => {
+  const handleClose = () => {
+    closeErrorModal();
+    closeAssignmentModal();
+  };
+
+  return (
+    <AlertModal
+      isBlocking
+      variant="danger"
+      icon={Error}
+      title="Something went wrong"
+      isOpen={isErrorModalOpen}
+      onClose={closeErrorModal}
+      footerNode={(
+        <ActionRow>
+          <Button variant="tertiary" onClick={handleClose}>Exit and discard changes</Button>
+          <Button onClick={retry} data-autofocus>Try again</Button>
+        </ActionRow>
+      )}
+    >
+      <p>
+        We&apos;re sorry. Something went wrong behind the scenes. Please
+        try again, or reach out to customer support for help.
+      </p>
+    </AlertModal>
+  );
+};
+
+SystemErrorAlertModal.propTypes = {
+  ...commonErrorAlertModalPropTypes,
+  retry: PropTypes.func.isRequired,
+};
+
+export default SystemErrorAlertModal;

--- a/src/components/learner-credit-management/tests/CatalogSearchResults.test.jsx
+++ b/src/components/learner-credit-management/tests/CatalogSearchResults.test.jsx
@@ -12,6 +12,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { BaseCatalogSearchResults } from '../search/CatalogSearchResults';
 import { CONTENT_TYPE_COURSE } from '../data/constants';
 import { queryClient } from '../../test/testUtils';
+import { useSubsidyAccessPolicy } from '../data';
 
 // Mocking this connected component so as not to have to mock the algolia Api
 const PAGINATE_ME = 'PAGINATE ME :)';
@@ -22,6 +23,19 @@ jest.mock('react-instantsearch-dom', () => ({
   ...jest.requireActual('react-instantsearch-dom'),
   InstantSearch: () => <div>Popular Courses</div>,
   Index: () => <div>Popular Courses</div>,
+}));
+
+jest.mock('../data', () => ({
+  ...jest.requireActual('../data'),
+  useSubsidyAccessPolicy: jest.fn().mockReturnValue({
+    data: {
+      uuid: 'test-uuid',
+      displayName: 'Test Budget',
+      aggregates: {
+        spendAvailableUsd: 100,
+      },
+    },
+  }),
 }));
 
 const DEFAULT_SEARCH_CONTEXT_VALUE = { refinements: {} };


### PR DESCRIPTION
# Description

Ticket: [ENT-7826](https://2u-internal.atlassian.net/browse/ENT-7826)

Adds error handling in the UX around the `allocate` POST API. Displays one of three `AlertModal` components with relevant messaging when the `allocate` POST API returns a non-200 HTTP status code.

## Screenshots

### Content not in catalog

<img width="1915" alt="image" src="https://github.com/openedx/frontend-app-admin-portal/assets/2828721/54e2af1d-5aa6-42c5-a615-2a4f1483edde">

### Not enough balance

<img width="1913" alt="image" src="https://github.com/openedx/frontend-app-admin-portal/assets/2828721/3e9c525e-3e84-484f-90d7-ea6434cbed0d">

### System error (generic fallback error, displayed for all other errors not explicitly handled above)

<img width="1910" alt="image" src="https://github.com/openedx/frontend-app-admin-portal/assets/2828721/c8955031-0cc0-4664-a150-119bb682eaa5">

## Screen recording of retry behavior from the `AlertModal`

https://github.com/openedx/frontend-app-admin-portal/assets/2828721/0ff3615a-7f15-4e50-914a-5acca1f54b53

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [x] Ensure to have UX team confirm screenshots
