### PR TITLE
fix: disables refetch on window focus for useEnterpriseBudgets useQuery hook call

### DIFF
--- a/src/components/EnterpriseSubsidiesContext/data/hooks.js
+++ b/src/components/EnterpriseSubsidiesContext/data/hooks.js
@@ -115,6 +115,9 @@ export const useEnterpriseBudgets = ({
     enterpriseId,
     enablePortalLearnerCreditManagementScreen,
   }),
+  // Disables the ability to re-fetch on window focus due to re-fetching behavior causing
+  // ProductTours component to rerender despite localStorage flagging
+  refetchOnWindowFocus: false,
 });
 
 export const useCustomerAgreement = ({ enterpriseId }) => {

--- a/src/components/ProductTours/data/hooks.js
+++ b/src/components/ProductTours/data/hooks.js
@@ -9,9 +9,9 @@ import { SubsidyRequestsContext } from '../../subsidy-requests';
 import { EnterpriseSubsidiesContext } from '../../EnterpriseSubsidiesContext';
 
 export const usePortalAppearanceTour = ({ enablePortalAppearance }) => {
-  const dismissedLearnerCreditTourCookie = global.localStorage.getItem(PORTAL_APPEARANCE_TOUR_COOKIE_NAME);
+  const dismissedPortalAppearanceTour = global.localStorage.getItem(PORTAL_APPEARANCE_TOUR_COOKIE_NAME);
   // Only show tour if feature is enabled, hide cookie is undefined or false or not in the settings page
-  const showPortalAppearanceTour = enablePortalAppearance && !dismissedLearnerCreditTourCookie;
+  const showPortalAppearanceTour = enablePortalAppearance && !dismissedPortalAppearanceTour;
   const [portalAppearanceTourEnabled, setPortalAppearanceTourEnabled] = useState(showPortalAppearanceTour);
   return [portalAppearanceTourEnabled, setPortalAppearanceTourEnabled];
 };


### PR DESCRIPTION
Sets `refetchOnWindowFocus` to false specifically on the useEnterpriseBudgets hook call as its the only component on the top level context that is implemented using `useQuery` and has `ProductTours` as a child component.
# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
