### PR TITLE
feat: add assignment status chip for a failed redemption

### DIFF
--- a/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
+++ b/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
@@ -4,6 +4,7 @@ import {
 import PropTypes from 'prop-types';
 import FailedBadEmail from './assignments-status-chips/FailedBadEmail';
 import FailedCancellation from './assignments-status-chips/FailedCancellation';
+import FailedRedemption from './assignments-status-chips/FailedRedemption';
 import FailedReminder from './assignments-status-chips/FailedReminder';
 import FailedSystem from './assignments-status-chips/FailedSystem';
 import NotifyingLearner from './assignments-status-chips/NotifyingLearner';
@@ -36,17 +37,19 @@ const AssignmentStatusTableCell = ({ row }) => {
   }
 
   if (learnerState === 'failed') {
-    // If learnerState is failed but no error reason is defined, return a failed system chip.
+    // If learnerState is failed but no top-level error reason is defined, return a failed system chip.
     if (!errorReason) {
       return <FailedSystem />;
     }
-    // Determine which failure chip to display based on the error reason.
+    // Determine which failure chip to display based on the top level errorReason. In most cases, the actual errorReason
+    // code is ignored, in which case we key off the actionType.
     if (errorReason.actionType === 'notified') {
       if (errorReason.errorReason === 'email_error') {
         return (
           <FailedBadEmail learnerEmail={learnerEmail} />
         );
       }
+      // non-email errors on failed notifications should NOT use the FailedBadEmail chip.
       return <FailedSystem />;
     }
     if (errorReason.actionType === 'cancelled') {
@@ -55,6 +58,11 @@ const AssignmentStatusTableCell = ({ row }) => {
     if (errorReason.actionType === 'reminded') {
       return <FailedReminder />;
     }
+    if (errorReason.actionType === 'redeemed') {
+      return <FailedRedemption />;
+    }
+    // In all other unexpected cases, return a failed system chip.
+    return <FailedSystem />;
   }
 
   // Note: The given `learnerState` not officially supported with a `ModalPopup`, but display it anyway.

--- a/src/components/learner-credit-management/assignments-status-chips/FailedRedemption.jsx
+++ b/src/components/learner-credit-management/assignments-status-chips/FailedRedemption.jsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import { Chip, Hyperlink, useToggle } from '@edx/paragon';
+import { Error } from '@edx/paragon/icons';
+import { getConfig } from '@edx/frontend-platform/config';
+
+import BaseModalPopup from './BaseModalPopup';
+
+const FailedRedemption = () => {
+  const [isOpen, open, close] = useToggle(false);
+  const [target, setTarget] = useState(null);
+
+  return (
+    <>
+      <Chip
+        ref={setTarget}
+        iconBefore={Error}
+        onClick={open}
+        onKeyPress={open}
+        tabIndex={0}
+      >
+        Failed: Redemption
+      </Chip>
+      <BaseModalPopup
+        positionRef={target}
+        isOpen={isOpen}
+        onClose={close}
+      >
+        <BaseModalPopup.Heading icon={Error} iconClassName="text-danger">
+          Failed: Redemption
+        </BaseModalPopup.Heading>
+        <BaseModalPopup.Content>
+          <p>
+            Something went wrong behind the scenes when the learner attempted to redeem this course assignment.
+            Associated Learner credit funds have been released into your available balance.
+          </p>
+          <div className="micro">
+            <p className="h6">Resolution steps</p>
+            <ul className="text-gray pl-3">
+              <li>
+                Try assigning this content to the learner again.
+              </li>
+              <li>
+                If the issue continues, contact customer support.
+              </li>
+              <li>
+                Get more troubleshooting help at{' '}
+                <Hyperlink destination={getConfig().ENTERPRISE_SUPPORT_LEARNER_CREDIT_URL} target="_blank">
+                  Help Center: Course Assignments
+                </Hyperlink>.
+              </li>
+            </ul>
+          </div>
+        </BaseModalPopup.Content>
+      </BaseModalPopup>
+    </>
+  );
+};
+
+export default FailedRedemption;

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -167,6 +167,12 @@ const mockFailedReminderLearnerAction = {
   errorReason: 'email_error',
 };
 
+const mockFailedRedemptionLearnerAction = {
+  actionType: 'redeemed',
+  completedAt: null,
+  errorReason: 'enrollment_error',
+};
+
 const defaultEnterpriseSubsidiesContextValue = {
   isLoading: false,
 };
@@ -1046,6 +1052,8 @@ describe('<BudgetDetailPage />', () => {
         actionType: 'notified',
       },
     },
+    // This test case is weird because we always serialize the latest failed action into error_reason in the assignment
+    // API response.  Nevertheless, keep it in just to cover potential backend serializer bugs.
     {
       learnerState: 'failed',
       hasLearnerEmail: true,
@@ -1089,6 +1097,21 @@ describe('<BudgetDetailPage />', () => {
       errorReason: {
         errorReason: 'internal_api_error',
         actionType: 'reminded',
+      },
+    },
+    {
+      learnerState: 'failed',
+      hasLearnerEmail: true,
+      expectedChipStatus: 'Failed: Redemption',
+      expectedModalPopupHeading: 'Failed: Redemption',
+      expectedModalPopupContent: (
+        'Something went wrong behind the scenes when the learner attempted to redeem this course assignment. '
+        + 'Associated Learner credit funds have been released into your available balance.'
+      ),
+      actions: [mockSuccessfulLinkedLearnerAction, mockSuccessfulNotifiedAction, mockFailedRedemptionLearnerAction],
+      errorReason: {
+        actionType: mockFailedRedemptionLearnerAction.actionType,
+        errorReason: mockFailedRedemptionLearnerAction.errorReason,
       },
     },
   ])('renders correct status chips with assigned table data (%s)', ({


### PR DESCRIPTION
This is the frontend component corresponding to:
https://github.com/openedx/enterprise-access/pull/364

Before this change, failed redemptions would result in the frontend displaying a "Failed: System" chip, which is a generic fallback.  After this change, an explicit "Failed: Redemption" chip is displayed.

ENT-8105

![image](https://github.com/openedx/frontend-app-admin-portal/assets/85151/156db8f9-05e4-40e1-ad8a-2887559e10da)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
