### PR TITLE
fix: modifies product tours state to fix re-rendering error

### DIFF
--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -34,7 +34,7 @@ const queryClient = new QueryClient({
       // relying on the cached data until the `staleTime` window has exceeded. This may be modified
       // per-query, as needed, if certain queries expect to be more up-to-date than others. Allows
       // `useQuery` to be used as a state manager.
-      staleTime: 1000 * 60,
+      staleTime: 1000 * 2,
     },
   },
 });

--- a/src/components/EnterpriseSubsidiesContext/index.jsx
+++ b/src/components/EnterpriseSubsidiesContext/index.jsx
@@ -18,6 +18,8 @@ export const useEnterpriseSubsidiesContext = ({
     enterpriseId,
     isTopDownAssignmentEnabled,
   });
+  console.log(isLoadingBudgets, isFetchingBudgets, budgetsOverview)
+  console.log(enablePortalLearnerCreditManagementScreen, enterpriseId, isTopDownAssignmentEnabled )
   const {
     budgets = [],
     canManageLearnerCredit = false,

--- a/src/components/EnterpriseSubsidiesContext/index.jsx
+++ b/src/components/EnterpriseSubsidiesContext/index.jsx
@@ -18,8 +18,7 @@ export const useEnterpriseSubsidiesContext = ({
     enterpriseId,
     isTopDownAssignmentEnabled,
   });
-  console.log(isLoadingBudgets, isFetchingBudgets, budgetsOverview)
-  console.log(enablePortalLearnerCreditManagementScreen, enterpriseId, isTopDownAssignmentEnabled )
+
   const {
     budgets = [],
     canManageLearnerCredit = false,

--- a/src/components/ProductTours/ProductTours.jsx
+++ b/src/components/ProductTours/ProductTours.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import { ProductTour } from '@edx/paragon';
 import { useHistory } from 'react-router-dom';
@@ -29,6 +29,7 @@ const ProductTours = ({
   enableLearnerPortal,
 }) => {
   const { FEATURE_CONTENT_HIGHLIGHTS } = getConfig();
+  const [tours, setTours] = useState([]);
   const enablePortalAppearance = features.SETTINGS_PAGE_APPEARANCE_TAB;
   const history = useHistory();
   const enabledFeatures = {
@@ -37,6 +38,7 @@ const ProductTours = ({
     [LEARNER_CREDIT_COOKIE_NAME]: useLearnerCreditTour()[0],
     [HIGHLIGHTS_COOKIE_NAME]: useHighlightsTour(FEATURE_CONTENT_HIGHLIGHTS)[0],
   };
+  console.log(enabledFeatures, 'step 1 product tour, enabledFeatures')
   const newFeatureTourCheckpoints = {
     [PORTAL_APPEARANCE_TOUR_COOKIE_NAME]: portalAppearanceTour({
       enterpriseSlug,
@@ -55,16 +57,22 @@ const ProductTours = ({
       history,
     }),
   };
-  const checkpointsArray = filterCheckpoints(newFeatureTourCheckpoints, enabledFeatures);
-  const tours = [{
-    tourId: 'newFeatureTour',
-    advanceButtonText: 'Next',
-    dismissButtonText: 'Dismiss',
-    endButtonText: 'End',
-    enabled: checkpointsArray?.length > 0,
-    onEnd: () => disableAll(),
-    checkpoints: checkpointsArray,
-  }];
+  console.log(newFeatureTourCheckpoints, 'step 2 product tour, newFeatureTourCheckpoints')
+
+  useEffect(() => {
+    if (tours.length === 0) {
+      const checkpointsArray = filterCheckpoints(newFeatureTourCheckpoints, enabledFeatures);
+      setTours([{
+        tourId: 'newFeatureTour',
+        advanceButtonText: 'Next',
+        dismissButtonText: 'Dismiss',
+        endButtonText: 'End',
+        enabled: checkpointsArray?.length > 0,
+        onEnd: () => disableAll(),
+        checkpoints: checkpointsArray,
+      }]);
+    }
+  }, [enabledFeatures, newFeatureTourCheckpoints, tours.length]);
 
   return (
     <ProductTour

--- a/src/components/ProductTours/ProductTours.jsx
+++ b/src/components/ProductTours/ProductTours.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { ProductTour } from '@edx/paragon';
 import { useHistory } from 'react-router-dom';
@@ -32,14 +32,20 @@ const ProductTours = ({
   const [tours, setTours] = useState([]);
   const enablePortalAppearance = features.SETTINGS_PAGE_APPEARANCE_TAB;
   const history = useHistory();
-  const enabledFeatures = {
-    [PORTAL_APPEARANCE_TOUR_COOKIE_NAME]: usePortalAppearanceTour({ enablePortalAppearance })[0],
-    [BROWSE_AND_REQUEST_TOUR_COOKIE_NAME]: useBrowseAndRequestTour({ enableLearnerPortal })[0],
-    [LEARNER_CREDIT_COOKIE_NAME]: useLearnerCreditTour()[0],
-    [HIGHLIGHTS_COOKIE_NAME]: useHighlightsTour(FEATURE_CONTENT_HIGHLIGHTS)[0],
-  };
-  console.log(enabledFeatures, 'step 1 product tour, enabledFeatures')
-  const newFeatureTourCheckpoints = {
+
+  const portalAppearance = usePortalAppearanceTour({ enablePortalAppearance })[0];
+  const browseAndRequest = useBrowseAndRequestTour({ enableLearnerPortal })[0];
+  const learnerCredit = useLearnerCreditTour()[0];
+  const highlightTour = useHighlightsTour(FEATURE_CONTENT_HIGHLIGHTS)[0];
+
+  const enabledFeatures = useMemo(() => ({
+    [PORTAL_APPEARANCE_TOUR_COOKIE_NAME]: portalAppearance,
+    [BROWSE_AND_REQUEST_TOUR_COOKIE_NAME]: browseAndRequest,
+    [LEARNER_CREDIT_COOKIE_NAME]: learnerCredit,
+    [HIGHLIGHTS_COOKIE_NAME]: highlightTour,
+  }), [browseAndRequest, highlightTour, learnerCredit, portalAppearance]);
+  console.log(enabledFeatures, 'step 1 product tour, enabledFeatures');
+  const newFeatureTourCheckpoints = useMemo(() => ({
     [PORTAL_APPEARANCE_TOUR_COOKIE_NAME]: portalAppearanceTour({
       enterpriseSlug,
       history,
@@ -56,8 +62,8 @@ const ProductTours = ({
       enterpriseSlug,
       history,
     }),
-  };
-  console.log(newFeatureTourCheckpoints, 'step 2 product tour, newFeatureTourCheckpoints')
+  }), [enterpriseSlug, history]);
+  console.log(newFeatureTourCheckpoints, 'step 2 product tour, newFeatureTourCheckpoints');
 
   useEffect(() => {
     if (tours.length === 0) {

--- a/src/components/ProductTours/ProductTours.jsx
+++ b/src/components/ProductTours/ProductTours.jsx
@@ -44,7 +44,7 @@ const ProductTours = ({
     [LEARNER_CREDIT_COOKIE_NAME]: learnerCredit,
     [HIGHLIGHTS_COOKIE_NAME]: highlightTour,
   }), [browseAndRequest, highlightTour, learnerCredit, portalAppearance]);
-  console.log(enabledFeatures, 'step 1 product tour, enabledFeatures');
+
   const newFeatureTourCheckpoints = useMemo(() => ({
     [PORTAL_APPEARANCE_TOUR_COOKIE_NAME]: portalAppearanceTour({
       enterpriseSlug,
@@ -63,7 +63,6 @@ const ProductTours = ({
       history,
     }),
   }), [enterpriseSlug, history]);
-  console.log(newFeatureTourCheckpoints, 'step 2 product tour, newFeatureTourCheckpoints');
 
   useEffect(() => {
     if (tours.length === 0) {


### PR DESCRIPTION
Updates how the product tour state is set within the component so on re-render, the component is passing the previously updated state of the `tours` object after it checks the localStorage flags to display the product tour. 
The refetching can still perform as intended but without re-rendering the product tours.

https://github.com/openedx/frontend-app-admin-portal/assets/82611798/b7f7ae61-93d7-4884-b86e-46630b2ead7d




# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
