### PR TITLE
fix: only request committed transactions for spent table

### DIFF
--- a/src/data/services/EnterpriseSubsidyApiService.js
+++ b/src/data/services/EnterpriseSubsidyApiService.js
@@ -14,6 +14,7 @@ class SubsidyApiService {
 
   static fetchCustomerTransactions(subsidyUuid, options = {}) {
     const queryParams = new URLSearchParams({
+      state: 'committed',
       ...snakeCaseObject(options),
     });
     const url = `${SubsidyApiService.baseUrlV2}/subsidies/${subsidyUuid}/admin/transactions/?${queryParams.toString()}`;

--- a/src/data/services/tests/EnterpriseSubsidyApiService.test.js
+++ b/src/data/services/tests/EnterpriseSubsidyApiService.test.js
@@ -15,12 +15,14 @@ describe('EnterpriseSubsidyApiService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
+
   test('fetchCustomerTransactions calls the API to fetch transactions by enterprise subsidy', () => {
     const mockSubsidyUUID = 'test-subsidy-uuid';
-    const expectedUrl = `${SubsidyApiService.baseUrlV2}/subsidies/${mockSubsidyUUID}/admin/transactions/?`;
+    const expectedUrl = `${SubsidyApiService.baseUrlV2}/subsidies/${mockSubsidyUUID}/admin/transactions/?state=committed`;
     SubsidyApiService.fetchCustomerTransactions(mockSubsidyUUID);
     expect(axios.get).toBeCalledWith(expectedUrl);
   });
+
   test('getSubsidyByCustomerUUID calls the API to fetch subsides by enterprise customer UUID', () => {
     const mockCustomerUUID = 'test-customer-uuid';
     const expectedUrl = `${SubsidyApiService.baseUrlV1}/subsidies/?enterprise_customer_uuid=${mockCustomerUUID}`;


### PR DESCRIPTION
# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
