### PR TITLE
fix: ensure pending balance is shown on budget cards even if 0

### DIFF
--- a/src/components/EnterpriseSubsidiesContext/data/hooks.js
+++ b/src/components/EnterpriseSubsidiesContext/data/hooks.js
@@ -12,6 +12,7 @@ import SubsidyApiService from '../../../data/services/EnterpriseSubsidyApiServic
 import { BUDGET_TYPES } from '../../EnterpriseApp/data/constants';
 import EnterpriseAccessApiService from '../../../data/services/EnterpriseAccessApiService';
 import { learnerCreditManagementQueryKeys } from '../../learner-credit-management/data';
+import { isAssignableSubsidyAccessPolicyType } from '../../../utils';
 
 dayjs.extend(isBetween);
 
@@ -74,6 +75,7 @@ async function fetchEnterpriseBudgets({
         spent: result.aggregates.amountRedeemedUsd,
         pending: result.aggregates.amountAllocatedUsd,
       },
+      isAssignable: isAssignableSubsidyAccessPolicyType(result),
     });
   });
   enterpriseSubsidyResults?.forEach((result) => {

--- a/src/components/EnterpriseSubsidiesContext/data/tests/hooks.test.jsx
+++ b/src/components/EnterpriseSubsidiesContext/data/tests/hooks.test.jsx
@@ -243,6 +243,7 @@ describe('useEnterpriseBudgets', () => {
         end: mockBudgetEnd,
         isCurrent: true,
         source: BUDGET_TYPES.policy,
+        isAssignable: false,
         aggregates: {
           available: 700,
           spent: 200,

--- a/src/components/learner-credit-management/BudgetCard.jsx
+++ b/src/components/learner-credit-management/BudgetCard.jsx
@@ -40,6 +40,7 @@ const BudgetCard = ({
         pending={budget.aggregates.pending}
         displayName={budget.name}
         enterpriseSlug={enterpriseSlug}
+        isAssignable={budget.isAssignable}
       />
     );
   }
@@ -94,6 +95,7 @@ BudgetCard.propTypes = {
       spent: PropTypes.number.isRequired,
       pending: PropTypes.number,
     }),
+    isAssignable: PropTypes.bool,
   }).isRequired,
   enterpriseUUID: PropTypes.string.isRequired,
   enterpriseSlug: PropTypes.string.isRequired,

--- a/src/components/learner-credit-management/SubBudgetCard.jsx
+++ b/src/components/learner-credit-management/SubBudgetCard.jsx
@@ -31,6 +31,7 @@ const SubBudgetCard = ({
   displayName,
   enterpriseSlug,
   isLoading,
+  isAssignable,
 }) => {
   const { isFetchingBudgets } = useContext(EnterpriseSubsidiesContext);
   const budgetLabel = getBudgetStatus(start, end);
@@ -81,7 +82,7 @@ const SubBudgetCard = ({
             {isFetchingBudgets ? <Skeleton /> : formatPrice(available)}
           </span>
         </Col>
-        {pending > 0 && (
+        {isAssignable && (
           <Col xs="6" md="auto" className="mb-3 mb-md-0">
             <div className="small font-weight-bold">Pending</div>
             <span className="small">
@@ -128,6 +129,7 @@ SubBudgetCard.propTypes = {
   available: PropTypes.number,
   pending: PropTypes.number,
   displayName: PropTypes.string,
+  isAssignable: PropTypes.bool,
 };
 
 export default SubBudgetCard;

--- a/src/components/learner-credit-management/data/hooks/useSubsidyAccessPolicy.js
+++ b/src/components/learner-credit-management/data/hooks/useSubsidyAccessPolicy.js
@@ -3,13 +3,7 @@ import { camelCaseObject } from '@edx/frontend-platform/utils';
 
 import EnterpriseAccessApiService from '../../../../data/services/EnterpriseAccessApiService';
 import { learnerCreditManagementQueryKeys } from '../constants';
-
-const determineBudgetAssignability = (subsidyAccessPolicy) => {
-  const policyType = subsidyAccessPolicy?.policyType;
-  const isAssignable = !!subsidyAccessPolicy?.assignmentConfiguration;
-  const assignableSubsidyAccessPolicyTypes = ['AssignedLearnerCreditAccessPolicy'];
-  return isAssignable && assignableSubsidyAccessPolicyTypes.includes(policyType);
-};
+import { isAssignableSubsidyAccessPolicyType } from '../../../../utils';
 
 /**
  * Retrieves a subsidy access policy by UUID from the API.
@@ -21,7 +15,7 @@ const getSubsidyAccessPolicy = async ({ queryKey }) => {
   const subsidyAccessPolicyUUID = queryKey[2];
   const response = await EnterpriseAccessApiService.retrieveSubsidyAccessPolicy(subsidyAccessPolicyUUID);
   const subsidyAccessPolicy = camelCaseObject(response.data);
-  subsidyAccessPolicy.isAssignable = determineBudgetAssignability(subsidyAccessPolicy);
+  subsidyAccessPolicy.isAssignable = isAssignableSubsidyAccessPolicyType(subsidyAccessPolicy);
   return subsidyAccessPolicy;
 };
 

--- a/src/components/learner-credit-management/tests/BudgetCard.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetCard.test.jsx
@@ -212,6 +212,7 @@ describe('<BudgetCard />', () => {
         pending: isAssignableBudget ? mockBudgetAggregates.pending : undefined,
         spent: mockBudgetAggregates.spent,
       },
+      isAssignable: isAssignableBudget,
     };
     useSubsidySummaryAnalyticsApi.mockReturnValue({
       isLoading: false,

--- a/src/utils.js
+++ b/src/utils.js
@@ -412,6 +412,17 @@ function defaultQueryClientRetryHandler(failureCount, err) {
   return true;
 }
 
+/**
+ * Determines whether a subsidy access policy is assignable, based on its policy type
+ * and the presence of an assignment configuration.
+ */
+function isAssignableSubsidyAccessPolicyType(policy) {
+  const policyType = policy?.policyType;
+  const isAssignable = !!policy?.assignmentConfiguration;
+  const assignableSubsidyAccessPolicyTypes = ['AssignedLearnerCreditAccessPolicy'];
+  return isAssignable && assignableSubsidyAccessPolicyTypes.includes(policyType);
+}
+
 export {
   camelCaseDict,
   camelCaseDictArray,
@@ -446,4 +457,5 @@ export {
   pollAsync,
   isNotValidNumberString,
   defaultQueryClientRetryHandler,
+  isAssignableSubsidyAccessPolicyType,
 };


### PR DESCRIPTION
# Description

Previously, if an assignable budget had no assignments yet, the "Pending" balance would not show on the budget card on the Budgets list page route. With this PR, the "Pending" balance will always display for assignable budgets, regardless of having any assignments allocated yet:

<img width="1423" alt="image" src="https://github.com/openedx/frontend-app-admin-portal/assets/2828721/7c9d2318-8932-40d7-9608-b4e5bb3dba41">

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
