### PR TITLE
fix: support remind/cancel-all

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,31 @@ module.exports = {
 
 NB: In order for webpack to properly resolve scss imports locally, you must use a `~` before the import, like so: `@import "~@edx/brand/paragon/fonts";`
 
+### Running tests
+
+You can run all tests as follows:
+```
+nvm use
+npm install
+npm run test
+```
+
+Additionally, you can run a single test file with
+```
+npm run test -- ProvisioningFormSubmissionButton.test.jsx
+```
+
+or run a given test function by appending a `.only` to the test function (or appending `.skip` to do the inverse).
+For example: `test.only('your test function', () => {...})`.
+
+You can use watch mode with tests as follows:
+```
+npm run test:watch BudgetDetailPage.test.jsx
+# or to skip coverage reporting
+npm run test:watch-no-cov BudgetDetailpage.test.jsx
+```
+Note the watcher has its own set of commands to help run test functions that match a regex (`t my regex`), etc.
+Use the `w` command to get a list of valid watch commands.
 
 ## Getting Help
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "debug-test": "node --inspect-brk node_modules/.bin/jest --runInBand --coverage",
     "test": "TZ=UTC fedx-scripts jest --coverage --passWithNoTests --maxWorkers=50%",
     "test:watch": "npm run test -- --watch",
+    "test:watch-no-cov": "npm run test -- --watch --collectCoverage=false",
     "snapshot": "fedx-scripts jest --updateSnapshot"
   },
   "license": "AGPL-3.0",

--- a/src/components/learner-credit-management/AssignmentTableCancel.jsx
+++ b/src/components/learner-credit-management/AssignmentTableCancel.jsx
@@ -5,7 +5,18 @@ import { DoNotDisturbOn } from '@edx/paragon/icons';
 import CancelAssignmentModal from './CancelAssignmentModal';
 import useCancelContentAssignments from './data/hooks/useCancelContentAssignments';
 
