### PR TITLE
fix: adds sane fallback to if learnerState is failed and no error reason exist

### DIFF
--- a/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
+++ b/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
@@ -8,6 +8,7 @@ import FailedReminder from './assignments-status-chips/FailedReminder';
 import FailedSystem from './assignments-status-chips/FailedSystem';
 import NotifyingLearner from './assignments-status-chips/NotifyingLearner';
 import WaitingForLearner from './assignments-status-chips/WaitingForLearner';
+import { capitalizeFirstLetter } from '../../utils';
 
 const AssignmentStatusTableCell = ({ row }) => {
   const { original } = row;
@@ -16,10 +17,14 @@ const AssignmentStatusTableCell = ({ row }) => {
     learnerState,
     errorReason,
   } = original;
-
   // Learner state is not available for this assignment, so don't display anything.
   if (!learnerState) {
     return null;
+  }
+
+  // If learnerState is failed but no error reason is defined, don't display anything.
+  if (learnerState === 'failed' && !errorReason) {
+    return <FailedSystem />;
   }
 
   // Display the appropriate status chip based on the learner state.
@@ -54,7 +59,7 @@ const AssignmentStatusTableCell = ({ row }) => {
   }
 
   // Note: The given `learnerState` not officially supported with a `ModalPopup`, but display it anyway.
-  return <Chip>{`${learnerState.charAt(0).toUpperCase()}${learnerState.substr(1)}`}</Chip>;
+  return <Chip>{`${capitalizeFirstLetter(learnerState)}`}</Chip>;
 };
 
 AssignmentStatusTableCell.propTypes = {

--- a/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
+++ b/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
@@ -22,11 +22,6 @@ const AssignmentStatusTableCell = ({ row }) => {
     return null;
   }
 
-  // If learnerState is failed but no error reason is defined, return a failed system chip.
-  if (learnerState === 'failed' && !errorReason) {
-    return <FailedSystem />;
-  }
-
   // Display the appropriate status chip based on the learner state.
   if (learnerState === 'notifying') {
     return (
@@ -41,6 +36,10 @@ const AssignmentStatusTableCell = ({ row }) => {
   }
 
   if (learnerState === 'failed') {
+    // If learnerState is failed but no error reason is defined, return a failed system chip.
+    if (!errorReason) {
+      return <FailedSystem />;
+    }
     // Determine which failure chip to display based on the error reason.
     if (errorReason.actionType === 'notified') {
       if (errorReason.errorReason === 'email_error') {

--- a/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
+++ b/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
@@ -22,7 +22,7 @@ const AssignmentStatusTableCell = ({ row }) => {
     return null;
   }
 
-  // If learnerState is failed but no error reason is defined, don't display anything.
+  // If learnerState is failed but no error reason is defined, return a failed system chip.
   if (learnerState === 'failed' && !errorReason) {
     return <FailedSystem />;
   }

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -849,6 +849,15 @@ describe('<BudgetDetailPage />', () => {
     {
       learnerState: 'failed',
       hasLearnerEmail: true,
+      expectedChipStatus: 'Failed: System',
+      expectedModalPopupHeading: 'Failed: System',
+      expectedModalPopupContent: 'Something went wrong behind the scenes.',
+      actions: [mockFailedLinkedLearnerAction],
+      errorReason: null,
+    },
+    {
+      learnerState: 'failed',
+      hasLearnerEmail: true,
       expectedChipStatus: 'Failed: Cancellation',
       expectedModalPopupHeading: 'Failed: Cancellation',
       expectedModalPopupContent: 'Something went wrong behind the scenes.',


### PR DESCRIPTION
Returns a generalized failed system chip if no error reason exist and the learnerState is 'failed'.
Also refactors return string (capitalize first letter) using and existing utilities function

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
