### PR TITLE
fix: update UI padding

### DIFF
--- a/src/components/learner-credit-management/SubBudgetCard.jsx
+++ b/src/components/learner-credit-management/SubBudgetCard.jsx
@@ -2,6 +2,7 @@ import { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
+import classNames from 'classnames';
 import {
   Card,
   Button,
@@ -42,6 +43,7 @@ const SubBudgetCard = ({
       data-testid="view-budget"
       as={Link}
       to={`/${enterpriseSlug}/admin/${ROUTE_NAMES.learnerCredit}/${budgetId}`}
+      variant={budgetLabel.status === BUDGET_STATUSES.expired ? 'outline-primary' : 'primary'}
     >
       View budget
     </Button>
@@ -49,26 +51,27 @@ const SubBudgetCard = ({
 
   const renderCardHeader = (budgetType, budgetId) => {
     const subtitle = (
-      <Stack direction="horizontal" gap={2.5} className="pb-4">
+      <Stack direction="horizontal" gap={2.5}>
         <Badge variant={budgetLabel.badgeVariant}>{budgetLabel.status}</Badge>
         <span data-testid="budget-date">
           {budgetLabel.term} {formattedDate}
         </span>
       </Stack>
     );
-    const action = budgetLabel.status !== BUDGET_STATUSES.scheduled
-      ? renderActions(budgetId)
-      : undefined;
+
     return (
-      <Stack direction="horizontal" className="justify-content-between">
-        <Card.Header
-          title={<BackgroundFetchingWrapper>{budgetType}</BackgroundFetchingWrapper>}
-          subtitle={<BackgroundFetchingWrapper>{subtitle}</BackgroundFetchingWrapper>}
-        />
-        <div className="pr-3">
-          {action && action}
-        </div>
-      </Stack>
+      <Card.Header
+        title={<BackgroundFetchingWrapper>{budgetType}</BackgroundFetchingWrapper>}
+        subtitle={<BackgroundFetchingWrapper>{subtitle}</BackgroundFetchingWrapper>}
+        actions={
+            budgetLabel.status !== BUDGET_STATUSES.scheduled
+              ? renderActions(budgetId)
+              : undefined
+          }
+        className={classNames('align-items-center', {
+          'mb-4.5': budgetLabel.status !== BUDGET_STATUSES.active,
+        })}
+      />
     );
   };
 
@@ -108,7 +111,7 @@ const SubBudgetCard = ({
       isLoading={isLoading}
     >
       <Card.Body>
-        <Stack>
+        <Stack gap={4.5}>
           {renderCardHeader(displayName || 'Overview', id)}
           {budgetLabel.status === BUDGET_STATUSES.active && renderCardSection()}
         </Stack>

--- a/src/components/learner-credit-management/SubBudgetCard.jsx
+++ b/src/components/learner-credit-management/SubBudgetCard.jsx
@@ -49,24 +49,26 @@ const SubBudgetCard = ({
 
   const renderCardHeader = (budgetType, budgetId) => {
     const subtitle = (
-      <Stack direction="horizontal" gap={2.5}>
+      <Stack direction="horizontal" gap={2.5} className="pb-4">
         <Badge variant={budgetLabel.badgeVariant}>{budgetLabel.status}</Badge>
         <span data-testid="budget-date">
           {budgetLabel.term} {formattedDate}
         </span>
       </Stack>
     );
-
+    const action = budgetLabel.status !== BUDGET_STATUSES.scheduled
+      ? renderActions(budgetId)
+      : undefined;
     return (
-      <Card.Header
-        title={<BackgroundFetchingWrapper>{budgetType}</BackgroundFetchingWrapper>}
-        subtitle={<BackgroundFetchingWrapper>{subtitle}</BackgroundFetchingWrapper>}
-        actions={
-          budgetLabel.status !== BUDGET_STATUSES.scheduled
-            ? renderActions(budgetId)
-            : undefined
-        }
-      />
+      <Stack direction="horizontal" className="justify-content-between">
+        <Card.Header
+          title={<BackgroundFetchingWrapper>{budgetType}</BackgroundFetchingWrapper>}
+          subtitle={<BackgroundFetchingWrapper>{subtitle}</BackgroundFetchingWrapper>}
+        />
+        <div className="pr-3">
+          {action && action}
+        </div>
+      </Stack>
     );
   };
 
@@ -106,9 +108,9 @@ const SubBudgetCard = ({
       isLoading={isLoading}
     >
       <Card.Body>
-        <Stack gap={4}>
+        <Stack>
           {renderCardHeader(displayName || 'Overview', id)}
-          {budgetLabel.status !== BUDGET_STATUSES.scheduled && renderCardSection()}
+          {budgetLabel.status === BUDGET_STATUSES.active && renderCardSection()}
         </Stack>
       </Card.Body>
     </Card>


### PR DESCRIPTION
Updates UI components to match figma output for scheduled, expired, and a centered 'view budget' button.

Figma:
![Screenshot 2023-12-11 at 11 32 47 AM](https://github.com/openedx/frontend-app-admin-portal/assets/82611798/a8b47336-5847-488c-b8e2-ce0104f6301d)


Previous UI:
![Screenshot 2023-12-11 at 11 33 49 AM](https://github.com/openedx/frontend-app-admin-portal/assets/82611798/f0973d52-3355-4b1f-b766-33b901576640)


Updated UI:
![Screenshot 2023-12-11 at 12 47 37 PM](https://github.com/openedx/frontend-app-admin-portal/assets/82611798/7662b98d-2f42-422c-a13c-0346650f08fb)


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
