### PR TITLE
fix: cleaning up sso network error page

### DIFF
--- a/src/components/settings/SettingsSSOTab/SsoErrorPage.jsx
+++ b/src/components/settings/SettingsSSOTab/SsoErrorPage.jsx
@@ -19,17 +19,18 @@ const SsoErrorPage = ({
   return (
     <FullscreenModal
       isOpen={isOpen}
-      variant="error"
+      variant="default"
       hasCloseButton={false}
       onClose={() => { /* FullscreenModal requires an onClose prop despite hasCloseButton is false */ }}
       title={(
         <Image
           src={configuration.LOGO_URL}
           alt="edX logo title"
+          className="d-flex sso-error-lms-icon"
         />
       )}
     >
-      <Container size="md">
+      <Container size="md" className="pl-6 pr-6">
         <Image
           data-testid="sso-network-error-image"
           src={cardImage}

--- a/src/components/settings/settings.scss
+++ b/src/components/settings/settings.scss
@@ -9,6 +9,11 @@
   max-height: 35px;
 }
 
+.sso-error-lms-icon {
+  max-width: 71px;
+  max-height: 71px;
+}
+
 .lms-card-hover {
   &:hover {
     box-shadow: $box-shadow;


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-8052

I used the figma mocks dimensions when defining the css class

old: 
<img width="837" alt="image" src="https://github.com/openedx/frontend-app-admin-portal/assets/67655836/f4f932d4-81c5-44d9-8521-9e2716ce99e5">


new: 
<img width="832" alt="image" src="https://github.com/openedx/frontend-app-admin-portal/assets/67655836/f828e9bf-de02-47f2-824c-5e5125d6bbf3">


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
