### PR TITLE
feat: dynamically using enterprise slug when displaying sso informational alerts

### DIFF
--- a/src/components/settings/SettingsSSOTab/NewSSOConfigAlerts.jsx
+++ b/src/components/settings/SettingsSSOTab/NewSSOConfigAlerts.jsx
@@ -18,6 +18,7 @@ const NewSSOConfigAlerts = ({
   notConfigured,
   contactEmail,
   closeAlerts,
+  enterpriseSlug,
 }) => {
   const dismissSetupCompleteAlert = () => {
     ssoCookies.set(
@@ -63,7 +64,7 @@ const NewSSOConfigAlerts = ({
             <br />
             1. Copy the URL for your learner Portal dashboard below:<br />
             <br />
-            &emsp; http://courses.edx.org/dashboard?tpa_hint=saml-bestrun-hana<br />
+            &emsp; http://courses.edx.org/dashboard?tpa_hint={enterpriseSlug}<br />
             <br />
             2: Launch a new incognito or private window and paste the copied URL into the URL bar to load your
             learner Portal dashboard.<br />
@@ -103,10 +104,12 @@ NewSSOConfigAlerts.propTypes = {
   notConfigured: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   closeAlerts: PropTypes.func.isRequired,
   contactEmail: PropTypes.string.isRequired,
+  enterpriseSlug: PropTypes.string.isRequired,
 };
 
 const mapStateToProps = state => ({
   contactEmail: state.portalConfiguration.contactEmail,
+  enterpriseSlug: state.portalConfiguration.enterpriseSlug,
 });
 
 export default connect(mapStateToProps)(NewSSOConfigAlerts);

--- a/src/components/settings/SettingsSSOTab/tests/NewSSOConfigAlerts.test.jsx
+++ b/src/components/settings/SettingsSSOTab/tests/NewSSOConfigAlerts.test.jsx
@@ -124,6 +124,12 @@ describe('New SSO Config Alerts Tests', () => {
       ),
     ).toBeInTheDocument();
     expect(
+      screen.getByText(
+        'http://courses.edx.org/dashboard?tpa_hint=sluggy',
+        { exact: false },
+      ),
+    ).toBeInTheDocument();
+    expect(
       screen.queryByText(
         'Your SSO integration is live!',
       ),


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-8050

![image](https://github.com/openedx/frontend-app-admin-portal/assets/67655836/e946e30b-2f24-4932-8ed9-60bb8457976a)

nice and straight forward

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
