### PR TITLE
feat: implement cancel button

### DIFF
--- a/src/components/learner-credit-management/AssignmentRowActionTableCell.jsx
+++ b/src/components/learner-credit-management/AssignmentRowActionTableCell.jsx
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types';
 import {
   Icon, IconButton, OverlayTrigger, Stack, Tooltip,
 } from '@edx/paragon';
-import { Mail, DoNotDisturbOn } from '@edx/paragon/icons';
+import { Mail } from '@edx/paragon/icons';
+import PendingAssignmentCancelButton from './PendingAssignmentCancelButton';
 
-const AssignmentRowActionTableCell = ({ row }) => {
+const AssignmentRowActionTableCell = ({ refresh, row, tableInstance }) => {
   const isLearnerStateWaiting = row.original.learnerState === 'waiting';
   const emailAltText = row.original.learnerEmail ? `for ${row.original.learnerEmail}` : '';
   return (
@@ -26,32 +27,22 @@ const AssignmentRowActionTableCell = ({ row }) => {
           />
         </OverlayTrigger>
       )}
-      <OverlayTrigger
-        key="Cancel"
-        placement="top"
-        overlay={<Tooltip id={`tooltip-cancel-${row.original.uuid}`}>Cancel assignment</Tooltip>}
-      >
-        <IconButton
-          variant="danger"
-          src={DoNotDisturbOn}
-          iconAs={Icon}
-          alt={`Cancel assignment ${emailAltText}`}
-          // eslint-disable-next-line no-console
-          onClick={() => console.log(`Canceling ${row.original.uuid}`)}
-          data-testid={`cancel-assignment-${row.original.uuid}`}
-        />
-      </OverlayTrigger>
+      <PendingAssignmentCancelButton refresh={refresh} row={row} tableInstance={tableInstance} />
     </Stack>
   );
 };
 
 AssignmentRowActionTableCell.propTypes = {
+  refresh: PropTypes.func.isRequired,
   row: PropTypes.shape({
     original: PropTypes.shape({
       learnerEmail: PropTypes.string,
       learnerState: PropTypes.string,
       uuid: PropTypes.string.isRequired,
     }).isRequired,
+  }).isRequired,
+  tableInstance: PropTypes.shape({
+    state: PropTypes.shape(),
   }).isRequired,
 };
 

--- a/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
+++ b/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
@@ -1,12 +1,12 @@
-import React from 'react';
-import PropTypes from 'prop-types';
 import {
   Chip,
 } from '@edx/paragon';
+import PropTypes from 'prop-types';
+import FailedBadEmail from './assignments-status-chips/FailedBadEmail';
+import FailedCancellation from './assignments-status-chips/FailedCancellation';
+import FailedSystem from './assignments-status-chips/FailedSystem';
 import NotifyingLearner from './assignments-status-chips/NotifyingLearner';
 import WaitingForLearner from './assignments-status-chips/WaitingForLearner';
