### PR TITLE
fix: use controlled selection components from DataTable for BudgetAssigmentsTable

### DIFF
--- a/src/components/learner-credit-management/AssignmentRowActionTableCell.jsx
+++ b/src/components/learner-credit-management/AssignmentRowActionTableCell.jsx
@@ -1,13 +1,11 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  Icon, IconButton, OverlayTrigger, Stack, Tooltip, DataTableContext,
+  Icon, IconButton, OverlayTrigger, Stack, Tooltip,
 } from '@edx/paragon';
 import { Mail, DoNotDisturbOn } from '@edx/paragon/icons';
 
 const AssignmentRowActionTableCell = ({ row }) => {
-  const dataTableContext = useContext(DataTableContext);
-  console.log('dataTableContext', dataTableContext);
   const isLearnerStateWaiting = row.original.learnerState === 'waiting';
   const emailAltText = row.original.learnerEmail ? `for ${row.original.learnerEmail}` : '';
   return (

--- a/src/components/learner-credit-management/AssignmentRowActionTableCell.jsx
+++ b/src/components/learner-credit-management/AssignmentRowActionTableCell.jsx
@@ -1,11 +1,13 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Icon, IconButton, OverlayTrigger, Stack, Tooltip,
+  Icon, IconButton, OverlayTrigger, Stack, Tooltip, DataTableContext,
 } from '@edx/paragon';
 import { Mail, DoNotDisturbOn } from '@edx/paragon/icons';
 
 const AssignmentRowActionTableCell = ({ row }) => {
+  const dataTableContext = useContext(DataTableContext);
+  console.log('dataTableContext', dataTableContext);
   const isLearnerStateWaiting = row.original.learnerState === 'waiting';
   const emailAltText = row.original.learnerEmail ? `for ${row.original.learnerEmail}` : '';
   return (

--- a/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
+++ b/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
@@ -28,6 +28,13 @@ const getLearnerStateDisplayName = (learnerState) => {
   return undefined;
 };
 
+const selectColumn = {
+  id: 'selection',
+  Header: DataTable.ControlledSelectHeader,
+  Cell: DataTable.ControlledSelect,
+  disableSortBy: true,
+};
+
 const BudgetAssignmentsTable = ({
   isLoading,
   tableData,
@@ -52,7 +59,9 @@ const BudgetAssignmentsTable = ({
       manualFilters
       isLoading={isLoading}
       defaultColumnValues={{ Filter: TableTextFilter }}
+      manualSelectColumn={selectColumn}
       FilterStatusComponent={FilterStatus}
+      SelectionStatusComponent={DataTable.ControlledSelectionStatus}
       columns={[
         {
           Header: 'Assignment details',

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -1074,8 +1074,8 @@ describe('<BudgetDetailPage />', () => {
       const remindRowAction = screen.getByTestId('remind-assignment-test-uuid');
       expect(remindRowAction).toBeInTheDocument();
     }
-
-    const checkBox = screen.getByTestId('datatable-select-column-checkbox-cell');
+    // 2 checkboxes exist; the first is the "Select all" checkbox; the 2nd is the checkbox for the first row
+    const checkBox = screen.getAllByRole('checkbox')[1];
     expect(checkBox).toBeInTheDocument();
     userEvent.click(checkBox);
     expect(await screen.findByText('Cancel (1)')).toBeInTheDocument();


### PR DESCRIPTION
# Description

https://2u-internal.atlassian.net/browse/ENT-8048

Ensures "Select all..." functions as expected, with exception of the Paragon bug related to the row count shown in the "Select all..." label (see [this Paragon bug](https://github.com/openedx/paragon/issues/2872) describing the issue with the "Select all..." label's count). Also, does not update the counts shown in the bulk actions or call a "full table selected" specific API endpoint.

https://github.com/openedx/frontend-app-admin-portal/assets/2828721/80cc5599-34db-4545-b982-674089da67ae

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
