### PR TITLE
feat: background refetching loading state on budgets cards

### DIFF
--- a/src/components/EnterpriseSubsidiesContext/index.jsx
+++ b/src/components/EnterpriseSubsidiesContext/index.jsx
@@ -11,6 +11,7 @@ export const useEnterpriseSubsidiesContext = ({
 }) => {
   const {
     isLoading: isLoadingBudgets,
+    isFetching: isFetchingBudgets,
     data: budgetsOverview,
   } = useEnterpriseBudgets({
     enablePortalLearnerCreditManagementScreen,
@@ -58,7 +59,16 @@ export const useEnterpriseSubsidiesContext = ({
     canManageLearnerCredit,
     enterpriseSubsidyTypes,
     isLoading,
-  }), [budgets, customerAgreement, coupons, canManageLearnerCredit, enterpriseSubsidyTypes, isLoading]);
+    isFetchingBudgets,
+  }), [
+    budgets,
+    customerAgreement,
+    coupons,
+    canManageLearnerCredit,
+    enterpriseSubsidyTypes,
+    isLoading,
+    isFetchingBudgets,
+  ]);
 
   return context;
 };

--- a/src/components/learner-credit-management/SubBudgetCard.jsx
+++ b/src/components/learner-credit-management/SubBudgetCard.jsx
@@ -1,3 +1,4 @@
+import { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
@@ -8,10 +9,17 @@ import {
   Col,
   Badge,
   Stack,
+  Skeleton,
 } from '@edx/paragon';
 
 import { BUDGET_STATUSES, ROUTE_NAMES } from '../EnterpriseApp/data/constants';
 import { formatPrice, getBudgetStatus } from './data/utils';
+import { EnterpriseSubsidiesContext } from '../EnterpriseSubsidiesContext';
+
+const BackgroundFetchingWrapper = ({ children }) => {
+  const { isFetchingBudgets } = useContext(EnterpriseSubsidiesContext);
+  return <span style={{ opacity: isFetchingBudgets ? 0.5 : 1 }}>{children}</span>;
+};
 
 const SubBudgetCard = ({
   id,
@@ -24,6 +32,7 @@ const SubBudgetCard = ({
   enterpriseSlug,
   isLoading,
 }) => {
+  const { isFetchingBudgets } = useContext(EnterpriseSubsidiesContext);
   const budgetLabel = getBudgetStatus(start, end);
   const formattedDate = dayjs(budgetLabel?.date).format('MMMM D, YYYY');
 
@@ -49,8 +58,8 @@ const SubBudgetCard = ({
 
     return (
       <Card.Header
-        title={budgetType}
-        subtitle={subtitle}
+        title={<BackgroundFetchingWrapper>{budgetType}</BackgroundFetchingWrapper>}
+        subtitle={<BackgroundFetchingWrapper>{subtitle}</BackgroundFetchingWrapper>}
         actions={
           budgetLabel.status !== BUDGET_STATUSES.scheduled
             ? renderActions(budgetId)
@@ -68,17 +77,23 @@ const SubBudgetCard = ({
       <Row className="d-flex flex-row justify-content-start w-md-75">
         <Col xs="6" md="auto" className="mb-3 mb-md-0">
           <div className="small font-weight-bold">Available</div>
-          <span className="small">{formatPrice(available)}</span>
+          <span className="small">
+            {isFetchingBudgets ? <Skeleton /> : formatPrice(available)}
+          </span>
         </Col>
         {pending > 0 && (
           <Col xs="6" md="auto" className="mb-3 mb-md-0">
             <div className="small font-weight-bold">Pending</div>
-            <span className="small">{formatPrice(pending)}</span>
+            <span className="small">
+              {isFetchingBudgets ? <Skeleton /> : formatPrice(pending)}
+            </span>
           </Col>
         )}
         <Col xs="6" md="auto" className="mb-3 mb-md-0">
           <div className="small font-weight-bold">Spent</div>
-          <span className="small">{formatPrice(spent)}</span>
+          <span className="small">
+            {isFetchingBudgets ? <Skeleton /> : formatPrice(spent)}
+          </span>
         </Col>
       </Row>
     </Card.Section>
@@ -97,6 +112,10 @@ const SubBudgetCard = ({
       </Card.Body>
     </Card>
   );
+};
+
+BackgroundFetchingWrapper.propTypes = {
+  children: PropTypes.node.isRequired,
 };
 
 SubBudgetCard.propTypes = {

--- a/src/components/learner-credit-management/cards/NewAssignmentModalButton.jsx
+++ b/src/components/learner-credit-management/cards/NewAssignmentModalButton.jsx
@@ -89,14 +89,13 @@ const NewAssignmentModalButton = ({ enterpriseId, course, children }) => {
   }, []);
 
   const onSuccessEnterpriseTrackEvents = ({
-    created, noChange, updated,
+    totalLearnersAllocated,
+    totalLearnersAlreadyAllocated,
   }) => {
     const trackEventMetadata = {
       ...sharedEnterpriseTrackEventMetadata,
-      totalAllocatedLearners: learnerEmails.length,
-      created: created.length,
-      noChange: noChange.length,
-      updated: updated.length,
+      totalLearnersAllocated,
+      totalLearnersAlreadyAllocated,
     };
     sendEnterpriseTrackEvent(
       enterpriseId,
@@ -129,9 +128,12 @@ const NewAssignmentModalButton = ({ enterpriseId, course, children }) => {
           queryKey: learnerCreditManagementQueryKeys.budgets(enterpriseId),
         });
         handleCloseAssignmentModal();
-        onSuccessEnterpriseTrackEvents({ created, noChange, updated });
         const totalLearnersAllocated = created.length + updated.length;
         const totalLearnersAlreadyAllocated = noChange.length;
+        onSuccessEnterpriseTrackEvents({
+          totalLearnersAllocated,
+          totalLearnersAlreadyAllocated,
+        });
         displayToastForAssignmentAllocation({
           totalLearnersAllocated,
           totalLearnersAlreadyAllocated,

--- a/src/components/learner-credit-management/cards/NewAssignmentModalButton.jsx
+++ b/src/components/learner-credit-management/cards/NewAssignmentModalButton.jsx
@@ -129,10 +129,13 @@ const NewAssignmentModalButton = ({ enterpriseId, course, children }) => {
           queryKey: learnerCreditManagementQueryKeys.budgets(enterpriseId),
         });
         handleCloseAssignmentModal();
-        onSuccessEnterpriseTrackEvents({
-          created, noChange, updated,
+        onSuccessEnterpriseTrackEvents({ created, noChange, updated });
+        const totalLearnersAllocated = created.length + updated.length;
+        const totalLearnersAlreadyAllocated = noChange.length;
+        displayToastForAssignmentAllocation({
+          totalLearnersAllocated,
+          totalLearnersAlreadyAllocated,
         });
-        displayToastForAssignmentAllocation({ totalLearnersAssigned: learnerEmails.length });
 
         // Navigate to the activity tab
         history.push(pathToActivityTab);

--- a/src/components/learner-credit-management/cards/tests/CourseCard.test.jsx
+++ b/src/components/learner-credit-management/cards/tests/CourseCard.test.jsx
@@ -507,8 +507,8 @@ describe('Course card works as expected', () => {
           // Verify toast notification was displayed
           expect(mockDisplaySuccessfulAssignmentToast).toHaveBeenCalledTimes(1);
           expect(mockDisplaySuccessfulAssignmentToast).toHaveBeenCalledWith({
-            totalLearnersAssigned: mockCreatedLearnerAssignments.length + mockUpdatedLearnerAssignments.length,
-            totalLearnersAlreadyAssigned: mockNoChangeLearnerAssignments.length,
+            totalLearnersAllocated: mockCreatedLearnerAssignments.length + mockUpdatedLearnerAssignments.length,
+            totalLearnersAlreadyAllocated: mockNoChangeLearnerAssignments.length,
           });
         });
       }

--- a/src/components/learner-credit-management/cards/tests/CourseCard.test.jsx
+++ b/src/components/learner-credit-management/cards/tests/CourseCard.test.jsx
@@ -103,7 +103,7 @@ const mockSubsidyAccessPolicy = {
     spendAvailableUsd: 50000,
   },
 };
-const mockLearnerEmails = ['hello@example.com', 'world@example.com'];
+const mockLearnerEmails = ['hello@example.com', 'world@example.com', 'dinesh@example.com'];
 
 const mockDisplaySuccessfulAssignmentToast = jest.fn();
 const defaultBudgetDetailPageContextValue = {
@@ -315,6 +315,22 @@ describe('Course card works as expected', () => {
     allocationExceptionReason,
     shouldRetryAllocationAfterException,
   }) => {
+    const mockUpdatedLearnerAssignments = [mockLearnerEmails[0]];
+    const mockNoChangeLearnerAssignments = [mockLearnerEmails[1]];
+    const mockCreatedLearnerAssignments = mockLearnerEmails.slice(2).map(learnerEmail => ({
+      uuid: '095be615-a8ad-4c33-8e9c-c7612fbf6c9f',
+      assignment_configuration: 'fd456a98-653b-41e9-94d1-94d7b136832a',
+      learner_email: learnerEmail,
+      lms_user_id: 0,
+      content_key: 'string',
+      content_title: 'string',
+      content_quantity: 0,
+      state: 'allocated',
+      transaction_uuid: '3a6bcbed-b7dc-4791-84fe-b20f12be4001',
+      last_notification_at: '2019-08-24T14:15:22Z',
+      actions: [],
+    }));
+
     if (hasAllocationException) {
       // mock Axios error
       mockAllocateContentAssignments.mockRejectedValue({
@@ -326,21 +342,9 @@ describe('Course card works as expected', () => {
     } else {
       mockAllocateContentAssignments.mockResolvedValue({
         data: {
-          updated: [],
-          created: mockLearnerEmails.map(learnerEmail => ({
-            uuid: '095be615-a8ad-4c33-8e9c-c7612fbf6c9f',
-            assignment_configuration: 'fd456a98-653b-41e9-94d1-94d7b136832a',
-            learner_email: learnerEmail,
-            lms_user_id: 0,
-            content_key: 'string',
-            content_title: 'string',
-            content_quantity: 0,
-            state: 'allocated',
-            transaction_uuid: '3a6bcbed-b7dc-4791-84fe-b20f12be4001',
-            last_notification_at: '2019-08-24T14:15:22Z',
-            actions: [],
-          })),
-          no_change: [],
+          updated: mockUpdatedLearnerAssignments,
+          created: mockCreatedLearnerAssignments,
+          no_change: mockNoChangeLearnerAssignments,
         },
       });
     }
@@ -408,6 +412,7 @@ describe('Course card works as expected', () => {
     const nextSteps = assignmentModal.getByText('Next steps for assigned learners');
     userEvent.click(nextSteps);
     expect(sendEnterpriseTrackEvent).toHaveBeenCalledTimes(4);
+
     // Verify modal footer
     expect(assignmentModal.getByText('Help Center: Course Assignments')).toBeInTheDocument();
     const cancelAssignmentCTA = getButtonElement('Cancel', { screenOverride: assignmentModal });
@@ -502,7 +507,8 @@ describe('Course card works as expected', () => {
           // Verify toast notification was displayed
           expect(mockDisplaySuccessfulAssignmentToast).toHaveBeenCalledTimes(1);
           expect(mockDisplaySuccessfulAssignmentToast).toHaveBeenCalledWith({
-            totalLearnersAssigned: mockLearnerEmails.length,
+            totalLearnersAssigned: mockCreatedLearnerAssignments.length + mockUpdatedLearnerAssignments.length,
+            totalLearnersAlreadyAssigned: mockNoChangeLearnerAssignments.length,
           });
         });
       }
@@ -513,7 +519,7 @@ describe('Course card works as expected', () => {
     }
   });
 
-  it.each([
+  test.each([
     {
       learnerEmails: ['a@a.com', 'b@bcom', 'c@c.com'],
       spendAvailableUsd: 1000,

--- a/src/components/learner-credit-management/data/hooks/useSuccessfulAssignmentToastContextValue.js
+++ b/src/components/learner-credit-management/data/hooks/useSuccessfulAssignmentToastContextValue.js
@@ -2,30 +2,43 @@ import { useCallback, useMemo, useState } from 'react';
 
 const useSuccessfulAssignmentToastContextValue = () => {
   const [isToastOpen, setIsToastOpen] = useState(false);
-  const [learnersAssignedCount, setLearnersAssignedCount] = useState();
+  const [learnersAllocatedCount, setLearnersAllocatedCount] = useState(0);
+  const [learnersAlreadyAllocatedCount, setLearnersAlreadyAllocatedCount] = useState(0);
 
-  const handleDisplayToast = useCallback(({ totalLearnersAssigned }) => {
+  const handleDisplayToast = useCallback(({ totalLearnersAllocated, totalLearnersAlreadyAllocated }) => {
+    setLearnersAllocatedCount(totalLearnersAllocated);
+    setLearnersAlreadyAllocatedCount(totalLearnersAlreadyAllocated);
     setIsToastOpen(true);
-    setLearnersAssignedCount(totalLearnersAssigned);
   }, []);
 
   const handleCloseToast = useCallback(() => {
     setIsToastOpen(false);
   }, []);
 
-  const successfulAssignmentAllocationToastMessage = `Course successfully assigned to ${learnersAssignedCount} ${learnersAssignedCount === 1 ? 'learner' : 'learners'}.`;
+  const pluralizeLearner = (count) => (count === 1 ? 'learner' : 'learners');
+
+  const toastMessages = [];
+  if (learnersAllocatedCount > 0) {
+    toastMessages.push(`Course successfully assigned to ${learnersAllocatedCount} ${pluralizeLearner(learnersAllocatedCount)}.`);
+  }
+  if (learnersAlreadyAllocatedCount > 0) {
+    toastMessages.push(`${learnersAlreadyAllocatedCount} ${pluralizeLearner(learnersAlreadyAllocatedCount)} already had this course assigned.`);
+  }
+  const successfulAssignmentAllocationToastMessage = toastMessages.join(' ');
 
   const successfulAssignmentToastContextValue = useMemo(() => ({
     isSuccessfulAssignmentAllocationToastOpen: isToastOpen,
     displayToastForAssignmentAllocation: handleDisplayToast,
     closeToastForAssignmentAllocation: handleCloseToast,
-    totalLearnersAssigned: learnersAssignedCount,
+    totalLearnersAllocated: learnersAllocatedCount,
+    totalLearnersAlreadyAllocated: learnersAlreadyAllocatedCount,
     successfulAssignmentAllocationToastMessage,
   }), [
     isToastOpen,
     handleDisplayToast,
     handleCloseToast,
-    learnersAssignedCount,
+    learnersAllocatedCount,
+    learnersAlreadyAllocatedCount,
     successfulAssignmentAllocationToastMessage,
   ]);
 

--- a/src/components/learner-credit-management/tests/BudgetCard.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetCard.test.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
@@ -15,6 +14,7 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 import BudgetCard from '../BudgetCard';
 import { formatPrice, useSubsidySummaryAnalyticsApi, useBudgetRedemptions } from '../data';
 import { BUDGET_TYPES } from '../../EnterpriseApp/data/constants';
+import { EnterpriseSubsidiesContext } from '../../EnterpriseSubsidiesContext';
 
 jest.mock('../data', () => ({
   ...jest.requireActual('../data'),
@@ -52,11 +52,20 @@ const mockBudgetUuid = 'test-budget-uuid';
 
 const mockBudgetDisplayName = 'Test Enterprise Budget Display Name';
 
-const BudgetCardWrapper = ({ ...rest }) => (
+const defaultEnterpriseSubsidiesContextValue = {
+  isFetchingBudgets: false,
+};
+
+const BudgetCardWrapper = ({
+  enterpriseSubsidiesContextValue = defaultEnterpriseSubsidiesContextValue,
+  ...rest
+}) => (
   <MemoryRouter initialEntries={['/test-enterprise/admin/learner-credit']}>
     <Provider store={store}>
       <IntlProvider locale="en">
-        <BudgetCard {...rest} />
+        <EnterpriseSubsidiesContext.Provider value={enterpriseSubsidiesContextValue}>
+          <BudgetCard {...rest} />
+        </EnterpriseSubsidiesContext.Provider>
       </IntlProvider>
     </Provider>
   </MemoryRouter>

--- a/src/components/learner-credit-management/tests/BudgetDetailPageWrapper.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPageWrapper.test.jsx
@@ -52,11 +52,47 @@ describe('<BudgetDetailPageWrapper />', () => {
   });
 
   it.each([
-    { totalLearnersAssigned: 1, expectedLearnerString: 'learner' },
-    { totalLearnersAssigned: 2, expectedLearnerString: 'learners' },
-  ])('should render Toast notification for successful assignment allocation (%s)', async ({
-    totalLearnersAssigned,
-    expectedLearnerString,
+    {
+      totalLearnersAllocated: 1,
+      expectedLearnersAllocatedString: 'learner',
+      totalLearnersAlreadyAllocated: 0,
+      expectedLearnersAlreadyAllocatedString: undefined,
+    },
+    {
+      totalLearnersAllocated: 2,
+      expectedLearnersAllocatedString: 'learners',
+      totalLearnersAlreadyAllocated: 0,
+      expectedLearnersAlreadyAllocatedString: undefined,
+    },
+    {
+      totalLearnersAllocated: 0,
+      expectedLearnersAllocatedString: undefined,
+      totalLearnersAlreadyAllocated: 1,
+      expectedLearnersAlreadyAllocatedString: 'learner',
+    },
+    {
+      totalLearnersAllocated: 0,
+      expectedLearnersAllocatedString: undefined,
+      totalLearnersAlreadyAllocated: 2,
+      expectedLearnersAlreadyAllocatedString: 'learners',
+    },
+    {
+      totalLearnersAllocated: 1,
+      expectedLearnersAllocatedString: 'learner',
+      totalLearnersAlreadyAllocated: 1,
+      expectedLearnersAlreadyAllocatedString: 'learner',
+    },
+    {
+      totalLearnersAllocated: 1,
+      expectedLearnersAllocatedString: 'learner',
+      totalLearnersAlreadyAllocated: 1,
+      expectedLearnersAlreadyAllocatedString: 'learner',
+    },
+  ])('should render Toast notification for successful assignment allocations (%s)', async ({
+    totalLearnersAllocated,
+    expectedLearnersAllocatedString,
+    totalLearnersAlreadyAllocated,
+    expectedLearnersAlreadyAllocatedString,
   }) => {
     const ToastContextController = () => {
       const {
@@ -65,7 +101,10 @@ describe('<BudgetDetailPageWrapper />', () => {
       } = useContext(BudgetDetailPageContext);
 
       const handleDisplayToast = () => {
-        displayToastForAssignmentAllocation({ totalLearnersAssigned });
+        displayToastForAssignmentAllocation({
+          totalLearnersAllocated,
+          totalLearnersAlreadyAllocated,
+        });
       };
 
       const handleCloseToast = () => {
@@ -81,7 +120,14 @@ describe('<BudgetDetailPageWrapper />', () => {
     };
     render(<MockBudgetDetailPageWrapper><ToastContextController /></MockBudgetDetailPageWrapper>);
 
-    const expectedToastMessage = `Course successfully assigned to ${totalLearnersAssigned} ${expectedLearnerString}.`;
+    const toastMessages = [];
+    if (totalLearnersAllocated > 0) {
+      toastMessages.push(`Course successfully assigned to ${totalLearnersAllocated} ${expectedLearnersAllocatedString}.`);
+    }
+    if (totalLearnersAlreadyAllocated > 0) {
+      toastMessages.push(`${totalLearnersAlreadyAllocated} ${expectedLearnersAlreadyAllocatedString} already had this course assigned.`);
+    }
+    const expectedToastMessage = toastMessages.join(' ');
 
     // Open Toast notification
     userEvent.click(getButtonElement('Open Toast'));


### PR DESCRIPTION
# Description

Introduces a background refetching loading state for the budget cards on the Learner Credit Management budgets list page. This is necessary to give the user immediate feedback that the budgets' metadata is refetching (e.g., after assignments were successfully allocated) as opposed to the current state where there is a delay between seeing the original budget aggregates vs. the updated budget aggregates after taking action on the budget (e.g., allocating assignments).

Considered using optimistic updates, where we manually update the query client cache instead of refetching the API, which would improve the perceived performance of the application. However, this preferred approach requires performing calculation(s) around remaining balance, etc. after successful assignment allocation that ideally would live in the backend API (e.g., after successful call to POST `allocate`, it could return the updated `aggregates` for the budget and the client-side optimistic update could rely on data given by the API vs. calculating itself).

Given the (possible) API changes to better support optimistic updates, I'm opting just to handle the background refetching loading state instead (lightest lift).

![image](https://github.com/openedx/frontend-app-admin-portal/assets/2828721/7ec69f9a-6c61-434d-82d5-2f0489ede2e2)

The success `Toast` notification assumes all emails entered were net-new assignments in its "Course successfully assigned to N learners". However, some learners may have already been assigned, where the `Toast` notification message is a bit misleading.

Taking inspiration from Subscriptions (which informs users of net-new subscription learners vs. subscription learners already invited), I've updated the `Toast` messaging to depict the count of learners already assigned to the course in addition to the count of learners with created+updated assignments (allocated or re-allocated, respectively):

![image](https://github.com/openedx/frontend-app-admin-portal/assets/2828721/8ab51fd7-b040-40e8-88ee-ae8237243949)



# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
