### PR TITLE
fix: replace pending with assigned in budget cards

### DIFF
--- a/src/components/learner-credit-management/SubBudgetCard.jsx
+++ b/src/components/learner-credit-management/SubBudgetCard.jsx
@@ -89,7 +89,7 @@ const SubBudgetCard = ({
         </Col>
         {isAssignable && (
           <Col xs="6" md="auto" className="mb-3 mb-md-0">
-            <div className="small font-weight-bold">Pending</div>
+            <div className="small font-weight-bold">Assigned</div>
             <span className="small">
               {isFetchingBudgets ? <Skeleton /> : formatPrice(pending)}
             </span>

--- a/src/components/learner-credit-management/tests/BudgetCard.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetCard.test.jsx
@@ -523,10 +523,10 @@ describe('<BudgetCard />', () => {
     expect(screen.getByText('Available')).toBeInTheDocument();
     expect(screen.getByText(formatPrice(mockBudgetAggregates.available))).toBeInTheDocument();
     if (isAssignableBudget) {
-      expect(screen.getByText('Pending')).toBeInTheDocument();
+      expect(screen.getByText('Assigned')).toBeInTheDocument();
       expect(screen.getByText(formatPrice(mockBudgetAggregates.pending))).toBeInTheDocument();
     } else {
-      expect(screen.queryByText('Pending')).not.toBeInTheDocument();
+      expect(screen.queryByText('Assigned')).not.toBeInTheDocument();
     }
     expect(screen.getByText('Spent')).toBeInTheDocument();
     expect(screen.getByText(formatPrice(mockBudgetAggregates.spent))).toBeInTheDocument();


### PR DESCRIPTION
# Description

Based on feedback from Jenn (UX), changing the assignable budget cards to say "Assigned" instead of "Pending" in the balances card section to be consistent with the language used on the budget detail page.

![image](https://github.com/openedx/frontend-app-admin-portal/assets/2828721/f5b19a69-fc10-41f9-b71d-440f8ee07cab)

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [x] Ensure to have UX team confirm screenshots