-const AssignmentTableCancelAction = ({ selectedFlatRows }) => {
+const calculateTotalToCancel = ({
+  assignmentUuids,
+  isEntireTableSelected,
+  tableItemCount,
+}) => {
+  if (isEntireTableSelected) {
+    return tableItemCount;
+  }
+  return assignmentUuids.length;
+};
+
+const AssignmentTableCancelAction = ({ selectedFlatRows, isEntireTableSelected, tableInstance }) => {
   const assignmentUuids = selectedFlatRows.map(row => row.id);
   const assignmentConfigurationUuid = selectedFlatRows[0].original.assignmentConfiguration;
   const {
@@ -14,19 +25,26 @@ const AssignmentTableCancelAction = ({ selectedFlatRows }) => {
     close,
     isOpen,
     open,
-  } = useCancelContentAssignments(assignmentConfigurationUuid, assignmentUuids);
+  } = useCancelContentAssignments(assignmentConfigurationUuid, assignmentUuids, isEntireTableSelected);
+
+  const tableItemCount = tableInstance.itemCount;
+  const totalToCancel = calculateTotalToCancel({
+    assignmentUuids,
+    isEntireTableSelected,
+    tableItemCount,
+  });
 
   return (
     <>
       <Button variant="danger" iconBefore={DoNotDisturbOn} onClick={open}>
-        {`Cancel (${assignmentUuids.length})`}
+        {`Cancel (${totalToCancel})`}
       </Button>
       <CancelAssignmentModal
         cancelContentAssignments={cancelContentAssignments}
         close={close}
         isOpen={isOpen}
         cancelButtonState={cancelButtonState}
-        uuidCount={assignmentUuids.length}
+        uuidCount={totalToCancel}
       />
     </>
   );
@@ -34,10 +52,18 @@ const AssignmentTableCancelAction = ({ selectedFlatRows }) => {
 
 AssignmentTableCancelAction.propTypes = {
   selectedFlatRows: PropTypes.arrayOf(PropTypes.shape()),
+  isEntireTableSelected: PropTypes.bool,
+  tableInstance: PropTypes.shape({
+    itemCount: PropTypes.number.isRequired,
+  }),
 };
 
 AssignmentTableCancelAction.defaultProps = {
   selectedFlatRows: [],
+  isEntireTableSelected: false,
+  tableInstance: {
+    itemCount: 0,
+  },
 };
 
 export default AssignmentTableCancelAction;

--- a/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
+++ b/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
@@ -117,7 +117,7 @@ const BudgetAssignmentsTable = ({
       pageCount={tableData.numPages || 1}
       EmptyTableComponent={CustomDataTableEmptyState}
       bulkActions={[
-        <AssignmentTableRemindAction />,
+        <AssignmentTableRemindAction learnerStateCounts={tableData.learnerStateCounts} />,
         <AssignmentTableCancelAction />,
       ]}
     />

--- a/src/components/learner-credit-management/data/hooks/useCancelContentAssignments.js
+++ b/src/components/learner-credit-management/data/hooks/useCancelContentAssignments.js
@@ -10,6 +10,7 @@ import useBudgetId from './useBudgetId';
 const useCancelContentAssignments = (
   assignmentConfigurationUuid,
   assignmentUuids,
+  cancelAll = false,
 ) => {
   const [isOpen, open, close] = useToggle(false);
   const [cancelButtonState, setCancelButtonState] = useState('default');
@@ -19,7 +20,11 @@ const useCancelContentAssignments = (
   const cancelContentAssignments = useCallback(async () => {
     setCancelButtonState('pending');
     try {
-      await EnterpriseAccessApiService.cancelContentAssignments(assignmentConfigurationUuid, assignmentUuids);
+      if (cancelAll) {
+        await EnterpriseAccessApiService.cancelAllContentAssignments(assignmentConfigurationUuid);
+      } else {
+        await EnterpriseAccessApiService.cancelContentAssignments(assignmentConfigurationUuid, assignmentUuids);
+      }
       setCancelButtonState('complete');
       queryClient.invalidateQueries({
         queryKey: learnerCreditManagementQueryKeys.budget(subsidyAccessPolicyId),
@@ -28,7 +33,7 @@ const useCancelContentAssignments = (
       logError(err);
       setCancelButtonState('error');
     }
-  }, [assignmentConfigurationUuid, assignmentUuids, queryClient, subsidyAccessPolicyId]);
+  }, [assignmentConfigurationUuid, assignmentUuids, cancelAll, queryClient, subsidyAccessPolicyId]);
 
   return {
     cancelButtonState,

--- a/src/components/learner-credit-management/data/hooks/useRemindContentAssignments.js
+++ b/src/components/learner-credit-management/data/hooks/useRemindContentAssignments.js
@@ -10,6 +10,7 @@ import useBudgetId from './useBudgetId';
 const useRemindContentAssignments = (
   assignmentConfigurationUuid,
   assignmentUuids,
+  remindAll = false,
 ) => {
   const [isOpen, open, close] = useToggle(false);
   const [remindButtonState, setRemindButtonState] = useState('default');
@@ -19,7 +20,11 @@ const useRemindContentAssignments = (
   const remindContentAssignments = useCallback(async () => {
     setRemindButtonState('pending');
     try {
-      await EnterpriseAccessApiService.remindContentAssignments(assignmentConfigurationUuid, assignmentUuids);
+      if (remindAll) {
+        await EnterpriseAccessApiService.remindAllContentAssignments(assignmentConfigurationUuid);
+      } else {
+        await EnterpriseAccessApiService.remindContentAssignments(assignmentConfigurationUuid, assignmentUuids);
+      }
       setRemindButtonState('complete');
       queryClient.invalidateQueries({
         queryKey: learnerCreditManagementQueryKeys.budget(subsidyAccessPolicyId),
@@ -28,7 +33,7 @@ const useRemindContentAssignments = (
       logError(err);
       setRemindButtonState('error');
     }
-  }, [assignmentConfigurationUuid, assignmentUuids, queryClient, subsidyAccessPolicyId]);
+  }, [assignmentConfigurationUuid, assignmentUuids, remindAll, queryClient, subsidyAccessPolicyId]);
 
   return {
     remindButtonState,

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -1453,7 +1453,7 @@ describe('<BudgetDetailPage />', () => {
   });
 
   it('cancels assignments in bulk', async () => {
-    EnterpriseAccessApiService.cancelContentAssignments.mockResolvedValueOnce({ status: 200 });
+    EnterpriseAccessApiService.cancelAllContentAssignments.mockResolvedValueOnce({ status: 200 });
     useParams.mockReturnValue({
       budgetId: mockSubsidyAccessPolicyUUID,
       activeTabKey: 'activity',
@@ -1520,16 +1520,18 @@ describe('<BudgetDetailPage />', () => {
     expect(modalDialog).toBeInTheDocument();
     const cancelDialogButton = getButtonElement('Cancel assignments (2)');
     userEvent.click(cancelDialogButton);
-    expect(
-      EnterpriseAccessApiService.cancelContentAssignments,
-    ).toHaveBeenCalled();
+    await waitFor(
+      () => expect(
+        EnterpriseAccessApiService.cancelAllContentAssignments,
+      ).toHaveBeenCalled(),
+    );
     await waitFor(
       () => expect(screen.getByText('Assignments canceled (2)')).toBeInTheDocument(),
     );
   });
 
   it('reminds assignments in bulk', async () => {
-    EnterpriseAccessApiService.remindContentAssignments.mockResolvedValueOnce({ status: 200 });
+    EnterpriseAccessApiService.remindAllContentAssignments.mockResolvedValueOnce({ status: 202 });
     useParams.mockReturnValue({
       budgetId: mockSubsidyAccessPolicyUUID,
       activeTabKey: 'activity',
@@ -1553,7 +1555,7 @@ describe('<BudgetDetailPage />', () => {
     useBudgetContentAssignments.mockReturnValue({
       isLoading: false,
       contentAssignments: {
-        count: 2,
+        count: 3,
         results: [
           {
             uuid: 'test-uuid1',
@@ -1575,10 +1577,20 @@ describe('<BudgetDetailPage />', () => {
             errorReason: null,
             state: 'allocated',
           },
+          {
+            uuid: 'test-uuid3',
+            contentKey: mockCourseKey,
+            contentQuantity: -29900,
+            learnerState: 'notifying',
+            recentAction: { actionType: 'assigned', timestamp: '2023-11-27' },
+            actions: [mockSuccessfulNotifiedAction],
+            errorReason: null,
+            state: 'allocated',
+          },
         ],
         learnerStateCounts: [
-          { learnerState: 'waiting', count: 1 },
-          { learnerState: 'waiting', count: 1 },
+          { learnerState: 'waiting', count: 2 },
+          { learnerState: 'notifying', count: 1 },
         ],
         numPages: 1,
         currentPage: 1,
@@ -1596,9 +1608,11 @@ describe('<BudgetDetailPage />', () => {
     expect(modalDialog).toBeInTheDocument();
     const remindDialogButton = getButtonElement('Send reminders (2)');
     userEvent.click(remindDialogButton);
-    expect(
-      EnterpriseAccessApiService.remindContentAssignments,
-    ).toHaveBeenCalled();
+    await waitFor(
+      () => expect(
+        EnterpriseAccessApiService.remindAllContentAssignments,
+      ).toHaveBeenCalled(),
+    );
     await waitFor(
       () => expect(screen.getByText('Reminders sent (2)')).toBeInTheDocument(),
     );

--- a/src/data/services/EnterpriseAccessApiService.js
+++ b/src/data/services/EnterpriseAccessApiService.js
@@ -185,6 +185,14 @@ class EnterpriseAccessApiService {
   }
 
   /**
+   * Cancel ALL content assignments for a specific AssignmentConfiguration.
+   */
+  static cancelAllContentAssignments(assignmentConfigurationUUID) {
+    const url = `${EnterpriseAccessApiService.baseUrl}/assignment-configurations/${assignmentConfigurationUUID}/admin/assignments/cancel-all/`;
+    return EnterpriseAccessApiService.apiClient().post(url);
+  }
+
+  /**
    * Remind content assignments for a specific AssignmentConfiguration.
    */
   static remindContentAssignments(assignmentConfigurationUUID, assignmentUuids) {
@@ -193,6 +201,14 @@ class EnterpriseAccessApiService {
     };
     const url = `${EnterpriseAccessApiService.baseUrl}/assignment-configurations/${assignmentConfigurationUUID}/admin/assignments/remind/`;
     return EnterpriseAccessApiService.apiClient().post(url, options);
+  }
+
+  /**
+   * Remind ALL content assignments for a specific AssignmentConfiguration.
+   */
+  static remindAllContentAssignments(assignmentConfigurationUUID) {
+    const url = `${EnterpriseAccessApiService.baseUrl}/assignment-configurations/${assignmentConfigurationUUID}/admin/assignments/remind-all/`;
+    return EnterpriseAccessApiService.apiClient().post(url);
   }
 
   /**

--- a/src/data/services/tests/EnterpriseAccessApiService.test.js
+++ b/src/data/services/tests/EnterpriseAccessApiService.test.js
@@ -201,7 +201,7 @@ describe('EnterpriseAccessApiService', () => {
     );
   });
 
-  test('remindContentAssignments calls enterprise-access cancel POST API to remind learners', () => {
+  test('remindContentAssignments calls enterprise-access remind POST API to remind learners', () => {
     const options = {
       assignment_uuids: mockAssignmentUUIDs,
     };
@@ -209,6 +209,20 @@ describe('EnterpriseAccessApiService', () => {
     expect(axios.post).toBeCalledWith(
       `${enterpriseAccessBaseUrl}/api/v1/assignment-configurations/${mockAssignmentConfigurationUUID}/admin/assignments/remind/`,
       options,
+    );
+  });
+
+  test('cancelAllContentAssignments calls enterprise-access cancel-all POST API to cancel all assignments', () => {
+    EnterpriseAccessApiService.cancelAllContentAssignments(mockAssignmentConfigurationUUID);
+    expect(axios.post).toBeCalledWith(
+      `${enterpriseAccessBaseUrl}/api/v1/assignment-configurations/${mockAssignmentConfigurationUUID}/admin/assignments/cancel-all/`,
+    );
+  });
+
+  test('remindAllContentAssignments calls enterprise-access remind-all POST API to remind all learners', () => {
+    EnterpriseAccessApiService.remindAllContentAssignments(mockAssignmentConfigurationUUID);
+    expect(axios.post).toBeCalledWith(
+      `${enterpriseAccessBaseUrl}/api/v1/assignment-configurations/${mockAssignmentConfigurationUUID}/admin/assignments/remind-all/`,
     );
   });
 });


### PR DESCRIPTION
Makes use of the `remind-all` and `cancel-all` endpoints to cancel/remind all assignments when the "all" checkbox is selected on the assignments table.

Selected, but not "select all"
<img width="1458" alt="image" src="https://github.com/openedx/frontend-app-admin-portal/assets/2307986/b11e6c34-0338-4259-a62c-3d8278e671a5">

Now all are selected, but one of the assignments is errored (not in waiting state), so it's not remindable
![image](https://github.com/openedx/frontend-app-admin-portal/assets/2307986/a6b6ad4a-14bf-4724-939c-60038801ab72)

Click the Cancel button, the cancel modal has all 27 as the number to cancel
<img width="856" alt="image" src="https://github.com/openedx/frontend-app-admin-portal/assets/2307986/2d12dd2e-5edb-4d10-a6ac-d4113d1f5dfe">

Go back, check out the remind modal:
![image](https://github.com/openedx/frontend-app-admin-portal/assets/2307986/01dc94d4-484c-452f-b3a8-8a76ec79d789)

Now do the remind-all action - only 26 reminders sent, b/c only 26 are remindable
![image](https://github.com/openedx/frontend-app-admin-portal/assets/2307986/d2af1a9b-b8a6-427b-8a5e-e09662664412)

Now select all and do the cancel-all action:
<img width="875" alt="image" src="https://github.com/openedx/frontend-app-admin-portal/assets/2307986/ddc29bc1-6f77-43dd-bbd5-20f1b9f9bc92">


# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
