### PR TITLE
feat: adding sso orchestrator failure and timeout handling and genera…

### DIFF
--- a/src/components/forms/ValidatedFormRadio.tsx
+++ b/src/components/forms/ValidatedFormRadio.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 import omit from 'lodash/omit';
 import isString from 'lodash/isString';
 
-import { Form } from '@edx/paragon';
+import { Form, Stack } from '@edx/paragon';
 
 import { setFormFieldAction } from './data/actions';
 import { useFormContext } from './FormContext';
@@ -65,7 +65,9 @@ const ValidatedFormRadio = (props: ValidatedFormRadioProps) => {
         isInline={formRadioProps.isInline}
         value={value}
       >
-        {createOptions(formRadioProps.options)}
+        <Stack gap={3.5}>
+          {createOptions(formRadioProps.options)}
+        </Stack>
       </Form.RadioSet>
       {formRadioProps.fieldInstructions && (
         <Form.Text>{formRadioProps.fieldInstructions}</Form.Text>

--- a/src/components/settings/SettingsSSOTab/NewSSOConfigAlerts.jsx
+++ b/src/components/settings/SettingsSSOTab/NewSSOConfigAlerts.jsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import {
-  CheckCircle, Warning,
+  CheckCircle, Info, Warning,
 } from '@edx/paragon/icons';
-import { Alert } from '@edx/paragon';
+import { Alert, Button } from '@edx/paragon';
 import Cookies from 'universal-cookie';
+import { SSOConfigContext } from './SSOConfigContext';
 
 export const SSO_SETUP_COMPLETION_COOKIE_NAME = 'dismissed-sso-completion-alert';
 const SSO_ALERT_OVERRIDE_PARAM = 'sso_alert_override';
@@ -19,7 +20,19 @@ const NewSSOConfigAlerts = ({
   contactEmail,
   closeAlerts,
   enterpriseSlug,
+  timedOutConfigs,
+  erroredConfigs,
+  setIsStepperOpen,
 }) => {
+  const { setProviderConfig } = useContext(SSOConfigContext);
+
+  const configureOnClick = (config) => {
+    setProviderConfig(config);
+    setIsStepperOpen(true);
+  };
+  const onTimedOutConfigureClick = () => configureOnClick(timedOutConfigs[0]);
+  const onErroredConfigClick = () => configureOnClick(erroredConfigs[0]);
+
   const dismissSetupCompleteAlert = () => {
     ssoCookies.set(
       SSO_SETUP_COMPLETION_COOKIE_NAME,
@@ -32,13 +45,63 @@ const NewSSOConfigAlerts = ({
   const searchParams = new URLSearchParams(window.location.search);
   const dismissedSSOSetupCompletionCookie = ssoCookies.get(SSO_SETUP_COMPLETION_COOKIE_NAME) === 'true';
   const hideSSOLiveAlert = dismissedSSOSetupCompletionCookie && !searchParams.get(SSO_ALERT_OVERRIDE_PARAM);
+
+  const [showTimeoutAlert, setShowTimeoutAlert] = useState(true);
+  const [showErrorAlert, setShowErrorAlert] = useState(true);
+
+  if (timedOutConfigs.length >= 1) {
+    return (
+      <Alert
+        variant="danger"
+        icon={Info}
+        className="sso-alert-width"
+        actions={[
+          <Button data-testid="sso-timeout-alert-configure" onClick={onTimedOutConfigureClick}>Configure</Button>,
+        ]}
+        dismissible
+        show={showTimeoutAlert}
+        onClose={() => { setShowTimeoutAlert(false); }}
+        stacked
+      >
+        <Alert.Heading>SSO Configuration timed out</Alert.Heading>
+        <p>
+          Your SSO configuration failed due to an internal error. Please try again by selecting “Configure” below and
+          {' '}verifying your integration details. Then reconfigure, reauthorize, and test your connection.
+        </p>
+      </Alert>
+    );
+  }
+
+  if (erroredConfigs.length >= 1) {
+    return (
+      <Alert
+        variant="danger"
+        icon={Info}
+        className="sso-alert-width"
+        show={showErrorAlert}
+        actions={[
+          <Button data-testid="sso-errored-alert-configure" onClick={onErroredConfigClick}>Configure</Button>,
+        ]}
+        dismissible
+        onClose={() => { setShowErrorAlert(false); }}
+        stacked
+      >
+        <Alert.Heading>SSO Configuration failed</Alert.Heading>
+        <p>
+          Please verify integration details have been entered correctly. Select “Configure” below and verify your
+          {' '}integration details. Then reconfigure, reauthorize, and test your connection.
+        </p>
+      </Alert>
+    );
+  }
+
   return (
     <>
       {inProgressConfigs.length >= 1 && (
         <Alert
           variant="warning"
           icon={Warning}
-          className="ml-0 w-75"
+          className="ml-0 sso-alert-width"
           dismissible
           onClose={closeAlerts}
         >
@@ -53,21 +116,21 @@ const NewSSOConfigAlerts = ({
         <Alert
           variant="warning"
           icon={Warning}
-          className="ml-0 w-75"
+          className="ml-0 sso-alert-width"
           onClose={closeAlerts}
           dismissible
         >
           <Alert.Heading>You need to test your SSO connection</Alert.Heading>
           <p>
-            Your SSO configuration has completed,
+            Your SSO configuration has been completed,
             and you should have received an email with the following instructions:<br />
             <br />
-            1. Copy the URL for your learner Portal dashboard below:<br />
+            1: Copy the URL for your Learner Portal dashboard below:<br />
             <br />
             &emsp; http://courses.edx.org/dashboard?tpa_hint={enterpriseSlug}<br />
             <br />
             2: Launch a new incognito or private window and paste the copied URL into the URL bar to load your
-            learner Portal dashboard.<br />
+            Learner Portal dashboard.<br />
             <br />
             3: When prompted, enter login credentials supported by your IDP to test your connection to edX.<br />
             <br />
@@ -82,7 +145,7 @@ const NewSSOConfigAlerts = ({
         !hideSSOLiveAlert) && (
         <Alert
           variant="success"
-          className="ml-0 w-75"
+          className="ml-0 sso-alert-width"
           icon={CheckCircle}
           onClose={dismissSetupCompleteAlert}
           dismissible
@@ -105,6 +168,9 @@ NewSSOConfigAlerts.propTypes = {
   closeAlerts: PropTypes.func.isRequired,
   contactEmail: PropTypes.string.isRequired,
   enterpriseSlug: PropTypes.string.isRequired,
+  erroredConfigs: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  timedOutConfigs: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  setIsStepperOpen: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => ({

--- a/src/components/settings/SettingsSSOTab/index.jsx
+++ b/src/components/settings/SettingsSSOTab/index.jsx
@@ -14,7 +14,7 @@ import NewSSOConfigForm from './NewSSOConfigForm';
 import { SSOConfigContext, SSOConfigContextProvider } from './SSOConfigContext';
 import LmsApiService from '../../../data/services/LmsApiService';
 import { features } from '../../../config';
-import { isInProgressConfig } from './utils';
+import { isInProgressConfig, checkErroredOrTimedOutConfig } from './utils';
 
 const SettingsSSOTab = ({ enterpriseId, setHasSSOConfig }) => {
   const {
@@ -59,7 +59,9 @@ const SettingsSSOTab = ({ enterpriseId, setHasSSOConfig }) => {
 
   if (AUTH0_SELF_SERVICE_INTEGRATION) {
     const newButtonVisible = existingConfigs?.length > 0 && (providerConfig === null);
-    const newButtonDisabled = existingConfigs.some(isInProgressConfig);
+    const newButtonDisabled = existingConfigs.some(isInProgressConfig) && (
+      !existingConfigs.some(checkErroredOrTimedOutConfig)
+    );
     return (
       <div>
         <ModalDialog

--- a/src/components/settings/SettingsSSOTab/steps/NewSSOConfigConfigureStep.tsx
+++ b/src/components/settings/SettingsSSOTab/steps/NewSSOConfigConfigureStep.tsx
@@ -222,7 +222,7 @@ const SSOConfigConfigureStep = () => {
             formId="displayName"
             type="text"
             floatingLabel="Display Name (Optional)"
-            fieldInstructions="Create a custom display name for this SSO integration"
+            fieldInstructions="Create a custom display name for this SSO integration."
           />
         </Form.Group>
 

--- a/src/components/settings/SettingsSSOTab/steps/NewSSOConfigConfirmStep.tsx
+++ b/src/components/settings/SettingsSSOTab/steps/NewSSOConfigConfirmStep.tsx
@@ -44,7 +44,7 @@ const SSOConfigConfirmStep = () => (
     <hr />
     <p>
       Select the <strong>&quot;Finish&quot;</strong> button below or close this form via the
-      <strong>&quot;X&quot;</strong> in the upper right corner while you wait for your
+      {' '}<strong>&quot;X&quot;</strong> in the upper right corner while you wait for your
       configuration email.  Your SSO testing status will display on the following SSO settings screen.
     </p>
   </>

--- a/src/components/settings/SettingsSSOTab/steps/NewSSOConfigConnectStep.tsx
+++ b/src/components/settings/SettingsSSOTab/steps/NewSSOConfigConnectStep.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Container, Dropzone, Form } from '@edx/paragon';
+import { Container, Dropzone, Form, Stack } from '@edx/paragon';
 
 import ValidatedFormRadio from '../../../forms/ValidatedFormRadio';
 import ValidatedFormControl from '../../../forms/ValidatedFormControl';
@@ -73,9 +73,9 @@ const SSOConfigConnectStep = () => {
 
       <Form style={{ maxWidth: '60rem' }}>
 
-        <h1>Let&apos;s get started</h1>
-        What is your organization&apos;s SSO Identity Provider?
-        <Form.Group className="mb-4.5">
+        <h3 className="mb-4">Let&apos;s get started</h3>
+        <p className="mb-n3">What is your organization&apos;s SSO Identity Provider?</p>
+        <Form.Group className="mb-5.5">
           <ValidatedFormRadio
             formId="identityProvider"
             label=""
@@ -83,9 +83,9 @@ const SSOConfigConnectStep = () => {
           />
         </Form.Group>
 
-        <h3>Connect edX to your Identity Provider</h3>
-        Select a method to connect edX to your Identity Provider
-        <Form.Group className="mb-4.5">
+        <h4 className="mb-4">Connect edX to your Identity Provider</h4>
+        <p className="mb-n3">Select a method to connect edX to your Identity Provider</p>
+        <Form.Group className="mb-5">
           <ValidatedFormRadio
             formId="idpConnectOption"
             label=""
@@ -94,14 +94,14 @@ const SSOConfigConnectStep = () => {
         </Form.Group>
 
         {showUrlEntry && (
-        <Form.Group className="mb-4">
-          <ValidatedFormControl
-            formId="metadataUrl"
-            type="text"
-            floatingLabel="Identity Provider Metadata URL"
-            fieldInstructions="Find the URL in your Identity Provider portal or website."
-          />
-        </Form.Group>
+          <Form.Group className="mb-4 mt-4">
+            <ValidatedFormControl
+              formId="metadataUrl"
+              type="text"
+              floatingLabel="Identity Provider Metadata URL"
+              fieldInstructions="Find the URL in your Identity Provider portal or website."
+            />
+          </Form.Group>
         )}
 
         {showXmlUpload

--- a/src/components/settings/SettingsSSOTab/tests/NewSSOConfigAlerts.test.jsx
+++ b/src/components/settings/SettingsSSOTab/tests/NewSSOConfigAlerts.test.jsx
@@ -58,6 +58,9 @@ describe('New SSO Config Alerts Tests', () => {
               untestedConfigs={[{ display_name: 'untested' }]}
               notConfigured={[]}
               closeAlerts={jest.fn()}
+              timedOutConfigs={[]}
+              erroredConfigs={[]}
+              setIsStepperOpen={jest.fn()}
             />,
           </Provider>
         </SSOConfigContext.Provider>
@@ -90,6 +93,9 @@ describe('New SSO Config Alerts Tests', () => {
               untestedConfigs={[]}
               notConfigured={[{ display_name: 'not configured' }]}
               closeAlerts={jest.fn()}
+              timedOutConfigs={[]}
+              erroredConfigs={[]}
+              setIsStepperOpen={jest.fn()}
             />,
           </Provider>
         </SSOConfigContext.Provider>
@@ -113,6 +119,9 @@ describe('New SSO Config Alerts Tests', () => {
               untestedConfigs={[{ display_name: 'untested' }]}
               notConfigured={[]}
               closeAlerts={jest.fn()}
+              timedOutConfigs={[]}
+              erroredConfigs={[]}
+              setIsStepperOpen={jest.fn()}
             />,
           </Provider>
         </SSOConfigContext.Provider>
@@ -150,6 +159,9 @@ describe('New SSO Config Alerts Tests', () => {
               untestedConfigs={[]}
               notConfigured={[]}
               closeAlerts={jest.fn()}
+              timedOutConfigs={[]}
+              erroredConfigs={[]}
+              setIsStepperOpen={jest.fn()}
             />,
           </Provider>
         </SSOConfigContext.Provider>
@@ -173,6 +185,9 @@ describe('New SSO Config Alerts Tests', () => {
               untestedConfigs={[{ display_name: 'untested' }]}
               notConfigured={[]}
               closeAlerts={mockCloseAlerts}
+              timedOutConfigs={[]}
+              erroredConfigs={[]}
+              setIsStepperOpen={jest.fn()}
             />,
           </Provider>
         </SSOConfigContext.Provider>
@@ -199,6 +214,9 @@ describe('New SSO Config Alerts Tests', () => {
               untestedConfigs={[]}
               notConfigured={[]}
               closeAlerts={jest.fn()}
+              timedOutConfigs={[]}
+              erroredConfigs={[]}
+              setIsStepperOpen={jest.fn()}
             />,
           </Provider>
         </SSOConfigContext.Provider>

--- a/src/components/settings/SettingsSSOTab/utils.js
+++ b/src/components/settings/SettingsSSOTab/utils.js
@@ -31,6 +31,10 @@ function isInProgressConfig(config) {
   || config.configured_at < config.submitted_at;
 }
 
+function checkErroredOrTimedOutConfig(config) {
+  return config.errored_at || (config.submitted_at && !config.configured_at && !config.is_pending_configuration);
+}
+
 export {
-  updateSamlProviderData, deleteSamlProviderData, createSAMLURLs, isInProgressConfig,
+  updateSamlProviderData, deleteSamlProviderData, createSAMLURLs, isInProgressConfig, checkErroredOrTimedOutConfig,
 };

--- a/src/components/settings/settings.scss
+++ b/src/components/settings/settings.scss
@@ -14,6 +14,10 @@
   max-height: 71px;
 }
 
+.sso-alert-width {
+  width: 73% !important;
+}
+
 .lms-card-hover {
   &:hover {
     box-shadow: $box-shadow;


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-8053

time out alert (alert width now matches config cards)
![image](https://github.com/openedx/frontend-app-admin-portal/assets/67655836/a8edb963-6b68-4b70-8299-65c4f0a729f6)

errored alert
![image](https://github.com/openedx/frontend-app-admin-portal/assets/67655836/0764bab6-e868-4fe5-8fd3-69a8eac75d70)
 
fixed spelling/formatting of needs testing alert
![image](https://github.com/openedx/frontend-app-admin-portal/assets/67655836/ca640cfc-58aa-4235-bad7-227144f903c3)

fixed spacing before `"x"` in text
![image](https://github.com/openedx/frontend-app-admin-portal/assets/67655836/cdc81f4a-3fd3-46cd-a48f-d86a89a93524)

fixed formatting on connect step
![image](https://github.com/openedx/frontend-app-admin-portal/assets/67655836/1971c02c-c27d-417f-9c7d-89a15d311f83)

NOT ADDRESSED IN THIS TICKET:

> Radio button focus circles are off center compared with Paragon technical documentation 

> add step label error states, per [Figma Error states](https://www.figma.com/file/d0I9hSyXdSGtsqgniJPmK2/Admin-Portal-Redesign?type=design&node-id=3660%3A45806&mode=design&t=I6pybbbV8ERdPz9f-1) design.

see Jira ticket for reasons and follow ups

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
