### PR TITLE
feat: display only active budgets from subsidy-access-policy

### DIFF
--- a/src/data/services/EnterpriseAccessApiService.js
+++ b/src/data/services/EnterpriseAccessApiService.js
@@ -167,6 +167,7 @@ class EnterpriseAccessApiService {
   static listSubsidyAccessPolicies(enterpriseCustomerId) {
     const queryParams = new URLSearchParams({
       enterprise_customer_uuid: enterpriseCustomerId,
+      active: true,
     });
     const url = `${EnterpriseAccessApiService.baseUrl}/subsidy-access-policies/?${queryParams.toString()}`;
     return EnterpriseAccessApiService.apiClient().get(url);

--- a/src/data/services/tests/EnterpriseAccessApiService.test.js
+++ b/src/data/services/tests/EnterpriseAccessApiService.test.js
@@ -166,7 +166,7 @@ describe('EnterpriseAccessApiService', () => {
   test('listSubsidyAccessPolicies calls enterprise-access to fetch subsidy access policies', () => {
     EnterpriseAccessApiService.listSubsidyAccessPolicies(mockEnterpriseUUID);
     expect(axios.get).toBeCalledWith(
-      `${enterpriseAccessBaseUrl}/api/v1/subsidy-access-policies/?enterprise_customer_uuid=${mockEnterpriseUUID}`,
+      `${enterpriseAccessBaseUrl}/api/v1/subsidy-access-policies/?enterprise_customer_uuid=${mockEnterpriseUUID}&active=true`,
     );
   });
 


### PR DESCRIPTION
Updates API for subsidy access policy list view to include the optional `active` query parameter

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