-import FailedBadEmail from './assignments-status-chips/FailedBadEmail';
-import FailedSystem from './assignments-status-chips/FailedSystem';
 
 const AssignmentStatusTableCell = ({ row }) => {
   const { original } = row;
@@ -14,7 +14,18 @@ const AssignmentStatusTableCell = ({ row }) => {
     learnerEmail,
     learnerState,
     errorReason,
+    actions,
   } = original;
+
+  // Determine if the last action was an attempt to cancel email
+  if (actions[actions.length - 1]?.actionType === 'cancelled') {
+    if (actions[actions.length - 1].errorReason === 'email_error'
+      || actions[actions.length - 1].errorReason === 'internal_api_error') {
+      return (
+        <FailedCancellation />
+      );
+    }
+  }
 
   // Learner state is not available for this assignment, so don't display anything.
   if (!learnerState) {

--- a/src/components/learner-credit-management/AssignmentTableCancel.jsx
+++ b/src/components/learner-credit-management/AssignmentTableCancel.jsx
@@ -1,16 +1,42 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button } from '@edx/paragon';
+import { Button, Toast } from '@edx/paragon';
 import { DoNotDisturbOn } from '@edx/paragon/icons';
+import CancelAssignmentModal from './CancelAssignmentModal';
+import useCancelContentAssignments from './data/hooks/useCancelContentAssignments';
 
-const AssignmentTableCancelAction = ({ selectedFlatRows, ...rest }) => (
-  // eslint-disable-next-line no-console
-  <Button variant="danger" iconBefore={DoNotDisturbOn} onClick={() => console.log('Cancel', selectedFlatRows, rest)}>
-    {`Cancel (${selectedFlatRows.length})`}
-  </Button>
-);
+const AssignmentTableCancelAction = ({ refresh, selectedFlatRows, ...rest }) => {
+  const { tableInstance: { state } } = rest;
+  const uuids = selectedFlatRows.map(row => row.id);
+  const assignmentConfigurationUuid = selectedFlatRows[0].original.assignmentConfiguration;
+  const {
+    cancelContentAssignments,
+    close,
+    isOpen,
+    open,
+    setShowToast,
+    showToast,
+    toastMessage,
+  } = useCancelContentAssignments(assignmentConfigurationUuid, refresh, state, uuids);
+
+  return (
+    <>
+      <Button variant="danger" iconBefore={DoNotDisturbOn} onClick={open}>
+        {`Cancel (${uuids.length})`}
+      </Button>
+      <CancelAssignmentModal
+        cancelContentAssignments={cancelContentAssignments}
+        close={close}
+        isOpen={isOpen}
+        uuidCount={uuids.length}
+      />
+      {toastMessage && <Toast onClose={() => setShowToast(false)} show={showToast}>{toastMessage}</Toast>}
+    </>
+  );
+};
 
 AssignmentTableCancelAction.propTypes = {
+  refresh: PropTypes.func.isRequired,
   selectedFlatRows: PropTypes.arrayOf(PropTypes.shape()),
 };
 

--- a/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
+++ b/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
@@ -84,7 +84,15 @@ const BudgetAssignmentsTable = ({
       additionalColumns={[
         {
           Header: '',
-          Cell: AssignmentRowActionTableCell,
+          /* eslint-disable react/no-unstable-nested-components */
+          /* eslint-disable react/prop-types */
+          Cell: ({ row, state }) => (
+            <AssignmentRowActionTableCell
+              refresh={fetchTableData}
+              row={row}
+              tableInstance={state}
+            />
+          ),
           id: 'action',
         },
       ]}
@@ -104,13 +112,13 @@ const BudgetAssignmentsTable = ({
         filters: [],
       }}
       fetchData={fetchTableData}
-      data={tableData.results || []}
+      data={tableData?.results.filter(assignment => assignment.state !== 'cancelled') || []}
       itemCount={tableData.count || 0}
       pageCount={tableData.numPages || 1}
       EmptyTableComponent={CustomDataTableEmptyState}
       bulkActions={[
         <AssignmentTableRemindAction />,
-        <AssignmentTableCancelAction />,
+        <AssignmentTableCancelAction refresh={fetchTableData} />,
       ]}
     />
   );

--- a/src/components/learner-credit-management/CancelAssignmentModal.jsx
+++ b/src/components/learner-credit-management/CancelAssignmentModal.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  ActionRow, Button, ModalDialog,
+} from '@edx/paragon';
+import { DoNotDisturbOn } from '@edx/paragon/icons';
+
+const CancelAssignmentModal = ({
+  cancelContentAssignments,
+  close,
+  isOpen,
+  uuidCount,
+}) => (
+  <ModalDialog
+    hasCloseButton
+    isOpen={isOpen}
+    onClose={close}
+    title="Cancel dialog"
+  >
+    <ModalDialog.Header>
+      <ModalDialog.Title>
+        Cancel assignment?
+      </ModalDialog.Title>
+    </ModalDialog.Header>
+
+    <ModalDialog.Body>
+      <p>This action cannot be undone.</p>
+      <p>The learner will be notified that you have canceled the assignment. The funds associated with
+        this course assignment will move from &quot;assigned&quot; back to &quot;available&quot;.
+      </p>
+    </ModalDialog.Body>
+
+    <ModalDialog.Footer>
+      <ActionRow>
+        <ModalDialog.CloseButton variant="tertiary">Go back</ModalDialog.CloseButton>
+        <Button
+          iconBefore={DoNotDisturbOn}
+          onClick={cancelContentAssignments}
+          variant="danger"
+        >
+          {uuidCount ? `Cancel assignments (${uuidCount})` : 'Cancel assignment'}
+        </Button>
+      </ActionRow>
+    </ModalDialog.Footer>
+  </ModalDialog>
+);
+
+CancelAssignmentModal.propTypes = {
+  cancelContentAssignments: PropTypes.func.isRequired,
+  close: PropTypes.func.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  uuidCount: PropTypes.number,
+};
+
+export default CancelAssignmentModal;

--- a/src/components/learner-credit-management/PendingAssignmentCancelButton.jsx
+++ b/src/components/learner-credit-management/PendingAssignmentCancelButton.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Icon, IconButtonWithTooltip, Toast,
+} from '@edx/paragon';
+import { DoNotDisturbOn } from '@edx/paragon/icons';
+import useCancelContentAssignments from './data/hooks/useCancelContentAssignments';
+import CancelAssignmentModal from './CancelAssignmentModal';
+
+const PendingAssignmentCancelButton = ({ refresh, row, tableInstance }) => {
+  const emailAltText = row.original.learnerEmail ? `for ${row.original.learnerEmail}` : '';
+  const {
+    cancelContentAssignments,
+    close,
+    isOpen,
+    open,
+    setShowToast,
+    showToast,
+    toastMessage,
+  } = useCancelContentAssignments(row.original.assignmentConfiguration, refresh, tableInstance, row.original.uuid);
+  return (
+    <>
+      <IconButtonWithTooltip
+        alt={`Cancel assignment ${emailAltText}`}
+        data-testid={`cancel-assignment-${row.original.uuid}`}
+        iconAs={Icon}
+        onClick={open}
+        src={DoNotDisturbOn}
+        tooltipContent="Cancel assignment"
+        tooltipPlacement="top"
+        variant="danger"
+      />
+      <CancelAssignmentModal close={close} cancelContentAssignments={cancelContentAssignments} isOpen={isOpen} />
+      {toastMessage && <Toast onClose={() => setShowToast(false)} show={showToast}>{toastMessage}</Toast>}
+    </>
+  );
+};
+
+PendingAssignmentCancelButton.propTypes = {
+  refresh: PropTypes.func.isRequired,
+  row: PropTypes.shape({
+    original: PropTypes.shape({
+      assignmentConfiguration: PropTypes.string.isRequired,
+      learnerEmail: PropTypes.string,
+      uuid: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
+  tableInstance: PropTypes.shape({
+    state: PropTypes.shape(),
+  }).isRequired,
+};
+
+export default PendingAssignmentCancelButton;

--- a/src/components/learner-credit-management/assignments-status-chips/FailedCancellation.jsx
+++ b/src/components/learner-credit-management/assignments-status-chips/FailedCancellation.jsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { Chip, useToggle, Hyperlink } from '@edx/paragon';
+import { Error } from '@edx/paragon/icons';
+import BaseModalPopup from './BaseModalPopup';
+
+const FailedCancellation = () => {
+  const [isOpen, open, close] = useToggle(false);
+  const [target, setTarget] = useState(null);
+
+  return (
+    <>
+      <Chip
+        disabled={false}
+        iconBefore={Error}
+        onClick={open}
+        onKeyPress={open}
+        ref={setTarget}
+        tabIndex={0}
+        variant="dark"
+      >
+        Failed: Cancellation
+      </Chip>
+      <BaseModalPopup
+        positionRef={target}
+        isOpen={isOpen}
+        onClose={close}
+      >
+        <BaseModalPopup.Heading icon={Error} iconClassName="text-danger-500">
+          Failed: Cancellation
+        </BaseModalPopup.Heading>
+        <BaseModalPopup.Content>
+          <p>This assignment was not canceled. Something went wrong behind the scenes.</p>
+          <div className="micro">
+            <p className="h6">Suggested resolution steps</p>
+            <ul className="text-gray pl-3">
+              <li>
+                Wait and try to cancel this assignment again later
+              </li>
+              <li>
+                If the issue continues, contact customer support.
+              </li>
+              <li>
+                Get more troubleshooting help at{' '}
+                <Hyperlink destination="https://edx.org" showLaunchIcon={false} target="_blank">
+                  Help Center: Course Assignments
+                </Hyperlink>.
+              </li>
+            </ul>
+          </div>
+        </BaseModalPopup.Content>
+      </BaseModalPopup>
+    </>
+  );
+};
+
+export default FailedCancellation;

--- a/src/components/learner-credit-management/data/hooks/useCancelContentAssignments.js
+++ b/src/components/learner-credit-management/data/hooks/useCancelContentAssignments.js
@@ -1,0 +1,55 @@
+import { useCallback, useState } from 'react';
+import { logError } from '@edx/frontend-platform/logging';
+import { useToggle } from '@edx/paragon';
+import EnterpriseAccessApiService from '../../../../data/services/EnterpriseAccessApiService';
+
+const generateSuccessCancelMessage = (assignmentUuids) => {
+  if (Array.isArray(assignmentUuids)) {
+    return `Assignments canceled (${assignmentUuids.length})`;
+  }
+
+  return 'Assignment canceled';
+};
+
+const useCancelContentAssignments = (
+  assignmentConfigurationUuid,
+  refresh,
+  tableInstance,
+  uuids,
+) => {
+  const [isOpen, open, close] = useToggle(false);
+  const [showToast, setShowToast] = useState(false);
+  const [toastMessage, setToastMessage] = useState('');
+
+  const cancelContentAssignments = useCallback(async () => {
+    const handleRefresh = () => {
+      refresh(tableInstance);
+    };
+    try {
+      const { status } = await EnterpriseAccessApiService.cancelContentAssignments(assignmentConfigurationUuid, uuids);
+      if (status === 200) {
+        setToastMessage(generateSuccessCancelMessage(uuids));
+        setShowToast(true);
+        close(true);
+        setTimeout(() => {
+          handleRefresh();
+        }, 2000);
+      }
+    } catch (err) {
+      logError(err);
+      close(true);
+    }
+  }, [assignmentConfigurationUuid, close, refresh, tableInstance, uuids]);
+
+  return {
+    cancelContentAssignments,
+    close,
+    isOpen,
+    open,
+    setShowToast,
+    showToast,
+    toastMessage,
+  };
+};
+
+export default useCancelContentAssignments;

--- a/src/components/learner-credit-management/data/hooks/useCancelContentAssignments.test.jsx
+++ b/src/components/learner-credit-management/data/hooks/useCancelContentAssignments.test.jsx
@@ -1,0 +1,130 @@
+import { renderHook } from '@testing-library/react-hooks/dom';
+import { act, waitFor } from '@testing-library/react';
+
+import { logError } from '@edx/frontend-platform/logging';
+
+import EnterpriseAccessApiService from '../../../../data/services/EnterpriseAccessApiService';
+import useCancelContentAssignments from './useCancelContentAssignments';
+
+const TEST_ASSIGNMENT_CONFIGURATION_UUID = 'test-assignment-configuration-uuid';
+const TEST_PENDING_ASSIGNMENT_UUID_1 = 'test-pending-assignment-uuid_1';
+const TEST_PENDING_ASSIGNMENT_UUID_2 = 'test-pending-assignment-uuid_2';
+const mockRefreshFn = jest.fn();
+const mockTableInstance = {};
+
+jest.mock('../../../../data/services/EnterpriseAccessApiService');
+jest.mock('@edx/frontend-platform/logging', () => ({
+  logError: jest.fn(),
+}));
+
+describe('useCancelContentAssignments', () => {
+  it('should send a post request to cancel a single pending assignment', async () => {
+    EnterpriseAccessApiService.cancelContentAssignments.mockResolvedValueOnce({ status: 200 });
+    const { result } = renderHook(() => useCancelContentAssignments(
+      TEST_ASSIGNMENT_CONFIGURATION_UUID,
+      mockRefreshFn,
+      mockTableInstance,
+      TEST_PENDING_ASSIGNMENT_UUID_1,
+    ));
+
+    expect(result.current).toEqual({
+      cancelContentAssignments: expect.any(Function),
+      close: expect.any(Function),
+      isOpen: false,
+      open: expect.any(Function),
+      setShowToast: expect.any(Function),
+      showToast: false,
+      toastMessage: '',
+    });
+
+    await waitFor(() => act(() => result.current.cancelContentAssignments()));
+    expect(
+      EnterpriseAccessApiService.cancelContentAssignments,
+    ).toHaveBeenCalled();
+    expect(logError).toBeCalledTimes(0);
+
+    expect(result.current).toEqual({
+      cancelContentAssignments: expect.any(Function),
+      close: expect.any(Function),
+      isOpen: false,
+      open: expect.any(Function),
+      setShowToast: expect.any(Function),
+      showToast: true,
+      toastMessage: 'Assignment canceled',
+    });
+  });
+
+  it('should send a post request to cancel multiple pending assignments', async () => {
+    EnterpriseAccessApiService.cancelContentAssignments.mockResolvedValueOnce({ status: 200 });
+    const { result } = renderHook(() => useCancelContentAssignments(
+      TEST_ASSIGNMENT_CONFIGURATION_UUID,
+      mockRefreshFn,
+      mockTableInstance,
+      [TEST_PENDING_ASSIGNMENT_UUID_1, TEST_PENDING_ASSIGNMENT_UUID_2],
+    ));
+
+    expect(result.current).toEqual({
+      cancelContentAssignments: expect.any(Function),
+      close: expect.any(Function),
+      isOpen: false,
+      open: expect.any(Function),
+      setShowToast: expect.any(Function),
+      showToast: false,
+      toastMessage: '',
+    });
+
+    await waitFor(() => act(() => result.current.cancelContentAssignments()));
+    expect(
+      EnterpriseAccessApiService.cancelContentAssignments,
+    ).toHaveBeenCalled();
+    expect(logError).toBeCalledTimes(0);
+
+    expect(result.current).toEqual({
+      cancelContentAssignments: expect.any(Function),
+      close: expect.any(Function),
+      isOpen: false,
+      open: expect.any(Function),
+      setShowToast: expect.any(Function),
+      showToast: true,
+      toastMessage: 'Assignments canceled (2)',
+    });
+  });
+
+  it('should handle error when fetching AI analytics summary data', async () => {
+    const error = new Error('An error occurred');
+    EnterpriseAccessApiService.cancelContentAssignments.mockRejectedValueOnce(error);
+    const { result } = renderHook(() => useCancelContentAssignments(
+      TEST_ASSIGNMENT_CONFIGURATION_UUID,
+      mockRefreshFn,
+      mockTableInstance,
+      [TEST_PENDING_ASSIGNMENT_UUID_1, TEST_PENDING_ASSIGNMENT_UUID_2],
+    ));
+
+    expect(result.current).toEqual({
+      cancelContentAssignments: expect.any(Function),
+      close: expect.any(Function),
+      isOpen: false,
+      open: expect.any(Function),
+      setShowToast: expect.any(Function),
+      showToast: false,
+      toastMessage: '',
+    });
+
+    await waitFor(() => act(() => result.current.cancelContentAssignments()));
+
+    expect(
+      EnterpriseAccessApiService.cancelContentAssignments,
+    ).toHaveBeenCalled();
+    expect(logError).toBeCalledTimes(1);
+
+    expect(result.current).toEqual({
+      cancelContentAssignments: expect.any(Function),
+      close: expect.any(Function),
+      isOpen: false,
+      open: expect.any(Function),
+      setShowToast: expect.any(Function),
+      showToast: false,
+      toastMessage: '',
+    });
+  });
+});

--- a/src/data/services/EnterpriseAccessApiService.js
+++ b/src/data/services/EnterpriseAccessApiService.js
@@ -160,6 +160,17 @@ class EnterpriseAccessApiService {
   }
 
   /**
+   * Cancel content assignments for a specific AssignmentConfiguration.
+   */
+  static cancelContentAssignments(assignmentConfigurationUUID, uuids) {
+    const options = {
+      assignment_uuids: Array.isArray(uuids) ? uuids : [uuids],
+    };
+    const url = `${EnterpriseAccessApiService.baseUrl}/assignment-configurations/${assignmentConfigurationUUID}/admin/assignments/cancel/`;
+    return EnterpriseAccessApiService.apiClient().post(url, options);
+  }
+
+  /**
    * Retrieve a specific subsidy access policy.
    */
   static retrieveSubsidyAccessPolicy(subsidyAccessPolicyUUID) {


### PR DESCRIPTION
## Description
Implement a button to cancel multiple pending assignments (bulk action) and a single pending assignment. When the cancellation is successful, the learner will receive an email notifying them that the course invitation has been rescinded, the admin user will see a toast, and the row removed from the datatable. On failure, the status row displays a "Failed: Cancelation" chip.

## UI changes for a single pending assignment
https://github.com/openedx/frontend-app-admin-portal/assets/71999631/e03d7991-59ae-421a-822b-c6d0cd92ab78

<img width="1425" alt="Screenshot 2023-11-20 at 10 36 15 PM" src="https://github.com/openedx/frontend-app-admin-portal/assets/71999631/8328294b-70a7-4024-8a07-7ce520e31a48">

## UI changes for multiple pending assignments
https://github.com/openedx/frontend-app-admin-portal/assets/71999631/7eb8ebbb-8b69-495c-9c81-05b81cad23d6

[JIRA Ticket](https://2u-internal.atlassian.net/browse/ENT-7816)
# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
