### PR TITLE
fix: use correct aggregates properties and resolve JS error

### DIFF
--- a/.env.development-stage
+++ b/.env.development-stage
@@ -70,6 +70,7 @@ ACCOUNT_PROFILE_URL="https://profile.stage.edx.org"
 SUPPORT_URL="https://support.edx.org"
 ENTERPRISE_SUPPORT_URL="https://business-support.edx.org/hc/en-us"
 ENTERPRISE_SUPPORT_PROGRAM_OPTIMIZATION_URL="https://business.edx.org/hubfs/Onboarding%20and%20Engagement/Onboarding%20Assets/Admin%20Resources/Program%20Optimization.pdf?hsLang=en"
+ENTERPRISE_SUPPORT_LEARNER_CREDIT_URL='http://stage.edx.org'
 CONTACT_URL="https://courses.stage.edx.org/support/contact_us"
 OPEN_SOURCE_URL="https://open.edx.org"
 TERMS_OF_SERVICE_URL="https://stage.edx.org/edx-terms-service"

--- a/src/components/learner-credit-management/BudgetDetailPage.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPage.jsx
@@ -1,22 +1,28 @@
 import React from 'react';
 import { Skeleton, Stack } from '@edx/paragon';
 
-import { useBudgetId, useSubsidyAccessPolicy } from './data';
+import { useBudgetId, useEnterpriseOffer, useSubsidyAccessPolicy } from './data';
 import BudgetDetailTabsAndRoutes from './BudgetDetailTabsAndRoutes';
 import BudgetDetailPageWrapper from './BudgetDetailPageWrapper';
 import BudgetDetailPageHeader from './BudgetDetailPageHeader';
 import NotFoundPage from '../NotFoundPage';
 
 const BudgetDetailPage = () => {
-  const { subsidyAccessPolicyId } = useBudgetId();
+  const { enterpriseOfferId, subsidyAccessPolicyId } = useBudgetId();
   const {
     data: subsidyAccessPolicy,
     isInitialLoading: isSubsidyAccessPolicyInitialLoading,
     isError: isSubsidyAccessPolicyError,
     error,
   } = useSubsidyAccessPolicy(subsidyAccessPolicyId);
+  const {
+    data: enterpriseOffer,
+    isInitialLoading: isEnterpriseOfferInitialLoading,
+  } = useEnterpriseOffer(enterpriseOfferId);
 
-  if (isSubsidyAccessPolicyInitialLoading) {
+  const isLoading = isSubsidyAccessPolicyInitialLoading || isEnterpriseOfferInitialLoading;
+
+  if (isLoading) {
     return (
       <BudgetDetailPageWrapper includeHero={false}>
         <Skeleton height={25} />
@@ -35,7 +41,10 @@ const BudgetDetailPage = () => {
   }
 
   return (
-    <BudgetDetailPageWrapper subsidyAccessPolicy={subsidyAccessPolicy}>
+    <BudgetDetailPageWrapper
+      subsidyAccessPolicy={subsidyAccessPolicy}
+      enterpriseOffer={enterpriseOffer}
+    >
       <Stack gap={4}>
         <BudgetDetailPageHeader />
         <BudgetDetailTabsAndRoutes />

--- a/src/components/learner-credit-management/BudgetDetailPageHeader.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPageHeader.jsx
@@ -28,14 +28,7 @@ const BudgetStatusBadge = ({
   </Stack>
 );
 
-BudgetStatusBadge.propTypes = {
-  badgeVariant: PropTypes.string.isRequired,
-  status: PropTypes.string.isRequired,
-  term: PropTypes.string.isRequired,
-  date: PropTypes.string.isRequired,
-};
-
-const BudgetDetailPageHeader = ({ enterpriseUUID }) => {
+const BudgetDetailPageHeader = ({ enterpriseUUID, enterpriseFeatures }) => {
   const { subsidyAccessPolicyId, enterpriseOfferId } = useBudgetId();
   const budgetType = (enterpriseOfferId !== null) ? BUDGET_TYPES.ecommerce : BUDGET_TYPES.policy;
 
@@ -64,6 +57,7 @@ const BudgetDetailPageHeader = ({ enterpriseUUID }) => {
     subsidySummary,
     budgetId: policyOrOfferId,
     enterpriseOfferMetadata,
+    isTopDownAssignmentEnabled: enterpriseFeatures.topDownAssignmentRealTimeLcm,
   });
 
   if (!subsidyAccessPolicy && (isLoadingSubsidySummary || isLoadingEnterpriseOffer)) {
@@ -101,10 +95,21 @@ const BudgetDetailPageHeader = ({ enterpriseUUID }) => {
 
 const mapStateToProps = state => ({
   enterpriseUUID: state.portalConfiguration.enterpriseId,
+  enterpriseFeatures: state.portalConfiguration.enterpriseFeatures,
 });
 
 BudgetDetailPageHeader.propTypes = {
   enterpriseUUID: PropTypes.string.isRequired,
+  enterpriseFeatures: PropTypes.shape({
+    topDownAssignmentRealTimeLcm: PropTypes.bool,
+  }).isRequired,
+};
+
+BudgetStatusBadge.propTypes = {
+  badgeVariant: PropTypes.string.isRequired,
+  status: PropTypes.string.isRequired,
+  term: PropTypes.string.isRequired,
+  date: PropTypes.string.isRequired,
 };
 
 export default connect(mapStateToProps)(BudgetDetailPageHeader);

--- a/src/components/learner-credit-management/BudgetDetailPageHeader.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPageHeader.jsx
@@ -75,10 +75,6 @@ const BudgetDetailPageHeader = ({ enterpriseUUID }) => {
     );
   }
 
-  if (subsidyAccessPolicy === null && subsidySummary === null) {
-    return null;
-  }
-
   return (
     <Stack gap={2}>
       <BudgetDetailPageBreadcrumbs budgetDisplayName={budgetDisplayName} />

--- a/src/components/learner-credit-management/BudgetDetailPageOverviewAvailability.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPageOverviewAvailability.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import {
-  Button, Col, Hyperlink, ProgressBar, Row, Stack,
+  Button, Col, Hyperlink, ProgressBar, Row, Stack, useMediaQuery, breakpoints,
 } from '@edx/paragon';
 import { Add } from '@edx/paragon/icons';
 import { generatePath, useRouteMatch, Link } from 'react-router-dom';
@@ -40,9 +41,11 @@ const BudgetActions = ({ budgetId, isAssignable }) => {
   const routeMatch = useRouteMatch();
   const supportUrl = configuration.ENTERPRISE_SUPPORT_URL;
 
+  const isLargeScreenOrGreater = useMediaQuery({ query: `(min-width: ${breakpoints.small.minWidth}px)` });
+
   if (!isAssignable) {
     return (
-      <div className="h-100 d-flex align-items-center p-4 py-lg-0">
+      <div className="h-100 d-flex align-items-center pt-4 pt-lg-0">
         <div>
           <h4>Get people learning using this budget</h4>
           <p>
@@ -58,8 +61,8 @@ const BudgetActions = ({ budgetId, isAssignable }) => {
   }
 
   return (
-    <div className="d-flex justify-content-center p-4">
-      <div className="text-center">
+    <div className="h-100 d-flex align-items-center justify-content-center pt-4 pt-lg-0">
+      <div className={classNames({ 'text-center': isLargeScreenOrGreater })}>
         <h4>Get people learning using this budget</h4>
         <Button
           variant="brand"

--- a/src/components/learner-credit-management/BudgetDetailPageOverviewAvailability.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPageOverviewAvailability.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { connect } from 'react-redux';
 import {
   Button, Col, Hyperlink, ProgressBar, Row, Stack, useMediaQuery, breakpoints,
 } from '@edx/paragon';
@@ -49,7 +50,7 @@ const BudgetActions = ({ budgetId, isAssignable }) => {
         <div>
           <h4>Get people learning using this budget</h4>
           <p>
-            Funds from this budget are set to autoallocate to registered learners based on
+            Funds from this budget are set to auto-allocate to registered learners based on
             settings configured with your support team.
           </p>
           <Button variant="outline-primary" as={Hyperlink} destination={supportUrl} target="_blank">
@@ -86,13 +87,12 @@ BudgetActions.propTypes = {
   isAssignable: PropTypes.bool.isRequired,
 };
 
-const BudgetDetailPageOverviewAvailability = (
-  {
-    budgetId,
-    isAssignable,
-    budgetTotalSummary: { available, utilized, limit },
-  },
-) => (
+const BudgetDetailPageOverviewAvailability = ({
+  budgetId,
+  isAssignable,
+  budgetTotalSummary: { available, utilized, limit },
+  enterpriseFeatures,
+}) => (
   <Stack className="mt-4">
     <Row>
       <Col lg={7}>
@@ -101,7 +101,7 @@ const BudgetDetailPageOverviewAvailability = (
       <Col lg={5}>
         <BudgetActions
           budgetId={budgetId}
-          isAssignable={isAssignable}
+          isAssignable={isAssignable && enterpriseFeatures.topDownAssignmentRealTimeLcm}
         />
       </Col>
     </Row>
@@ -118,6 +118,13 @@ BudgetDetailPageOverviewAvailability.propTypes = {
   budgetId: PropTypes.string.isRequired,
   budgetTotalSummary: PropTypes.shape(budgetTotalSummaryShape).isRequired,
   isAssignable: PropTypes.bool.isRequired,
+  enterpriseFeatures: PropTypes.shape({
+    topDownAssignmentRealTimeLcm: PropTypes.bool,
+  }).isRequired,
 };
 
-export default BudgetDetailPageOverviewAvailability;
+const mapStateToProps = state => ({
+  enterpriseFeatures: state.portalConfiguration.enterpriseFeatures,
+});
+
+export default connect(mapStateToProps)(BudgetDetailPageOverviewAvailability);

--- a/src/components/learner-credit-management/BudgetDetailPageOverviewUtilization.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPageOverviewUtilization.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import {
   Stack, Collapsible, Row, Col, Button,
 } from '@edx/paragon';
@@ -10,19 +11,18 @@ import {
 } from 'react-router-dom';
 import { formatPrice } from './data';
 
-const BudgetDetailPageOverviewUtilization = (
-  {
-    budgetId,
-    budgetTotalSummary: { utilized },
-    budgetAggregates,
-    isAssignable,
-  },
-) => {
+const BudgetDetailPageOverviewUtilization = ({
+  budgetId,
+  budgetTotalSummary: { utilized },
+  budgetAggregates,
+  isAssignable,
+  enterpriseFeatures,
+}) => {
   const routeMatch = useRouteMatch();
 
   const { amountAllocatedUsd, amountRedeemedUsd } = budgetAggregates;
 
-  if (budgetId === null || utilized <= 0 || !isAssignable) {
+  if (!budgetId || !enterpriseFeatures.topDownAssignmentRealTimeLcm || utilized <= 0 || !isAssignable) {
     return null;
   }
 
@@ -74,12 +74,10 @@ const BudgetDetailPageOverviewUtilization = (
                       {formatPrice(amountAllocatedUsd)}
                     </Col>
                     <Col xl={7} className="text-right">
-                      {
-                        renderActivityLink({
-                          amount: amountAllocatedUsd,
-                          type: 'assigned',
-                        })
-                      }
+                      {renderActivityLink({
+                        amount: amountAllocatedUsd,
+                        type: 'assigned',
+                      })}
                     </Col>
                   </Row>
                   <Row>
@@ -88,12 +86,10 @@ const BudgetDetailPageOverviewUtilization = (
                       {formatPrice(amountRedeemedUsd)}
                     </Col>
                     <Col xl={7} lg={7} className="text-right">
-                      {
-                        renderActivityLink({
-                          amount: amountRedeemedUsd,
-                          type: 'spent',
-                        })
-                      }
+                      {renderActivityLink({
+                        amount: amountRedeemedUsd,
+                        type: 'spent',
+                      })}
                     </Col>
                   </Row>
                 </Stack>
@@ -122,6 +118,13 @@ BudgetDetailPageOverviewUtilization.propTypes = {
   budgetTotalSummary: PropTypes.shape(budgetTotalSummaryShape).isRequired,
   budgetAggregates: PropTypes.shape(budgetAggregatesShape).isRequired,
   isAssignable: PropTypes.bool.isRequired,
+  enterpriseFeatures: PropTypes.shape({
+    topDownAssignmentRealTimeLcm: PropTypes.bool,
+  }).isRequired,
 };
 
-export default BudgetDetailPageOverviewUtilization;
+const mapStateToProps = state => ({
+  enterpriseFeatures: state.portalConfiguration.enterpriseFeatures,
+});
+
+export default connect(mapStateToProps)(BudgetDetailPageOverviewUtilization);

--- a/src/components/learner-credit-management/BudgetDetailPageOverviewUtilization.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPageOverviewUtilization.jsx
@@ -67,7 +67,7 @@ const BudgetDetailPageOverviewUtilization = (
                   Your total utilization includes both assigned funds (earmarked for future enrollment) and spent
                   funds (redeemed for enrollment).
                 </p>
-                <Stack className="small font-weight-bold">
+                <Stack className="small">
                   <Row>
                     <Col xl={3} className="mt-auto mb-auto">Amount assigned</Col>
                     <Col className="mt-auto mb-auto text-right" data-testid="budget-utilization-assigned">

--- a/src/components/learner-credit-management/BudgetDetailPageWrapper.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPageWrapper.jsx
@@ -10,14 +10,28 @@ const PAGE_TITLE = 'Learner Credit Management';
 
 export const BudgetDetailPageContext = React.createContext();
 
+function getBudgetDisplayName({
+  subsidyAccessPolicy,
+  enterpriseOffer,
+}) {
+  let displayName = 'Overview';
+  if (subsidyAccessPolicy?.displayName) {
+    displayName = subsidyAccessPolicy.displayName;
+  } else if (enterpriseOffer?.displayName) {
+    displayName = enterpriseOffer.displayName;
+  }
+  return displayName;
+}
+
 const BudgetDetailPageWrapper = ({
   subsidyAccessPolicy,
+  enterpriseOffer,
   includeHero,
   children,
 }) => {
   // display name is an optional field, and may not be set for all budgets so fallback to "Overview"
   // similar to the display name logic for budgets on the overview page route.
-  const budgetDisplayName = subsidyAccessPolicy?.displayName || 'Overview';
+  const budgetDisplayName = getBudgetDisplayName({ subsidyAccessPolicy, enterpriseOffer });
   const helmetPageTitle = budgetDisplayName ? `${budgetDisplayName} - ${PAGE_TITLE}` : PAGE_TITLE;
 
   const successfulAssignmentToast = useSuccessfulAssignmentToastContextValue();
@@ -49,9 +63,7 @@ const BudgetDetailPageWrapper = ({
   }), [successfulAssignmentToast, successfulCancellationToast, successfulReminderToast]);
 
   return (
-    <BudgetDetailPageContext.Provider
-      value={values}
-    >
+    <BudgetDetailPageContext.Provider value={values}>
       <Helmet title={helmetPageTitle} />
       {includeHero && <Hero title={PAGE_TITLE} />}
       <Container className="py-3" fluid>
@@ -90,13 +102,19 @@ const BudgetDetailPageWrapper = ({
 
 BudgetDetailPageWrapper.propTypes = {
   children: PropTypes.node.isRequired,
-  subsidyAccessPolicy: PropTypes.shape(),
+  subsidyAccessPolicy: PropTypes.shape({
+    displayName: PropTypes.string,
+  }),
+  enterpriseOffer: PropTypes.shape({
+    displayName: PropTypes.string,
+  }),
   includeHero: PropTypes.bool,
 };
 
 BudgetDetailPageWrapper.defaultProps = {
   includeHero: true,
   subsidyAccessPolicy: undefined,
+  enterpriseOffer: undefined,
 };
 
 export default BudgetDetailPageWrapper;

--- a/src/components/learner-credit-management/BudgetDetailRedemptions.jsx
+++ b/src/components/learner-credit-management/BudgetDetailRedemptions.jsx
@@ -39,14 +39,15 @@ const BudgetDetailRedemptions = ({ enterpriseFeatures, enterpriseUUID }) => {
       <h3 className="mb-3" ref={spentHeadingRef}>Spent</h3>
       <p className="small mb-4">
         Spent activity is driven by completed enrollments.{' '}
-        <Hyperlink destination={getConfig().ENTERPRISE_SUPPORT_LEARNER_CREDIT_URL} target="_blank">
-          Learn more
-        </Hyperlink>
-        {(enterpriseOfferId || (subsidyAccessPolicyId && !enterpriseFeatures.topDownAssignmentRealTimeLcm)) && (
+        {(enterpriseOfferId || (subsidyAccessPolicyId && !enterpriseFeatures.topDownAssignmentRealTimeLcm)) ? (
           <>
             Enrollment data is automatically updated every 12 hours.
             Come back later to view more recent enrollments.
           </>
+        ) : (
+          <Hyperlink destination={getConfig().ENTERPRISE_SUPPORT_LEARNER_CREDIT_URL} target="_blank">
+            Learn more
+          </Hyperlink>
         )}
       </p>
       <LearnerCreditAllocationTable

--- a/src/components/learner-credit-management/data/hooks/useBudgetDetailHeaderData.js
+++ b/src/components/learner-credit-management/data/hooks/useBudgetDetailHeaderData.js
@@ -36,7 +36,7 @@ const assignBudgetStatus = (policy) => {
   };
 };
 
-const assignBudgetDetails = (policy) => {
+const assignBudgetDetails = (policy, isTopDownAssignmentEnabled) => {
   if (!policy.aggregates) {
     return {};
   }
@@ -45,11 +45,17 @@ const assignBudgetDetails = (policy) => {
 
   const available = spendAvailableUsd;
   const limit = policy.spendLimit / 100;
-  const utilized = policy.isAssignable
+  const utilized = policy.isAssignable && isTopDownAssignmentEnabled
     ? (amountAllocatedUsd + amountRedeemedUsd)
     : amountRedeemedUsd;
 
-  return { budgetTotalSummary: { available, limit, utilized } };
+  return {
+    budgetTotalSummary: {
+      available,
+      limit,
+      utilized,
+    },
+  };
 };
 
 const useBudgetDetailHeaderData = ({
@@ -57,6 +63,7 @@ const useBudgetDetailHeaderData = ({
   subsidySummary,
   budgetId,
   enterpriseOfferMetadata,
+  isTopDownAssignmentEnabled,
 }) => {
   const policy = subsidyAccessPolicy || transformSubsidySummaryToPolicy(subsidySummary, enterpriseOfferMetadata);
 
@@ -74,7 +81,7 @@ const useBudgetDetailHeaderData = ({
 
   if (policy) {
     Object.assign(transformedPolicyData, assignBudgetStatus(policy));
-    Object.assign(transformedPolicyData, assignBudgetDetails(policy));
+    Object.assign(transformedPolicyData, assignBudgetDetails(policy, isTopDownAssignmentEnabled));
   }
   return transformedPolicyData;
 };

--- a/src/components/learner-credit-management/data/hooks/useBudgetRedemptions.js
+++ b/src/components/learner-credit-management/data/hooks/useBudgetRedemptions.js
@@ -105,7 +105,9 @@ const useBudgetRedemptions = (
 
         setBudgetRedemptions({
           itemCount: data.count,
-          pageCount: data.numPages,
+          // If the data comes from the subsidy transactions endpoint, the number of pages is calculated
+          // TODO: https://2u-internal.atlassian.net/browse/ENT-8106
+          pageCount: data.numPages ?? Math.floor(data.count / options.pageSize),
           results: transformedTableResults,
         });
         if (shouldTrackFetchEvents.current) {

--- a/src/components/learner-credit-management/data/tests/constants.js
+++ b/src/components/learner-credit-management/data/tests/constants.js
@@ -94,31 +94,18 @@ export const mockPerLearnerSpendLimitSubsidyAccessPolicy = {
 };
 
 export const mockSubsidySummary = {
-  offerId: '84014',
-  budgets: [],
-  enterpriseCustomerUuid: '852eac48-b5a9-4849-8490-743f3f2deabf',
-  enterpriseName: 'Executive Education (2U) Integration QA',
-  sumAmountLearnerPaid: 0.0,
-  sumCoursePrice: 0.0,
-  status: 'Open',
+  budgetsSummary: [],
+  offerId: '1234',
   offerType: 'Site',
-  dateCreated: '2022-09-23T12:37:32Z',
-  emailsForUsageAlert: '',
-  discountType: 'percent_discount',
-  discountValue: 100.0,
-  maxDiscount: 50000.0,
-  totalDiscountEcommerce: 42024.0,
-  amountOfOfferSpent: 0.0,
-  percentOfOfferSpent: 0.0,
-  remainingBalance: 50000.0,
-  amountOfferSpentOcm: 0.0,
-  amountOfferSpentExecEd: 0.0,
-  exportTimestamp: '2023-12-04T06:47:54Z',
+  percentUtilized: 0.5,
+  redeemedFunds: 500,
+  remainingFunds: 500,
+  totalFunds: 1000,
 };
 
 export const mockEnterpriseOfferMetadata = {
   id: 99511,
   startDatetime: '2022-09-01T00:00:00Z',
   endDatetime: '2024-09-01T00:00:00Z',
-  displayName: 'Test enterprise',
+  displayName: 'Test Display Name',
 };

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -127,6 +127,7 @@ const mockLearnerContentAssignment = {
   recentAction: { actionType: 'assigned', timestamp: '2023-10-27' },
   actions: [mockSuccessfulLinkedLearnerAction, mockSuccessfulNotifiedAction],
   errorReason: null,
+  assignmentConfiguration: expect.any(Object),
 };
 const createMockLearnerContentAssignment = () => ({
   ...mockLearnerContentAssignment,
@@ -343,18 +344,23 @@ describe('<BudgetDetailPage />', () => {
     {
       subsidyAccessPolicy: null,
       subsidySummary: mockSubsidySummary,
+      enterpriseOfferMetadata: mockEnterpriseOfferMetadata,
       expected: {
         displayName: mockEnterpriseOfferMetadata.displayName,
-        spend: formatPrice(mockSubsidySummary.remainingBalance),
-        utilized: formatPrice(mockSubsidySummary.amountOfOfferSpent),
-        limit: formatPrice(mockSubsidySummary.maxDiscount),
+        spend: formatPrice(mockSubsidySummary.remainingFunds),
+        utilized: formatPrice(mockSubsidySummary.redeemedFunds),
+        limit: formatPrice(mockSubsidySummary.totalFunds),
         allocated: formatPrice(0),
-        redeemed: formatPrice(mockSubsidySummary.amountOfOfferSpent),
+        redeemed: formatPrice(mockSubsidySummary.redeemedFunds),
       },
       isLoading: false,
     },
   ])('render budget banner data (%s)', async ({
-    subsidyAccessPolicy, subsidySummary, expected, isLoading,
+    subsidyAccessPolicy,
+    subsidySummary,
+    enterpriseOfferMetadata,
+    expected,
+    isLoading,
   }) => {
     useParams.mockReturnValue({
       budgetId: 'a52e6548-649f-4576-b73f-c5c2bee25e9c',
@@ -378,7 +384,7 @@ describe('<BudgetDetailPage />', () => {
     });
     useEnterpriseOffer.mockReturnValue({
       isLoading: false,
-      data: mockEnterpriseOfferMetadata,
+      data: enterpriseOfferMetadata,
     });
     useBudgetRedemptions.mockReturnValue({
       isLoading: false,
@@ -415,7 +421,7 @@ describe('<BudgetDetailPage />', () => {
       }
     }
 
-    if ((subsidySummary || subsidySummary) && !isLoading) {
+    if ((subsidyAccessPolicy || subsidySummary) && !isLoading) {
       expect(screen.getByText(expected.displayName, { selector: 'h2' }));
 
       expect(screen.getByTestId('budget-detail-available')).toHaveTextContent(expected.spend);


### PR DESCRIPTION
# Description

Follow-up patch applied after merging the PR (https://github.com/openedx/frontend-app-admin-portal/pull/1110) to resolve the following:

1. When viewing an enterprise offer in the budget detail page and the analytics API errors/doesn't return data, there are a few JS errors thrown.
2. Incorrect field names were being associated for the `spendAvailableUsd ` and `amountRedeemedUsd ` fields within `transformSubsidySummaryToPolicy`.

## Enterprise Offer using stage data powered by analytics API

<img width="1508" alt="image" src="https://github.com/openedx/frontend-app-admin-portal/assets/2828721/da9f7507-8064-4ede-95ac-ff0c537d1949">

## Subsidy Access Policy using stage data powered by analytics API (LC2 feature flag disabled)

TODO Screenshot

## Subsidy Access Policy using stage data powered by subsidy access policies API (LC2 feature flag enabled)

<img width="1507" alt="image" src="https://github.com/openedx/frontend-app-admin-portal/assets/2828721/191430fa-a0de-4ed9-9095-c06b7a337c36">

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
