### PR TITLE
fix: list transactions from the admin-tx view

### DIFF
--- a/src/data/services/EnterpriseSubsidyApiService.js
+++ b/src/data/services/EnterpriseSubsidyApiService.js
@@ -16,7 +16,7 @@ class SubsidyApiService {
     const queryParams = new URLSearchParams({
       ...snakeCaseObject(options),
     });
-    const url = `${SubsidyApiService.baseUrlV2}/subsidies/${subsidyUuid}/transactions/?${queryParams.toString()}`;
+    const url = `${SubsidyApiService.baseUrlV2}/subsidies/${subsidyUuid}/admin/transactions/?${queryParams.toString()}`;
     return SubsidyApiService.apiClient().get(url);
   }
 

--- a/src/data/services/tests/EnterpriseSubsidyApiService.test.js
+++ b/src/data/services/tests/EnterpriseSubsidyApiService.test.js
@@ -17,7 +17,7 @@ describe('EnterpriseSubsidyApiService', () => {
   });
   test('fetchCustomerTransactions calls the API to fetch transactions by enterprise subsidy', () => {
     const mockSubsidyUUID = 'test-subsidy-uuid';
-    const expectedUrl = `${SubsidyApiService.baseUrlV2}/subsidies/${mockSubsidyUUID}/transactions/?`;
+    const expectedUrl = `${SubsidyApiService.baseUrlV2}/subsidies/${mockSubsidyUUID}/admin/transactions/?`;
     SubsidyApiService.fetchCustomerTransactions(mockSubsidyUUID);
     expect(axios.get).toBeCalledWith(expectedUrl);
   });


### PR DESCRIPTION
ENT-7999

This PR https://github.com/openedx/frontend-app-admin-portal/pull/1087/files#diff-89082fcf3fbc9b339141578405314256fc4f1ae0210dab880414add817619ef7  pulls from the learner view, not the admin view.  So it tries to fetch only the transactions associated with the requesting user.  We want the admin-portal to pull from the admin view.

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
