### PR TITLE
chore: Update to the new version of paragon in the new scope.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@edx/frontend-enterprise-logistration": "3.2.0",
         "@edx/frontend-enterprise-utils": "3.2.0",
         "@edx/frontend-platform": "4.0.1",
-        "@edx/paragon": "20.46.3",
+        "@openedx/paragon": "21.5.7",
         "@tanstack/react-query": "4.36.1",
         "@tanstack/react-query-devtools": "4.36.1",
         "algoliasearch": "4.8.3",
@@ -3599,6 +3599,7 @@
       "version": "20.46.3",
       "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-20.46.3.tgz",
       "integrity": "sha512-cHxoxoOREVFbBqW9IRAtlIAQo1lcF9JJXkLoEw1Vam6oetKSa5Mc0SL5kykbV+1iRPP7kS8A0Csf5nRr0oolLQ==",
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",
@@ -3637,6 +3638,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.1.tgz",
       "integrity": "sha512-Sz07mnQrTekFWLz5BMjOzHl/+NooTdW8F8kDQxjWwbpOJcnoSg4vUDng8d/WR1wOxM0O+CY9Zw0nR054riNYtQ==",
       "hasInstallScript": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3646,6 +3648,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.2.1.tgz",
       "integrity": "sha512-HELwwbCz6C1XEcjzyT1Jugmz2NNklMrSPjZOWMlc+ZsHIVk+XOvOXLGGQtFBwSyqfJDNgRq4xBCwWOaZ/d9DEA==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.2.1"
       },
@@ -3653,22 +3656,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/@edx/paragon/node_modules/@fortawesome/react-fontawesome": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.19.tgz",
-      "integrity": "sha512-Hyb+lB8T18cvLNX0S3llz7PcSOAJMLwiVKBuuzwM/nI5uoBw+gQjnf9il0fR1C3DKOI5Kc79pkJ4/xB0Uw9aFQ==",
-      "dependencies": {
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
-        "react": ">=16.x"
-      }
-    },
     "node_modules/@edx/paragon/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -3676,12 +3668,14 @@
     "node_modules/@edx/paragon/node_modules/classnames": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
+      "peer": true
     },
     "node_modules/@edx/paragon/node_modules/glob": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
       "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3700,6 +3694,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
       "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -3711,6 +3706,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -4024,16 +4020,25 @@
       }
     },
     "node_modules/@fortawesome/react-fontawesome": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.14.tgz",
-      "integrity": "sha512-4wqNb0gRLVaBm/h+lGe8UfPPivcbuJ6ecI4hIgW0LjI7kzpYB9FkN0L9apbVzg+lsBdcTf0AlBtODjcSX5mmKA==",
-      "peer": true,
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.19.tgz",
+      "integrity": "sha512-Hyb+lB8T18cvLNX0S3llz7PcSOAJMLwiVKBuuzwM/nI5uoBw+gQjnf9il0fR1C3DKOI5Kc79pkJ4/xB0Uw9aFQ==",
       "dependencies": {
-        "prop-types": "^15.7.2"
+        "prop-types": "^15.8.1"
       },
       "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "^1.2.32",
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
         "react": ">=16.x"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome/node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
       }
     },
     "node_modules/@fullhuman/postcss-purgecss": {
@@ -5199,6 +5204,186 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@openedx/paragon": {
+      "version": "21.5.7",
+      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-21.5.7.tgz",
+      "integrity": "sha512-lgS9wLRlRKsN99Bo30QOwyPyZ0UeH2g7S6Vut2i9tWIa2km8vfzZZb4k+oR/8HACbJyYQ9Zz0RaWk95eTAAKSw==",
+      "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.1.1",
+        "@fortawesome/react-fontawesome": "^0.1.18",
+        "@popperjs/core": "^2.11.4",
+        "bootstrap": "^4.6.2",
+        "chalk": "^4.1.2",
+        "child_process": "^1.0.2",
+        "classnames": "^2.3.1",
+        "email-prop-type": "^3.0.0",
+        "file-selector": "^0.6.0",
+        "font-awesome": "^4.7.0",
+        "glob": "^8.0.3",
+        "inquirer": "^8.2.5",
+        "lodash.uniqby": "^4.7.0",
+        "mailto-link": "^2.0.0",
+        "prop-types": "^15.8.1",
+        "react-bootstrap": "^1.6.5",
+        "react-colorful": "^5.6.1",
+        "react-dropzone": "^14.2.1",
+        "react-focus-on": "^3.5.4",
+        "react-loading-skeleton": "^3.1.0",
+        "react-popper": "^2.2.5",
+        "react-proptype-conditional-require": "^1.0.4",
+        "react-responsive": "^8.2.0",
+        "react-table": "^7.7.0",
+        "react-transition-group": "^4.4.2",
+        "tabbable": "^5.3.3",
+        "uncontrollable": "^7.2.1",
+        "uuid": "^9.0.0"
+      },
+      "bin": {
+        "paragon": "bin/paragon-scripts.js"
+      },
+      "peerDependencies": {
+        "react": "^16.8.6 || ^17.0.0",
+        "react-dom": "^16.8.6 || ^17.0.0",
+        "react-intl": "^5.25.1 || ^6.4.0"
+      }
+    },
+    "node_modules/@openedx/paragon/node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.1.tgz",
+      "integrity": "sha512-GkWzv+L6d2bI5f/Vk6ikJ9xtl7dfXtoRu3YGE6nq0p/FFqA1ebMOAWg3XgRyb0I6LYyYkiAo+3/KrwuBp8xG7A==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@openedx/paragon/node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.1.tgz",
+      "integrity": "sha512-MfRCYlQPXoLlpem+egxjfkEuP9UQswTrlCOsknus/NcMoblTH2g0jPrapbcIb04KGA7E2GZxbAccGZfWoYgsrQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@openedx/paragon/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@openedx/paragon/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@openedx/paragon/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@openedx/paragon/node_modules/classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+    },
+    "node_modules/@openedx/paragon/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@openedx/paragon/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/@openedx/paragon/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@openedx/paragon/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@openedx/paragon/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@openedx/paragon/node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/@openedx/paragon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -8533,6 +8718,11 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+    },
     "node_modules/cheerio": {
       "version": "1.0.0-rc.12",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
@@ -8570,6 +8760,11 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/child_process": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
+      "integrity": "sha512-Wmza/JzL0SiWz7kl6MhIKT5ceIlnFPJX+lwUGj7Clhy5MMldsSoJR0+uvRzOS5Kv45Mq7t1PoE8TsOA9bzvb6g=="
     },
     "node_modules/chokidar": {
       "version": "3.5.3",
@@ -8765,6 +8960,36 @@
         "webpack": "*"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -8773,6 +8998,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/clone-deep": {
@@ -9553,6 +9786,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-data-property": {
@@ -11403,6 +11647,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -11519,6 +11776,20 @@
       "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-entry-cache": {
@@ -13155,6 +13426,108 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
       "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
+    "node_modules/inquirer": {
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
+      "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.5.5",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6",
+        "wrap-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/inquirer/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
@@ -13487,6 +13860,14 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-invalid-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
@@ -13740,6 +14121,17 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-valid-path": {
       "version": "0.1.1",
@@ -16554,6 +16946,85 @@
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww=="
     },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/log-symbols/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-symbols/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -17034,6 +17505,11 @@
       "bin": {
         "multicast-dns": "cli.js"
       }
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "node_modules/nanoid": {
       "version": "3.3.6",
@@ -17676,11 +18152,96 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ora/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/ora/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20298,6 +20859,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -20366,6 +20939,14 @@
         "rtlcss": "bin/rtlcss.js"
       }
     },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -20386,6 +20967,14 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-array-concat": {
@@ -22370,6 +22959,11 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA=="
     },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
     "node_modules/thunky": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
@@ -22394,7 +22988,6 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
       "dependencies": {
         "os-tmpdir": "~1.0.2"
       },
@@ -23349,6 +23942,14 @@
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dependencies": {
+        "defaults": "^1.0.3"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@edx/frontend-enterprise-logistration": "3.2.0",
     "@edx/frontend-enterprise-utils": "3.2.0",
     "@edx/frontend-platform": "4.0.1",
-    "@edx/paragon": "20.46.3",
+    "@openedx/paragon": "21.5.7",
     "@tanstack/react-query": "4.36.1",
     "@tanstack/react-query-devtools": "4.36.1",
     "algoliasearch": "4.8.3",

--- a/src/components/ActionButtonWithModal/index.jsx
+++ b/src/components/ActionButtonWithModal/index.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Button } from '@edx/paragon';
+import { Button } from '@openedx/paragon';
 
 const ActionButtonWithModal = ({
   buttonClassName,

--- a/src/components/Admin/AIAnalyticsSummary.jsx
+++ b/src/components/Admin/AIAnalyticsSummary.jsx
@@ -3,9 +3,9 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
   Button, Card, Stack, Badge, useToggle,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
-import { AutoFixHigh, Groups } from '@edx/paragon/icons';
+import { AutoFixHigh, Groups } from '@openedx/paragon/icons';
 import useAIAnalyticsSummary from '../AIAnalyticsSummary/data/hooks';
 
 const AnalyticsDetailCard = ({

--- a/src/components/Admin/AIAnalyticsSummarySkeleton.jsx
+++ b/src/components/Admin/AIAnalyticsSummarySkeleton.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Skeleton, Stack } from '@edx/paragon';
+import { Skeleton, Stack } from '@openedx/paragon';
 
 const AIAnalyticsSummarySkeleton = () => (
   <Stack direction="horizontal" gap={2}>

--- a/src/components/Admin/AdminCards.jsx
+++ b/src/components/Admin/AdminCards.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import {
   Award, Check, Groups, RemoveRedEye,
-} from '@edx/paragon/icons';
+} from '@openedx/paragon/icons';
 
 import NumberCard from '../NumberCard';
 

--- a/src/components/Admin/AdminCardsSkeleton.jsx
+++ b/src/components/Admin/AdminCardsSkeleton.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Skeleton } from '@edx/paragon';
+import { Skeleton } from '@openedx/paragon';
 
 const AdminCardsSkeleton = () => (
   <div

--- a/src/components/Admin/AdminSearchForm.jsx
+++ b/src/components/Admin/AdminSearchForm.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 import dayjs from 'dayjs';
 import PropTypes from 'prop-types';
 
-import { Form } from '@edx/paragon';
-import { Info } from '@edx/paragon/icons';
+import { Form } from '@openedx/paragon';
+import { Info } from '@openedx/paragon/icons';
 
 import SearchBar from '../SearchBar';
 import { updateUrl } from '../../utils';

--- a/src/components/Admin/AdminSearchForm.test.jsx
+++ b/src/components/Admin/AdminSearchForm.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { FormControl } from '@edx/paragon';
+import { FormControl } from '@openedx/paragon';
 
 import AdminSearchForm from './AdminSearchForm';
 import SearchBar from '../SearchBar';

--- a/src/components/Admin/EmbeddedSubscription.jsx
+++ b/src/components/Admin/EmbeddedSubscription.jsx
@@ -1,8 +1,8 @@
 import React, { useContext, useState } from 'react';
 import dayjs from 'dayjs';
 import { useParams, Link } from 'react-router-dom';
-import { Form, Icon } from '@edx/paragon';
-import { Lightbulb, ArrowOutward } from '@edx/paragon/icons';
+import { Form, Icon } from '@openedx/paragon';
+import { Lightbulb, ArrowOutward } from '@openedx/paragon/icons';
 import ConnectedSubscriptionDetailPage from './SubscriptionDetailPage';
 import { SubscriptionContext } from '../subscriptions/SubscriptionData';
 import { sortSubscriptionsByStatus } from '../subscriptions/data/utils';

--- a/src/components/Admin/SubscriptionDetails.jsx
+++ b/src/components/Admin/SubscriptionDetails.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import dayjs from 'dayjs';
 import {
   Row, Col, Toast, Button,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 
 import { Link } from 'react-router-dom';
 import { SubscriptionDetailContext } from '../subscriptions/SubscriptionDetailContextProvider';

--- a/src/components/Admin/index.jsx
+++ b/src/components/Admin/index.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
-import { Alert, Icon } from '@edx/paragon';
-import { Error, Undo } from '@edx/paragon/icons';
+import { Alert, Icon } from '@openedx/paragon';
+import { Error, Undo } from '@openedx/paragon/icons';
 import { Link } from 'react-router-dom';
 
 import Hero from '../Hero';

--- a/src/components/Admin/licenses/LicenseAllocationHeader.jsx
+++ b/src/components/Admin/licenses/LicenseAllocationHeader.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { Badge } from '@edx/paragon';
+import { Badge } from '@openedx/paragon';
 import { SubscriptionDetailContext } from '../../subscriptions/SubscriptionDetailContextProvider';
 import { SubsidyRequestsContext } from '../../subsidy-requests';
 import NewFeatureAlertBrowseAndRequest from '../../NewFeatureAlertBrowseAndRequest';

--- a/src/components/Admin/licenses/LicenseManagementTable/index.jsx
+++ b/src/components/Admin/licenses/LicenseManagementTable/index.jsx
@@ -12,7 +12,7 @@ import {
   TextFilter,
   CheckboxFilter,
   Toast,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 
 import { SubscriptionContext } from '../../../subscriptions/SubscriptionData';
 import { SubscriptionDetailContext } from '../../../subscriptions/SubscriptionDetailContextProvider';

--- a/src/components/BulkEnrollmentPage/BulkEnrollButton.jsx
+++ b/src/components/BulkEnrollmentPage/BulkEnrollButton.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Button } from '@edx/paragon';
-import { BookOpen } from '@edx/paragon/icons';
+import { Button } from '@openedx/paragon';
+import { BookOpen } from '@openedx/paragon/icons';
 
 /**
  * Bulk action button, meant to be used in License management page to initiate Bulk Enrollment Dialog

--- a/src/components/BulkEnrollmentPage/BulkEnrollmentWarningModal.jsx
+++ b/src/components/BulkEnrollmentPage/BulkEnrollmentWarningModal.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 
 import {
   ActionRow, AlertModal, Button, Icon,
-} from '@edx/paragon';
-import { Error } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Error } from '@openedx/paragon/icons';
 
 import BulkEnrollButton from './BulkEnrollButton';
 

--- a/src/components/BulkEnrollmentPage/CourseSearchResults.jsx
+++ b/src/components/BulkEnrollmentPage/CourseSearchResults.jsx
@@ -5,8 +5,8 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import { connectStateResults } from 'react-instantsearch-dom';
-import { Alert, DataTable, Skeleton } from '@edx/paragon';
-import { Error, ErrorOutline } from '@edx/paragon/icons';
+import { Alert, DataTable, Skeleton } from '@openedx/paragon';
+import { Error, ErrorOutline } from '@openedx/paragon/icons';
 import { SearchContext, SearchPagination } from '@edx/frontend-enterprise-catalog-search';
 
 import { CourseNameCell, FormattedDateCell } from './table/CourseSearchResultsCells';

--- a/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentStepper.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import {
   Button, ModalDialog, Stepper,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 
 import BulkEnrollmentSubmit from './BulkEnrollmentSubmit';
 import AddCoursesStep from './AddCoursesStep';

--- a/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/BulkEnrollmentSubmit.jsx
@@ -11,7 +11,7 @@ import {
   MailtoLink,
   Stack,
   Toast,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import { logError } from '@edx/frontend-platform/logging';
 import {

--- a/src/components/BulkEnrollmentPage/stepper/DismissibleCourseWarning.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/DismissibleCourseWarning.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
-import { Alert } from '@edx/paragon';
-import { WarningFilled } from '@edx/paragon/icons';
+import { Alert } from '@openedx/paragon';
+import { WarningFilled } from '@openedx/paragon/icons';
 import { WARNING_ALERT_TITLE_TEXT, WARNING_ALERT_BODY_TEXT } from './constants';
 
 /**

--- a/src/components/BulkEnrollmentPage/stepper/ReviewItem.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/ReviewItem.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Delete } from '@edx/paragon/icons';
+import { Delete } from '@openedx/paragon/icons';
 import {
   Card, IconButton, Icon,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import PropTypes from 'prop-types';
 
 import { deleteSelectedRowAction } from '../data/actions';

--- a/src/components/BulkEnrollmentPage/stepper/ReviewItem.test.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/ReviewItem.test.jsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { IconButton } from '@edx/paragon';
+import { IconButton } from '@openedx/paragon';
 import ReviewItem from './ReviewItem';
 import { deleteSelectedRowAction } from '../data/actions';
 

--- a/src/components/BulkEnrollmentPage/stepper/ReviewList.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/ReviewList.jsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {
   Alert, Button, useToggle, Skeleton,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import ReviewItem from './ReviewItem';
 
 export const MAX_ITEMS_DISPLAYED = 25;

--- a/src/components/BulkEnrollmentPage/stepper/ReviewStep.jsx
+++ b/src/components/BulkEnrollmentPage/stepper/ReviewStep.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { Row } from '@edx/paragon';
+import { Row } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 
 import { BulkEnrollContext } from '../BulkEnrollmentContext';

--- a/src/components/BulkEnrollmentPage/table/BaseSelectionStatus.jsx
+++ b/src/components/BulkEnrollmentPage/table/BaseSelectionStatus.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { Button, DataTableContext } from '@edx/paragon';
+import { Button, DataTableContext } from '@openedx/paragon';
 
 // This selection status component uses the BulkEnrollContext to show selection status rather than the data table state.
 const BaseSelectionStatus = ({

--- a/src/components/BulkEnrollmentPage/table/BaseSelectionStatus.test.jsx
+++ b/src/components/BulkEnrollmentPage/table/BaseSelectionStatus.test.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import { DataTableContext } from '@edx/paragon';
+import { DataTableContext } from '@openedx/paragon';
 import userEvent from '@testing-library/user-event';
 
 import BaseSelectionStatus from './BaseSelectionStatus';

--- a/src/components/BulkEnrollmentPage/table/BulkEnrollSelect.jsx
+++ b/src/components/BulkEnrollmentPage/table/BulkEnrollSelect.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { CheckboxControl } from '@edx/paragon';
+import { CheckboxControl } from '@openedx/paragon';
 
 export const SELECT_ONE_TEST_ID = 'selectOne';
 export const SELECT_ALL_TEST_ID = 'selectAll';

--- a/src/components/BulkEnrollmentPage/table/CourseSearchResultsCells.jsx
+++ b/src/components/BulkEnrollmentPage/table/CourseSearchResultsCells.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
 
-import { Popover, Button, OverlayTrigger } from '@edx/paragon';
+import { Popover, Button, OverlayTrigger } from '@openedx/paragon';
 
 import { configuration } from '../../../config';
 

--- a/src/components/BulkEnrollmentResultsDownloadPage/index.jsx
+++ b/src/components/BulkEnrollmentResultsDownloadPage/index.jsx
@@ -4,7 +4,7 @@ import { Redirect, useParams } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { logError } from '@edx/frontend-platform/logging';
 import { camelCaseObject } from '@edx/frontend-platform';
-import { Toast } from '@edx/paragon';
+import { Toast } from '@openedx/paragon';
 import EnterpriseAppSkeleton from '../EnterpriseApp/EnterpriseAppSkeleton';
 import LicenseManagerApiService from '../../data/services/LicenseManagerAPIService';
 

--- a/src/components/CodeAssignmentModal/constants.jsx
+++ b/src/components/CodeAssignmentModal/constants.jsx
@@ -1,4 +1,4 @@
-import { Info } from '@edx/paragon/icons';
+import { Info } from '@openedx/paragon/icons';
 import { MODAL_TYPES } from '../EmailTemplateForm/constants';
 import { getTemplateEmailFields } from '../EmailTemplateForm';
 import CheckboxWithTooltip from '../ReduxFormCheckbox/CheckboxWithTooltip';

--- a/src/components/CodeAssignmentModal/index.jsx
+++ b/src/components/CodeAssignmentModal/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { reduxForm, SubmissionError } from 'redux-form';
 import {
   Button, Modal, Form, Spinner,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 
 import isEmail from 'validator/lib/isEmail';

--- a/src/components/CodeManagement/CouponCodeTabs.jsx
+++ b/src/components/CodeManagement/CouponCodeTabs.jsx
@@ -1,7 +1,7 @@
 import React, { useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Tabs, Tab } from '@edx/paragon';
+import { Tabs, Tab } from '@openedx/paragon';
 import {
   useHistory,
   Route,

--- a/src/components/CodeManagement/ManageCodesTab.jsx
+++ b/src/components/CodeManagement/ManageCodesTab.jsx
@@ -8,10 +8,10 @@ import {
   Button,
   Icon,
   Pagination,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import {
   CheckCircle, Info, Plus, SpinnerIcon, WarningFilled,
-} from '@edx/paragon/icons';
+} from '@openedx/paragon/icons';
 
 import SearchBar from '../SearchBar';
 import CodeSearchResults from '../CodeSearchResults';

--- a/src/components/CodeManagement/ManageRequestsTab.jsx
+++ b/src/components/CodeManagement/ManageRequestsTab.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import dayjs from 'dayjs';
 
-import { Stack } from '@edx/paragon';
+import { Stack } from '@openedx/paragon';
 import { camelCaseObject } from '@edx/frontend-platform';
 
 import SubsidyRequestManagementTable, {

--- a/src/components/CodeManagement/index.jsx
+++ b/src/components/CodeManagement/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Helmet from 'react-helmet';
-import { Container } from '@edx/paragon';
+import { Container } from '@openedx/paragon';
 
 import Hero from '../Hero';
 import CodeManagementRoutes from './CodeManagementRoutes';

--- a/src/components/CodeModal/ModalError.jsx
+++ b/src/components/CodeModal/ModalError.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Alert, Icon } from '@edx/paragon';
-import { Warning } from '@edx/paragon/icons';
+import { Alert, Icon } from '@openedx/paragon';
+import { Warning } from '@openedx/paragon/icons';
 
 const ModalError = React.forwardRef(({ title, errors }, ref) => (
   <div

--- a/src/components/CodeReminderModal/index.jsx
+++ b/src/components/CodeReminderModal/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm, SubmissionError } from 'redux-form';
-import { Button, Modal, Spinner } from '@edx/paragon';
+import { Button, Modal, Spinner } from '@openedx/paragon';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 
 import SaveTemplateButton from '../../containers/SaveTemplateButton';

--- a/src/components/CodeRevokeModal/index.jsx
+++ b/src/components/CodeRevokeModal/index.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import { Field, reduxForm, SubmissionError } from 'redux-form';
 import {
   Button, Modal, Spinner,
-} from '@edx/paragon';
-import { Info } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Info } from '@openedx/paragon/icons';
 
 import SaveTemplateButton from '../../containers/SaveTemplateButton';
 

--- a/src/components/CodeSearchResults/CodeSearchResultsHeading.jsx
+++ b/src/components/CodeSearchResults/CodeSearchResultsHeading.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, Icon } from '@edx/paragon';
-import { Close } from '@edx/paragon/icons';
+import { Button, Icon } from '@openedx/paragon';
+import { Close } from '@openedx/paragon/icons';
 
 const CodeSearchResultsHeading = ({ searchQuery, onClose }) => (
   <div className="d-flex align-items-center justify-content-between mb-3">

--- a/src/components/CodeSearchResults/CodeSearchResultsTable.jsx
+++ b/src/components/CodeSearchResults/CodeSearchResultsTable.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
 import { withRouter } from 'react-router-dom';
-import { Icon } from '@edx/paragon';
-import { Check } from '@edx/paragon/icons';
+import { Icon } from '@openedx/paragon';
+import { Check } from '@openedx/paragon/icons';
 
 import { isValidEmail } from '../../utils';
 import TableContainer from '../../containers/TableContainer';

--- a/src/components/CodeSearchResults/index.jsx
+++ b/src/components/CodeSearchResults/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Alert, TransitionReplace } from '@edx/paragon';
-import { CheckCircle } from '@edx/paragon/icons';
+import { Alert, TransitionReplace } from '@openedx/paragon';
+import { CheckCircle } from '@openedx/paragon/icons';
 
 import { updateUrl } from '../../utils';
 

--- a/src/components/ConfirmationModal/index.jsx
+++ b/src/components/ConfirmationModal/index.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   ModalDialog, ActionRow, Button, StatefulButton, Alert,
-} from '@edx/paragon';
-import { Info } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Info } from '@openedx/paragon/icons';
 
 export const DEFAULT_TITLE = 'Are you sure?';
 export const CONFIRM_BUTTON_STATES = {

--- a/src/components/ContactCustomerSupportButton/index.jsx
+++ b/src/components/ContactCustomerSupportButton/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Hyperlink } from '@edx/paragon';
+import { Hyperlink } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 

--- a/src/components/ContentHighlights/CatalogVisibility/ContentHighlightCatalogVisibilityAlert.jsx
+++ b/src/components/ContentHighlights/CatalogVisibility/ContentHighlightCatalogVisibilityAlert.jsx
@@ -1,8 +1,8 @@
 import React, { useContext } from 'react';
 import {
   Alert, Button, Row, Col,
-} from '@edx/paragon';
-import { Info, Add } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Info, Add } from '@openedx/paragon/icons';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { useContextSelector } from 'use-context-selector';
 import { ALERT_TEXT, BUTTON_TEXT } from '../data/constants';

--- a/src/components/ContentHighlights/CatalogVisibility/ContentHighlightCatalogVisibilityRadioInput.jsx
+++ b/src/components/ContentHighlights/CatalogVisibility/ContentHighlightCatalogVisibilityRadioInput.jsx
@@ -1,8 +1,8 @@
 import {
   Form, Container, Spinner,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { useState, useContext, useEffect } from 'react';
-import { ActionRowSpacer } from '@edx/paragon/dist/ActionRow';
+import { ActionRowSpacer } from '@openedx/paragon/dist/ActionRow';
 import { logError } from '@edx/frontend-platform/logging';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { useHistory } from 'react-router-dom';

--- a/src/components/ContentHighlights/ContentHighlightCardContainer.jsx
+++ b/src/components/ContentHighlights/ContentHighlightCardContainer.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { Stack } from '@edx/paragon';
+import { Stack } from '@openedx/paragon';
 
 import { useHighlightSetsForCuration } from './data/hooks';
 import { EnterpriseAppContext } from '../EnterpriseApp/EnterpriseAppContextProvider';

--- a/src/components/ContentHighlights/ContentHighlightCardItem.jsx
+++ b/src/components/ContentHighlights/ContentHighlightCardItem.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Truncate from 'react-truncate';
 import PropTypes from 'prop-types';
-import { Card, Hyperlink } from '@edx/paragon';
+import { Card, Hyperlink } from '@openedx/paragon';
 import cardImageCapFallbackSrc from '@edx/brand/paragon/images/card-imagecap-fallback.png';
 
 import { getContentHighlightCardFooter } from './data/utils';

--- a/src/components/ContentHighlights/ContentHighlightSet.jsx
+++ b/src/components/ContentHighlights/ContentHighlightSet.jsx
@@ -1,4 +1,4 @@
-import { Container } from '@edx/paragon';
+import { Container } from '@openedx/paragon';
 import { useParams } from 'react-router-dom';
 import React from 'react';
 import ContentHighlightsCardItemContainer from './ContentHighlightsCardItemsContainer';

--- a/src/components/ContentHighlights/ContentHighlightSetCard.jsx
+++ b/src/components/ContentHighlights/ContentHighlightSetCard.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card } from '@edx/paragon';
+import { Card } from '@openedx/paragon';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';

--- a/src/components/ContentHighlights/ContentHighlightToast.jsx
+++ b/src/components/ContentHighlights/ContentHighlightToast.jsx
@@ -1,4 +1,4 @@
-import { Toast } from '@edx/paragon';
+import { Toast } from '@openedx/paragon';
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 

--- a/src/components/ContentHighlights/ContentHighlightsCardItemsContainer.jsx
+++ b/src/components/ContentHighlights/ContentHighlightsCardItemsContainer.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CardGrid, Alert } from '@edx/paragon';
+import { CardGrid, Alert } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';

--- a/src/components/ContentHighlights/ContentHighlightsDashboard.jsx
+++ b/src/components/ContentHighlights/ContentHighlightsDashboard.jsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Container, Tabs, Tab } from '@edx/paragon';
+import { Container, Tabs, Tab } from '@openedx/paragon';
 import { camelCaseObject } from '@edx/frontend-platform';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import CurrentContentHighlights from './CurrentContentHighlights';

--- a/src/components/ContentHighlights/CurrentContentHighlightHeader.jsx
+++ b/src/components/ContentHighlights/CurrentContentHighlightHeader.jsx
@@ -2,12 +2,12 @@ import React, { useContext, useState, useEffect } from 'react';
 
 import {
   Button, ActionRow, Alert,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 
 import PropTypes from 'prop-types';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { connect } from 'react-redux';
-import { Add, Info } from '@edx/paragon/icons';
+import { Add, Info } from '@openedx/paragon/icons';
 import { useContentHighlightsContext } from './data/hooks';
 import EVENT_NAMES from '../../eventTracking';
 

--- a/src/components/ContentHighlights/CurrentContentHighlightItemsHeader.jsx
+++ b/src/components/ContentHighlights/CurrentContentHighlightItemsHeader.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ActionRow, Skeleton } from '@edx/paragon';
+import { ActionRow, Skeleton } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import ContentHighlightHelmet from './ContentHighlightHelmet';
 import DeleteHighlightSet from './DeleteHighlightSet';

--- a/src/components/ContentHighlights/CurrentContentHighlights.jsx
+++ b/src/components/ContentHighlights/CurrentContentHighlights.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   Stack,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 
 import ContentHighlightCardContainer from './ContentHighlightCardContainer';
 import CurrentContentHighlightHeader from './CurrentContentHighlightHeader';

--- a/src/components/ContentHighlights/DeleteHighlightSet.jsx
+++ b/src/components/ContentHighlights/DeleteHighlightSet.jsx
@@ -7,8 +7,8 @@ import {
   useToggle,
   ActionRow,
   StatefulButton,
-} from '@edx/paragon';
-import { Info } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Info } from '@openedx/paragon/icons';
 import { useParams, useHistory } from 'react-router-dom';
 import { logError } from '@edx/frontend-platform/logging';
 import { connect } from 'react-redux';

--- a/src/components/ContentHighlights/HighlightSetSection.jsx
+++ b/src/components/ContentHighlights/HighlightSetSection.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { CardGrid } from '@edx/paragon';
+import { CardGrid } from '@openedx/paragon';
 import { connect } from 'react-redux';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import ContentHighlightSetCard from './ContentHighlightSetCard';

--- a/src/components/ContentHighlights/HighlightStepper/ContentConfirmContentCard.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/ContentConfirmContentCard.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Delete } from '@edx/paragon/icons';
-import { IconButton, Icon } from '@edx/paragon';
+import { Delete } from '@openedx/paragon/icons';
+import { IconButton, Icon } from '@openedx/paragon';
 import { connect } from 'react-redux';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import ContentHighlightCardItem from '../ContentHighlightCardItem';

--- a/src/components/ContentHighlights/HighlightStepper/ContentHighlightStepper.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/ContentHighlightStepper.jsx
@@ -12,7 +12,7 @@ import {
   useToggle,
   AlertModal,
   ActionRow,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { logError } from '@edx/frontend-platform/logging';
 import { camelCaseObject } from '@edx/frontend-platform';
 

--- a/src/components/ContentHighlights/HighlightStepper/HighlightStepperConfirmContent.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/HighlightStepperConfirmContent.jsx
@@ -10,8 +10,8 @@ import {
   Icon,
   CardGrid,
   Alert,
-} from '@edx/paragon';
-import { Assignment } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Assignment } from '@openedx/paragon/icons';
 import { camelCaseObject } from '@edx/frontend-platform';
 import { Configure, InstantSearch, connectStateResults } from 'react-instantsearch-dom';
 import { connect } from 'react-redux';

--- a/src/components/ContentHighlights/HighlightStepper/HighlightStepperFooterHelpLink.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/HighlightStepperFooterHelpLink.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   Hyperlink,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { useContextSelector } from 'use-context-selector';

--- a/src/components/ContentHighlights/HighlightStepper/HighlightStepperSelectContent.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/HighlightStepperSelectContent.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   Row, Col, Container,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import HighlightStepperSelectContentSearch from './HighlightStepperSelectContentSearch';
 import HighlightStepperSelectContentHeader from './HighlightStepperSelectContentHeader';

--- a/src/components/ContentHighlights/HighlightStepper/HighlightStepperSelectContentHeader.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/HighlightStepperSelectContentHeader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useContextSelector } from 'use-context-selector';
-import { Icon } from '@edx/paragon';
-import { AddCircle } from '@edx/paragon/icons';
+import { Icon } from '@openedx/paragon';
+import { AddCircle } from '@openedx/paragon/icons';
 import { STEPPER_STEP_TEXT } from '../data/constants';
 import { ContentHighlightsContext } from '../ContentHighlightsContext';
 

--- a/src/components/ContentHighlights/HighlightStepper/HighlightStepperSelectContentSearch.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/HighlightStepperSelectContentSearch.jsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useContextSelector } from 'use-context-selector';
 import { Configure, InstantSearch, connectStateResults } from 'react-instantsearch-dom';
-import { DataTable, CardView } from '@edx/paragon';
+import { DataTable, CardView } from '@openedx/paragon';
 import { camelCaseObject } from '@edx/frontend-platform';
 import { SearchData, SearchHeader } from '@edx/frontend-enterprise-catalog-search';
 

--- a/src/components/ContentHighlights/HighlightStepper/HighlightStepperTitle.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/HighlightStepperTitle.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {
   Row, Col, Icon, Container,
-} from '@edx/paragon';
-import { EditCircle } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { EditCircle } from '@openedx/paragon/icons';
 
 import { STEPPER_STEP_TEXT } from '../data/constants';
 import HighlightStepperTitleInput from './HighlightStepperTitleInput';

--- a/src/components/ContentHighlights/HighlightStepper/HighlightStepperTitleInput.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/HighlightStepperTitleInput.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useContextSelector } from 'use-context-selector';
-import { Form } from '@edx/paragon';
+import { Form } from '@openedx/paragon';
 
 import { ContentHighlightsContext } from '../ContentHighlightsContext';
 import { DEFAULT_ERROR_MESSAGE, MAX_HIGHLIGHT_TITLE_LENGTH } from '../data/constants';

--- a/src/components/ContentHighlights/HighlightStepper/SelectContentSearchPagination.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/SelectContentSearchPagination.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connectPagination } from 'react-instantsearch-dom';
-import { ActionRow, Pagination, DataTable } from '@edx/paragon';
+import { ActionRow, Pagination, DataTable } from '@openedx/paragon';
 
 export const BaseSearchPagination = ({
   nbPages,

--- a/src/components/ContentHighlights/HighlightStepper/SelectContentSelectionCheckbox.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/SelectContentSelectionCheckbox.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useContextSelector } from 'use-context-selector';
 import PropTypes from 'prop-types';
-import { CheckboxControl } from '@edx/paragon';
+import { CheckboxControl } from '@openedx/paragon';
 
 import { MAX_CONTENT_ITEMS_PER_HIGHLIGHT_SET } from '../data/constants';
 import { ContentHighlightsContext } from '../ContentHighlightsContext';

--- a/src/components/ContentHighlights/HighlightStepper/SelectContentSelectionStatus.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/SelectContentSelectionStatus.jsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import { useContextSelector } from 'use-context-selector';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Button, DataTableContext } from '@edx/paragon';
+import { Button, DataTableContext } from '@openedx/paragon';
 
 import { ContentHighlightsContext } from '../ContentHighlightsContext';
 

--- a/src/components/ContentHighlights/SkeletonContentCard.jsx
+++ b/src/components/ContentHighlights/SkeletonContentCard.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card } from '@edx/paragon';
+import { Card } from '@openedx/paragon';
 
 const SkeletonContentCard = () => (
   <Card isLoading data-testid="card-item-skeleton">

--- a/src/components/ContentHighlights/SkeletonContentCardContainer.jsx
+++ b/src/components/ContentHighlights/SkeletonContentCardContainer.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { CardGrid } from '@edx/paragon';
+import { CardGrid } from '@openedx/paragon';
 import { v4 as uuidv4 } from 'uuid';
 import SkeletonContentCard from './SkeletonContentCard';
 import { HIGHLIGHTS_CARD_GRID_COLUMN_SIZES } from './data/constants';

--- a/src/components/ContentHighlights/ZeroState/ZeroStateCardFooter.jsx
+++ b/src/components/ContentHighlights/ZeroState/ZeroStateCardFooter.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card } from '@edx/paragon';
+import { Card } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 
 const ZeroStateCardFooter = ({ footerClassName, children }) => (

--- a/src/components/ContentHighlights/ZeroState/ZeroStateCardImage.jsx
+++ b/src/components/ContentHighlights/ZeroState/ZeroStateCardImage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card } from '@edx/paragon';
+import { Card } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 
 const ZeroStateCardImage = ({ imageContainerClassName, imageClassName, cardImage }) => (

--- a/src/components/ContentHighlights/ZeroState/ZeroStateCardText.jsx
+++ b/src/components/ContentHighlights/ZeroState/ZeroStateCardText.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card } from '@edx/paragon';
+import { Card } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 
 const ZeroStateCardText = ({ textContainerClassName, children }) => (

--- a/src/components/ContentHighlights/ZeroState/ZeroStateHighlights.jsx
+++ b/src/components/ContentHighlights/ZeroState/ZeroStateHighlights.jsx
@@ -1,9 +1,9 @@
 import React, { useContext } from 'react';
 import {
   Card, Button, Col, Row,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import PropTypes from 'prop-types';
-import { Add } from '@edx/paragon/icons';
+import { Add } from '@openedx/paragon/icons';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { connect } from 'react-redux';
 import cardImage from '../data/images/ContentHighlightImage.svg';

--- a/src/components/Coupon/index.jsx
+++ b/src/components/Coupon/index.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Icon } from '@edx/paragon';
-import { Error, ExpandLess, ExpandMore } from '@edx/paragon/icons';
+import { Icon } from '@openedx/paragon';
+import { Error, ExpandLess, ExpandMore } from '@openedx/paragon/icons';
 
 import CouponDetails from '../../containers/CouponDetails';
 

--- a/src/components/CouponDetails/ActionButton.jsx
+++ b/src/components/CouponDetails/ActionButton.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Button,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import RemindButton from '../RemindButton';
 import RevokeButton from '../RevokeButton';
 import { ACTIONS, COUPON_FILTERS, COUPON_FILTER_TYPES } from './constants';

--- a/src/components/CouponDetails/CouponBulkActions.jsx
+++ b/src/components/CouponDetails/CouponBulkActions.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import {
   Button, Form,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { BULK_ACTION, COUPON_FILTERS, COUPON_FILTER_TYPES } from './constants';
 import { getBASelectOptions, getFirstNonDisabledOption } from './helpers';
 

--- a/src/components/CouponDetails/CouponFilters.jsx
+++ b/src/components/CouponDetails/CouponFilters.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Form } from '@edx/paragon';
+import { Form } from '@openedx/paragon';
 
 const CouponFilters = ({
   selectedToggle, tableFilterSelectOptions, isTableLoading, handleToggleSelect,

--- a/src/components/CouponDetails/index.jsx
+++ b/src/components/CouponDetails/index.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {
   Alert, Button, Icon, Form,
-} from '@edx/paragon';
-import { CheckCircle, Error } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { CheckCircle, Error } from '@openedx/paragon/icons';
 
 import TableContainer from '../../containers/TableContainer';
 import DownloadCsvButton from '../../containers/DownloadCsvButton';

--- a/src/components/DownloadCsvButton/index.jsx
+++ b/src/components/DownloadCsvButton/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, Spinner } from '@edx/paragon';
-import { FileDownload } from '@edx/paragon/icons';
+import { Button, Spinner } from '@openedx/paragon';
+import { FileDownload } from '@openedx/paragon/icons';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 

--- a/src/components/EnterpriseApp/EnterpriseAppSkeleton.jsx
+++ b/src/components/EnterpriseApp/EnterpriseAppSkeleton.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Skeleton } from '@edx/paragon';
+import { Skeleton } from '@openedx/paragon';
 
 const EnterpriseAppSkeleton = () => (
   <>

--- a/src/components/EnterpriseApp/index.jsx
+++ b/src/components/EnterpriseApp/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Redirect } from 'react-router-dom';
-import { breakpoints, MediaQuery } from '@edx/paragon';
+import { breakpoints, MediaQuery } from '@openedx/paragon';
 
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import Sidebar from '../../containers/Sidebar';

--- a/src/components/ErrorPage/index.jsx
+++ b/src/components/ErrorPage/index.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 
-import { Alert } from '@edx/paragon';
-import { Cancel as ErrorIcon } from '@edx/paragon/icons';
+import { Alert } from '@openedx/paragon';
+import { Cancel as ErrorIcon } from '@openedx/paragon/icons';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 
 import NotFoundPage from '../NotFoundPage';

--- a/src/components/FeatureAnnouncementBanner/index.jsx
+++ b/src/components/FeatureAnnouncementBanner/index.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import ReactMarkdown from 'react-markdown';
-import { Alert } from '@edx/paragon';
+import { Alert } from '@openedx/paragon';
 import { logError } from '@edx/frontend-platform/logging';
 
 import LmsApiService from '../../data/services/LmsApiService';

--- a/src/components/FileInput/index.jsx
+++ b/src/components/FileInput/index.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { clearFields } from 'redux-form';
-import { Button, Icon, ValidationFormGroup } from '@edx/paragon';
-import { Close } from '@edx/paragon/icons';
+import { Button, Icon, ValidationFormGroup } from '@openedx/paragon';
+import { Close } from '@openedx/paragon/icons';
 
 class FileInput extends React.Component {
   constructor(props) {

--- a/src/components/ForbiddenPage/index.jsx
+++ b/src/components/ForbiddenPage/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Helmet from 'react-helmet';
-import { MailtoLink } from '@edx/paragon';
+import { MailtoLink } from '@openedx/paragon';
 
 const ForbiddenPage = () => (
   <main role="main">

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Dropdown, Navbar, AvatarButton, Nav,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { getProxyLoginUrl } from '@edx/frontend-enterprise-logistration';
 
 import {

--- a/src/components/IconWithTooltip/IconWithTooltip.test.jsx
+++ b/src/components/IconWithTooltip/IconWithTooltip.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Info } from '@edx/paragon/icons';
+import { Info } from '@openedx/paragon/icons';
 import IconWithTooltip from './index';
 
 const defaultAltText = 'infoooo';

--- a/src/components/IconWithTooltip/index.jsx
+++ b/src/components/IconWithTooltip/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Icon, OverlayTrigger, Tooltip, useWindowSize,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 
 const IconWithTooltip = ({
   icon, altText, tooltipText, placementSm = 'right', placementLg = 'top', trigger = ['hover', 'focus'], breakpoint = 768, iconClassNames = 'ml-1',

--- a/src/components/InfoHover/index.jsx
+++ b/src/components/InfoHover/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { OverlayTrigger, Tooltip } from '@edx/paragon';
-import { InfoOutline } from '@edx/paragon/icons';
+import { OverlayTrigger, Tooltip } from '@openedx/paragon';
+import { InfoOutline } from '@openedx/paragon/icons';
 
 const InfoHover = ({
   className, size, keyName, message,

--- a/src/components/InviteLearnersModal/index.jsx
+++ b/src/components/InviteLearnersModal/index.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import { Field, reduxForm, SubmissionError } from 'redux-form';
 import {
   Button, Modal, Alert, Spinner,
-} from '@edx/paragon';
-import { Cancel as ErrorIcon } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Cancel as ErrorIcon } from '@openedx/paragon/icons';
 
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 import emailTemplate from './emailTemplate';

--- a/src/components/MultipleFileInputField/MultipleFileInputField.jsx
+++ b/src/components/MultipleFileInputField/MultipleFileInputField.jsx
@@ -2,8 +2,8 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import {
   Form, FormControl, IconButton,
-} from '@edx/paragon';
-import { Close } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Close } from '@openedx/paragon/icons';
 import classNames from 'classnames';
 import { getSizeInBytes, formatBytes } from './utils';
 import { MAX_FILES_SIZE, FILE_SIZE_EXCEEDS_ERROR } from './constants';

--- a/src/components/NewFeatureAlertBrowseAndRequest/index.jsx
+++ b/src/components/NewFeatureAlertBrowseAndRequest/index.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Alert, Button } from '@edx/paragon';
+import { Alert, Button } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { useHistory } from 'react-router-dom';

--- a/src/components/NumberCard/NumberCard.test.jsx
+++ b/src/components/NumberCard/NumberCard.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
-import { Groups } from '@edx/paragon/icons';
+import { Groups } from '@openedx/paragon/icons';
 
 import NumberCard from './index';
 

--- a/src/components/NumberCard/index.jsx
+++ b/src/components/NumberCard/index.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import { Button, Icon, Spinner } from '@edx/paragon';
-import { ArrowDropDown, Close } from '@edx/paragon/icons';
+import { Button, Icon, Spinner } from '@openedx/paragon';
+import { ArrowDropDown, Close } from '@openedx/paragon/icons';
 import { Link, withRouter } from 'react-router-dom';
 
 import { removeTrailingSlash, isTriggerKey } from '../../utils';

--- a/src/components/PlotlyAnalytics/PlotlyAnalyticsPage.jsx
+++ b/src/components/PlotlyAnalytics/PlotlyAnalyticsPage.jsx
@@ -3,8 +3,8 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 
-import { Alert } from '@edx/paragon';
-import { CheckCircle, Error } from '@edx/paragon/icons';
+import { Alert } from '@openedx/paragon';
+import { CheckCircle, Error } from '@openedx/paragon/icons';
 import Hero from '../Hero';
 import PlotlyAnalyticsCharts from './PlotlyAnalyticsCharts';
 

--- a/src/components/ProductTours/ProductTours.jsx
+++ b/src/components/ProductTours/ProductTours.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ProductTour } from '@edx/paragon';
+import { ProductTour } from '@openedx/paragon';
 import { useHistory } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { getConfig } from '@edx/frontend-platform/config';

--- a/src/components/ReduxFormCheckbox/index.jsx
+++ b/src/components/ReduxFormCheckbox/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Form } from '@edx/paragon';
+import { Form } from '@openedx/paragon';
 
 const ReduxFormCheckbox = (props) => {
   const {

--- a/src/components/ReduxFormSelect/index.jsx
+++ b/src/components/ReduxFormSelect/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Form, FormControl } from '@edx/paragon';
+import { Form, FormControl } from '@openedx/paragon';
 
 const ReduxFormSelect = ({
   input, label: formLabel, disabled, options, description, meta: { touched, error },

--- a/src/components/RenderField/index.jsx
+++ b/src/components/RenderField/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Form, FormControl } from '@edx/paragon';
+import { Form, FormControl } from '@openedx/paragon';
 
 const RenderField = ({
   input,

--- a/src/components/ReportingConfig/EmailDeliveryMethodForm.jsx
+++ b/src/components/ReportingConfig/EmailDeliveryMethodForm.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Input, ValidationFormGroup } from '@edx/paragon';
+import { Input, ValidationFormGroup } from '@openedx/paragon';
 import isEmpty from 'lodash/isEmpty';
 import isEmail from 'validator/lib/isEmail';
 

--- a/src/components/ReportingConfig/ReportingConfigForm.jsx
+++ b/src/components/ReportingConfig/ReportingConfigForm.jsx
@@ -4,8 +4,8 @@ import isEmpty from 'lodash/isEmpty';
 import omit from 'lodash/omit';
 import {
   ValidationFormGroup, Input, StatefulButton, Icon, Button, Spinner,
-} from '@edx/paragon';
-import { Check, Close, Download } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Check, Close, Download } from '@openedx/paragon/icons';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 import SFTPDeliveryMethodForm from './SFTPDeliveryMethodForm';
 import EmailDeliveryMethodForm from './EmailDeliveryMethodForm';

--- a/src/components/ReportingConfig/SFTPDeliveryMethodForm.jsx
+++ b/src/components/ReportingConfig/SFTPDeliveryMethodForm.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Input, ValidationFormGroup } from '@edx/paragon';
+import { Input, ValidationFormGroup } from '@openedx/paragon';
 
 const SFTPDeliveryMethodForm = ({ invalidFields, config, handleBlur }) => {
   const [checked, setChecked] = useState(false);

--- a/src/components/ReportingConfig/index.jsx
+++ b/src/components/ReportingConfig/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Collapsible, Icon } from '@edx/paragon';
-import { Check, Close } from '@edx/paragon/icons';
+import { Collapsible, Icon } from '@openedx/paragon';
+import { Check, Close } from '@openedx/paragon/icons';
 import { camelCaseObject } from '@edx/frontend-platform';
 import EnterpriseCatalogApiService from '../../data/services/EnterpriseCatalogApiService';
 import LMSApiService from '../../data/services/LmsApiService';

--- a/src/components/RequestCodesPage/RequestCodesForm.jsx
+++ b/src/components/RequestCodesPage/RequestCodesForm.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Field, reduxForm } from 'redux-form';
 import { Link, Redirect } from 'react-router-dom';
-import { Alert, Button, Spinner } from '@edx/paragon';
+import { Alert, Button, Spinner } from '@openedx/paragon';
 
 import RenderField from '../RenderField';
 

--- a/src/components/SaveTemplateButton/index.jsx
+++ b/src/components/SaveTemplateButton/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { StatefulButton, Icon, Spinner } from '@edx/paragon';
-import { CheckCircle } from '@edx/paragon/icons';
+import { StatefulButton, Icon, Spinner } from '@openedx/paragon';
+import { CheckCircle } from '@openedx/paragon/icons';
 import { SubmissionError } from 'redux-form';
 
 import { validateEmailTemplateFields } from '../../data/validation/email';

--- a/src/components/SearchBar/index.jsx
+++ b/src/components/SearchBar/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { SearchField } from '@edx/paragon';
+import { SearchField } from '@openedx/paragon';
 
 const SearchBar = props => (
   <SearchField

--- a/src/components/Sidebar/IconLink.jsx
+++ b/src/components/Sidebar/IconLink.jsx
@@ -2,7 +2,7 @@ import React, { useLayoutEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { NavLink } from 'react-router-dom';
 import classNames from 'classnames';
-import { Bubble } from '@edx/paragon';
+import { Bubble } from '@openedx/paragon';
 
 const BUBBLE_MARGIN_LEFT = 5;
 

--- a/src/components/Sidebar/IconLink.test.jsx
+++ b/src/components/Sidebar/IconLink.test.jsx
@@ -3,8 +3,8 @@ import {
 } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import React from 'react';
-import { Icon } from '@edx/paragon';
-import { School } from '@edx/paragon/icons';
+import { Icon } from '@openedx/paragon';
+import { School } from '@openedx/paragon/icons';
 import { MemoryRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';

--- a/src/components/Sidebar/index.jsx
+++ b/src/components/Sidebar/index.jsx
@@ -3,10 +3,10 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Icon } from '@edx/paragon';
+import { Icon } from '@openedx/paragon';
 import {
   BookOpen, CreditCard, Description, InsertChartOutlined, MoneyOutline, Settings, Support, Tag, TrendingUp,
-} from '@edx/paragon/icons';
+} from '@openedx/paragon/icons';
 
 import { getConfig } from '@edx/frontend-platform/config';
 import IconLink from './IconLink';

--- a/src/components/SidebarToggle/index.jsx
+++ b/src/components/SidebarToggle/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button } from '@edx/paragon';
-import { Close, MenuIcon } from '@edx/paragon/icons';
+import { Button } from '@openedx/paragon';
+import { Close, MenuIcon } from '@openedx/paragon/icons';
 
 import './SidebarToggle.scss';
 

--- a/src/components/SubsidyRequestManagementTable/ActionCell.jsx
+++ b/src/components/SubsidyRequestManagementTable/ActionCell.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {
   ActionRow,
   Button,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 
 const ActionCell = ({
   row, onApprove, onDecline, disableApproveButton,

--- a/src/components/SubsidyRequestManagementTable/CourseTitleCell.jsx
+++ b/src/components/SubsidyRequestManagementTable/CourseTitleCell.jsx
@@ -7,7 +7,7 @@ import {
   Button,
   Hyperlink,
   Skeleton,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { getConfig } from '@edx/frontend-platform/config';
 
 import { useCourseDetails } from './data/hooks';

--- a/src/components/SubsidyRequestManagementTable/RequestStatusCell.jsx
+++ b/src/components/SubsidyRequestManagementTable/RequestStatusCell.jsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { Badge } from '@edx/paragon';
+import { Badge } from '@openedx/paragon';
 
 import { capitalizeFirstLetter } from '../../utils';
 

--- a/src/components/SubsidyRequestManagementTable/SubsidyRequestManagementTable.jsx
+++ b/src/components/SubsidyRequestManagementTable/SubsidyRequestManagementTable.jsx
@@ -4,7 +4,7 @@ import {
   DataTable,
   TextFilter,
   CheckboxFilter,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 
 import EmailAddressCell from './EmailAddressCell';
 import RequestDateCell from './RequestDateCell';

--- a/src/components/TableComponent/TableLoadingSkeleton.jsx
+++ b/src/components/TableComponent/TableLoadingSkeleton.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Skeleton } from '@edx/paragon';
+import { Skeleton } from '@openedx/paragon';
 
 const TableLoadingSkeleton = (props) => (
   <div {...props}>

--- a/src/components/TableComponent/index.jsx
+++ b/src/components/TableComponent/index.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
-import { Alert, Pagination, Table } from '@edx/paragon';
-import { Error } from '@edx/paragon/icons';
+import { Alert, Pagination, Table } from '@openedx/paragon';
+import { Error } from '@openedx/paragon/icons';
 
 import 'font-awesome/css/font-awesome.css';
 

--- a/src/components/TemplateSourceFields/index.jsx
+++ b/src/components/TemplateSourceFields/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Button, OverlayTrigger, Tooltip,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { Field } from 'redux-form';
 
 import RenderField from '../RenderField';

--- a/src/components/TextAreaAutoSize/index.jsx
+++ b/src/components/TextAreaAutoSize/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Form, FormControl } from '@edx/paragon';
+import { Form, FormControl } from '@openedx/paragon';
 
 const TextAreaAutoSize = ({
   input,

--- a/src/components/UserActivationPage/index.jsx
+++ b/src/components/UserActivationPage/index.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { Redirect } from 'react-router-dom';
 import {
   Container, Row, Col, Alert, MailtoLink, Toast,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { getAuthenticatedUser, hydrateAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { LoginRedirect } from '@edx/frontend-enterprise-logistration';
 import { configuration } from '../../config';

--- a/src/components/forms/FormWaitModal.tsx
+++ b/src/components/forms/FormWaitModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AlertModal, Spinner } from '@edx/paragon';
+import { AlertModal, Spinner } from '@openedx/paragon';
 import { useFormContext } from './FormContext';
 import type { FormContext } from './FormContext';
 

--- a/src/components/forms/FormWorkflow.tsx
+++ b/src/components/forms/FormWorkflow.tsx
@@ -2,8 +2,8 @@ import React, { useEffect, useState } from 'react';
 import type { Dispatch } from 'react';
 import {
   ActionRow, Button, FullscreenModal, Spinner, Stepper, useToggle,
-} from '@edx/paragon';
-import { Launch } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Launch } from '@openedx/paragon/icons';
 
 import { useFormContext } from './FormContext';
 import type { FormFieldValidation, FormContext } from './FormContext';

--- a/src/components/forms/ValidatedFormCheckbox.tsx
+++ b/src/components/forms/ValidatedFormCheckbox.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import omit from 'lodash/omit';
 import isString from 'lodash/isString';
 
-import { Form } from '@edx/paragon';
+import { Form } from '@openedx/paragon';
 
 import { setFormFieldAction } from './data/actions';
 import { useFormContext } from './FormContext';

--- a/src/components/forms/ValidatedFormControl.tsx
+++ b/src/components/forms/ValidatedFormControl.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import omit from 'lodash/omit';
 import isString from 'lodash/isString';
 
-import { Form } from '@edx/paragon';
+import { Form } from '@openedx/paragon';
 
 import { setFormFieldAction } from './data/actions';
 import { useFormContext } from './FormContext';

--- a/src/components/forms/ValidatedFormRadio.tsx
+++ b/src/components/forms/ValidatedFormRadio.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 import omit from 'lodash/omit';
 import isString from 'lodash/isString';
 
-import { Form, Stack } from '@edx/paragon';
+import { Form, Stack } from '@openedx/paragon';
 
 import { setFormFieldAction } from './data/actions';
 import { useFormContext } from './FormContext';

--- a/src/components/learner-credit-management/AssignMoreCoursesEmptyStateMinimal.jsx
+++ b/src/components/learner-credit-management/AssignMoreCoursesEmptyStateMinimal.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Button, Card } from '@edx/paragon';
+import { Button, Card } from '@openedx/paragon';
 
 import {
   formatDate, formatPrice, useBudgetId, usePathToCatalogTab, useSubsidyAccessPolicy,

--- a/src/components/learner-credit-management/AssignmentDetailsTableCell.jsx
+++ b/src/components/learner-credit-management/AssignmentDetailsTableCell.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Stack, Hyperlink } from '@edx/paragon';
+import { Stack, Hyperlink } from '@openedx/paragon';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
 import { configuration } from '../../config';

--- a/src/components/learner-credit-management/AssignmentRowActionTableCell.jsx
+++ b/src/components/learner-credit-management/AssignmentRowActionTableCell.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Stack } from '@edx/paragon';
+import { Stack } from '@openedx/paragon';
 import PendingAssignmentRemindButton from './PendingAssignmentRemindButton';
 import PendingAssignmentCancelButton from './PendingAssignmentCancelButton';
 

--- a/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
+++ b/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
@@ -1,6 +1,6 @@
 import {
   Chip,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import FailedBadEmail from './assignments-status-chips/FailedBadEmail';
 import FailedCancellation from './assignments-status-chips/FailedCancellation';

--- a/src/components/learner-credit-management/AssignmentTableCancel.jsx
+++ b/src/components/learner-credit-management/AssignmentTableCancel.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button } from '@edx/paragon';
-import { DoNotDisturbOn } from '@edx/paragon/icons';
+import { Button } from '@openedx/paragon';
+import { DoNotDisturbOn } from '@openedx/paragon/icons';
 import CancelAssignmentModal from './CancelAssignmentModal';
 import useCancelContentAssignments from './data/hooks/useCancelContentAssignments';
 

--- a/src/components/learner-credit-management/AssignmentTableRemind.jsx
+++ b/src/components/learner-credit-management/AssignmentTableRemind.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button } from '@edx/paragon';
-import { Mail } from '@edx/paragon/icons';
+import { Button } from '@openedx/paragon';
+import { Mail } from '@openedx/paragon/icons';
 import useRemindContentAssignments from './data/hooks/useRemindContentAssignments';
 import RemindAssignmentModal from './RemindAssignmentModal';
 

--- a/src/components/learner-credit-management/AssignmentsTableRefreshAction.jsx
+++ b/src/components/learner-credit-management/AssignmentsTableRefreshAction.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from '@edx/paragon';
+import { Button } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { connect } from 'react-redux';

--- a/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
+++ b/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { DataTable, CheckboxFilter } from '@edx/paragon';
+import { DataTable, CheckboxFilter } from '@openedx/paragon';
 import TableTextFilter from './TableTextFilter';
 import CustomDataTableEmptyState from './CustomDataTableEmptyState';
 import AssignmentDetailsTableCell from './AssignmentDetailsTableCell';

--- a/src/components/learner-credit-management/BudgetDetailActivityTabContents.jsx
+++ b/src/components/learner-credit-management/BudgetDetailActivityTabContents.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Stack, Skeleton } from '@edx/paragon';
+import { Stack, Skeleton } from '@openedx/paragon';
 
 import BudgetDetailRedemptions from './BudgetDetailRedemptions';
 import BudgetDetailAssignments from './BudgetDetailAssignments';

--- a/src/components/learner-credit-management/BudgetDetailAssignments.jsx
+++ b/src/components/learner-credit-management/BudgetDetailAssignments.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Hyperlink } from '@edx/paragon';
+import { Hyperlink } from '@openedx/paragon';
 import { getConfig } from '@edx/frontend-platform/config';
 
 import { useHistory } from 'react-router-dom';

--- a/src/components/learner-credit-management/BudgetDetailCatalogTabContents.jsx
+++ b/src/components/learner-credit-management/BudgetDetailCatalogTabContents.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { InstantSearch } from 'react-instantsearch-dom';
 import algoliasearch from 'algoliasearch/lite';
-import { Row, Col } from '@edx/paragon';
+import { Row, Col } from '@openedx/paragon';
 
 import { SearchData, SEARCH_FACET_FILTERS } from '@edx/frontend-enterprise-catalog-search';
 import { useHistory } from 'react-router';

--- a/src/components/learner-credit-management/BudgetDetailPage.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Skeleton, Stack } from '@edx/paragon';
+import { Skeleton, Stack } from '@openedx/paragon';
 
 import { useBudgetId, useEnterpriseOffer, useSubsidyAccessPolicy } from './data';
 import BudgetDetailTabsAndRoutes from './BudgetDetailTabsAndRoutes';

--- a/src/components/learner-credit-management/BudgetDetailPageBreadcrumbs.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPageBreadcrumbs.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Breadcrumb } from '@edx/paragon';
+import { Breadcrumb } from '@openedx/paragon';
 import { Link } from 'react-router-dom';
 import React from 'react';
 import { ROUTE_NAMES } from '../EnterpriseApp/data/constants';

--- a/src/components/learner-credit-management/BudgetDetailPageHeader.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPageHeader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   Stack, Card, Badge, Skeleton,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';

--- a/src/components/learner-credit-management/BudgetDetailPageOverviewAvailability.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPageOverviewAvailability.jsx
@@ -4,8 +4,8 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 import {
   Button, Col, Hyperlink, ProgressBar, Row, Stack, useMediaQuery, breakpoints,
-} from '@edx/paragon';
-import { Add } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Add } from '@openedx/paragon/icons';
 import { generatePath, useRouteMatch, Link } from 'react-router-dom';
 import { formatPrice } from './data';
 import { configuration } from '../../config';

--- a/src/components/learner-credit-management/BudgetDetailPageOverviewUtilization.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPageOverviewUtilization.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import {
   Stack, Collapsible, Row, Col, Button,
-} from '@edx/paragon';
-import { ArrowDownward } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { ArrowDownward } from '@openedx/paragon/icons';
 
 import {
   generatePath, useRouteMatch, Link,

--- a/src/components/learner-credit-management/BudgetDetailPageWrapper.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPageWrapper.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
-import { Container, Toast } from '@edx/paragon';
+import { Container, Toast } from '@openedx/paragon';
 
 import Hero from '../Hero';
 import { useSuccessfulAssignmentToastContextValue, useSuccessfulCancellationToastContextValue, useSuccessfulReminderToastContextValue } from './data';

--- a/src/components/learner-credit-management/BudgetDetailRedemptions.jsx
+++ b/src/components/learner-credit-management/BudgetDetailRedemptions.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Hyperlink } from '@edx/paragon';
+import { Hyperlink } from '@openedx/paragon';
 import { getConfig } from '@edx/frontend-platform/config';
 
 import { useHistory } from 'react-router';

--- a/src/components/learner-credit-management/BudgetDetailTabsAndRoutes.jsx
+++ b/src/components/learner-credit-management/BudgetDetailTabsAndRoutes.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { useHistory, useParams } from 'react-router-dom';
-import { Tabs } from '@edx/paragon';
+import { Tabs } from '@openedx/paragon';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
 import {

--- a/src/components/learner-credit-management/CancelAssignmentModal.jsx
+++ b/src/components/learner-credit-management/CancelAssignmentModal.jsx
@@ -2,8 +2,8 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import {
   ActionRow, ModalDialog, StatefulButton,
-} from '@edx/paragon';
-import { DoNotDisturbOn } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { DoNotDisturbOn } from '@openedx/paragon/icons';
 import { BudgetDetailPageContext } from './BudgetDetailPageWrapper';
 
 const CancelAssignmentModal = ({

--- a/src/components/learner-credit-management/CustomDataTableEmptyState.jsx
+++ b/src/components/learner-credit-management/CustomDataTableEmptyState.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { DataTable, DataTableContext } from '@edx/paragon';
+import { DataTable, DataTableContext } from '@openedx/paragon';
 
 const CustomDataTableEmptyState = () => {
   const { isLoading } = useContext(DataTableContext);

--- a/src/components/learner-credit-management/EmailAddressTableCell.jsx
+++ b/src/components/learner-credit-management/EmailAddressTableCell.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import {
   Stack, OverlayTrigger, IconButton, Icon, Popover,
-} from '@edx/paragon';
-import { InfoOutline } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { InfoOutline } from '@openedx/paragon/icons';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
 /**

--- a/src/components/learner-credit-management/LearnerCreditAggregateCards.jsx
+++ b/src/components/learner-credit-management/LearnerCreditAggregateCards.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Col, Card, ProgressBar, Skeleton,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 
 import { getProgressBarVariant } from './data/utils';
 

--- a/src/components/learner-credit-management/LearnerCreditAllocationTable.jsx
+++ b/src/components/learner-credit-management/LearnerCreditAllocationTable.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { DataTable } from '@edx/paragon';
+import { DataTable } from '@openedx/paragon';
 
 import TableTextFilter from './TableTextFilter';
 import CustomDataTableEmptyState from './CustomDataTableEmptyState';

--- a/src/components/learner-credit-management/LearnerCreditDisclaimer.jsx
+++ b/src/components/learner-credit-management/LearnerCreditDisclaimer.jsx
@@ -1,7 +1,7 @@
 import {
   Icon, Col, Stack,
-} from '@edx/paragon';
-import { Info } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Info } from '@openedx/paragon/icons';
 import PropTypes from 'prop-types';
 
 const LearnerCreditDisclaimer = ({ offerLastUpdated }) => (

--- a/src/components/learner-credit-management/MultipleBudgetsPage.jsx
+++ b/src/components/learner-credit-management/MultipleBudgetsPage.jsx
@@ -8,7 +8,7 @@ import {
   Hyperlink,
   Container,
   Skeleton,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { connect } from 'react-redux';
 import { Helmet } from 'react-helmet';
 

--- a/src/components/learner-credit-management/MultipleBudgetsPicker.jsx
+++ b/src/components/learner-credit-management/MultipleBudgetsPicker.jsx
@@ -4,7 +4,7 @@ import {
   Stack,
   Row,
   Col,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 
 import BudgetCard from './BudgetCard';
 import { orderBudgets } from './data/utils';

--- a/src/components/learner-credit-management/NoBudgetActivityEmptyState.jsx
+++ b/src/components/learner-credit-management/NoBudgetActivityEmptyState.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {
   Button, Card, Row, Col,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';

--- a/src/components/learner-credit-management/OfferUtilizationAlerts.jsx
+++ b/src/components/learner-credit-management/OfferUtilizationAlerts.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { Alert } from '@edx/paragon';
-import { Info, WarningFilled } from '@edx/paragon/icons';
+import { Alert } from '@openedx/paragon';
+import { Info, WarningFilled } from '@openedx/paragon/icons';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
 import ContactCustomerSupportButton from '../ContactCustomerSupportButton';

--- a/src/components/learner-credit-management/PendingAssignmentCancelButton.jsx
+++ b/src/components/learner-credit-management/PendingAssignmentCancelButton.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Icon, IconButtonWithTooltip,
-} from '@edx/paragon';
-import { DoNotDisturbOn } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { DoNotDisturbOn } from '@openedx/paragon/icons';
 import useCancelContentAssignments from './data/hooks/useCancelContentAssignments';
 import CancelAssignmentModal from './CancelAssignmentModal';
 

--- a/src/components/learner-credit-management/PendingAssignmentRemindButton.jsx
+++ b/src/components/learner-credit-management/PendingAssignmentRemindButton.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Icon, IconButtonWithTooltip } from '@edx/paragon';
+import { Icon, IconButtonWithTooltip } from '@openedx/paragon';
 
-import { Mail } from '@edx/paragon/icons';
+import { Mail } from '@openedx/paragon/icons';
 import RemindAssignmentModal from './RemindAssignmentModal';
 import useRemindContentAssignments from './data/hooks/useRemindContentAssignments';
 

--- a/src/components/learner-credit-management/RemindAssignmentModal.jsx
+++ b/src/components/learner-credit-management/RemindAssignmentModal.jsx
@@ -2,8 +2,8 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import {
   ActionRow, ModalDialog, StatefulButton,
-} from '@edx/paragon';
-import { Mail } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Mail } from '@openedx/paragon/icons';
 import { BudgetDetailPageContext } from './BudgetDetailPageWrapper';
 
 const RemindAssignmentModal = ({

--- a/src/components/learner-credit-management/SpendTableAmountContents.jsx
+++ b/src/components/learner-credit-management/SpendTableAmountContents.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Stack } from '@edx/paragon';
+import { Stack } from '@openedx/paragon';
 
 import { formatPrice } from './data';
 

--- a/src/components/learner-credit-management/SpendTableEnrollmentDetails.jsx
+++ b/src/components/learner-credit-management/SpendTableEnrollmentDetails.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Stack, Hyperlink } from '@edx/paragon';
+import { Stack, Hyperlink } from '@openedx/paragon';
 import { getConfig } from '@edx/frontend-platform';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 

--- a/src/components/learner-credit-management/SubBudgetCard.jsx
+++ b/src/components/learner-credit-management/SubBudgetCard.jsx
@@ -11,7 +11,7 @@ import {
   Badge,
   Stack,
   Skeleton,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 
 import { BUDGET_STATUSES, ROUTE_NAMES } from '../EnterpriseApp/data/constants';
 import { formatPrice, getBudgetStatus } from './data/utils';

--- a/src/components/learner-credit-management/TableTextFilter.jsx
+++ b/src/components/learner-credit-management/TableTextFilter.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Form, Icon } from '@edx/paragon';
-import { Search } from '@edx/paragon/icons';
+import { Form, Icon } from '@openedx/paragon';
+import { Search } from '@openedx/paragon/icons';
 
 const formatHeaderForLabel = (Header) => {
   if (typeof Header === 'function') {

--- a/src/components/learner-credit-management/assignments-status-chips/BaseModalPopup.jsx
+++ b/src/components/learner-credit-management/assignments-status-chips/BaseModalPopup.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Icon, ModalPopup } from '@edx/paragon';
+import { Icon, ModalPopup } from '@openedx/paragon';
 import { ASSIGNMENT_STATUS_MODAL_MAX_WIDTH } from '../data';
 
 export const BaseModalPopupHeading = ({ icon, iconClassName, children }) => (

--- a/src/components/learner-credit-management/assignments-status-chips/FailedBadEmail.jsx
+++ b/src/components/learner-credit-management/assignments-status-chips/FailedBadEmail.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Chip, Hyperlink, useToggle } from '@edx/paragon';
-import { Error } from '@edx/paragon/icons';
+import { Chip, Hyperlink, useToggle } from '@openedx/paragon';
+import { Error } from '@openedx/paragon/icons';
 import { getConfig } from '@edx/frontend-platform/config';
 
 import BaseModalPopup from './BaseModalPopup';

--- a/src/components/learner-credit-management/assignments-status-chips/FailedCancellation.jsx
+++ b/src/components/learner-credit-management/assignments-status-chips/FailedCancellation.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { Chip, useToggle, Hyperlink } from '@edx/paragon';
-import { Error } from '@edx/paragon/icons';
+import { Chip, useToggle, Hyperlink } from '@openedx/paragon';
+import { Error } from '@openedx/paragon/icons';
 import { getConfig } from '@edx/frontend-platform/config';
 
 import BaseModalPopup from './BaseModalPopup';

--- a/src/components/learner-credit-management/assignments-status-chips/FailedRedemption.jsx
+++ b/src/components/learner-credit-management/assignments-status-chips/FailedRedemption.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { Chip, Hyperlink, useToggle } from '@edx/paragon';
-import { Error } from '@edx/paragon/icons';
+import { Chip, Hyperlink, useToggle } from '@openedx/paragon';
+import { Error } from '@openedx/paragon/icons';
 import { getConfig } from '@edx/frontend-platform/config';
 
 import BaseModalPopup from './BaseModalPopup';

--- a/src/components/learner-credit-management/assignments-status-chips/FailedReminder.jsx
+++ b/src/components/learner-credit-management/assignments-status-chips/FailedReminder.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { Chip, useToggle, Hyperlink } from '@edx/paragon';
-import { Error } from '@edx/paragon/icons';
+import { Chip, useToggle, Hyperlink } from '@openedx/paragon';
+import { Error } from '@openedx/paragon/icons';
 import BaseModalPopup from './BaseModalPopup';
 
 const FailedReminder = () => {

--- a/src/components/learner-credit-management/assignments-status-chips/FailedSystem.jsx
+++ b/src/components/learner-credit-management/assignments-status-chips/FailedSystem.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { Chip, Hyperlink, useToggle } from '@edx/paragon';
-import { Error } from '@edx/paragon/icons';
+import { Chip, Hyperlink, useToggle } from '@openedx/paragon';
+import { Error } from '@openedx/paragon/icons';
 import { getConfig } from '@edx/frontend-platform/config';
 
 import BaseModalPopup from './BaseModalPopup';

--- a/src/components/learner-credit-management/assignments-status-chips/NotifyingLearner.jsx
+++ b/src/components/learner-credit-management/assignments-status-chips/NotifyingLearner.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Chip, useToggle } from '@edx/paragon';
-import { Send } from '@edx/paragon/icons';
+import { Chip, useToggle } from '@openedx/paragon';
+import { Send } from '@openedx/paragon/icons';
 import BaseModalPopup from './BaseModalPopup';
 
 const NotifyingLearner = ({ learnerEmail }) => {

--- a/src/components/learner-credit-management/assignments-status-chips/WaitingForLearner.jsx
+++ b/src/components/learner-credit-management/assignments-status-chips/WaitingForLearner.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Chip, Hyperlink, useToggle } from '@edx/paragon';
-import { Timelapse } from '@edx/paragon/icons';
+import { Chip, Hyperlink, useToggle } from '@openedx/paragon';
+import { Timelapse } from '@openedx/paragon/icons';
 import { getConfig } from '@edx/frontend-platform/config';
 
 import BaseModalPopup from './BaseModalPopup';

--- a/src/components/learner-credit-management/cards/AssignmentAllocationHelpCollapsibles.jsx
+++ b/src/components/learner-credit-management/cards/AssignmentAllocationHelpCollapsibles.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Collapsible, Stack } from '@edx/paragon';
+import { Collapsible, Stack } from '@openedx/paragon';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import React from 'react';
 import { ASSIGNMENT_ENROLLMENT_DEADLINE } from '../data';

--- a/src/components/learner-credit-management/cards/AssignmentModalContent.jsx
+++ b/src/components/learner-credit-management/cards/AssignmentModalContent.jsx
@@ -10,7 +10,7 @@ import {
   Col,
   Form,
   Card,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
 import { connect } from 'react-redux';

--- a/src/components/learner-credit-management/cards/AssignmentModalSummary.jsx
+++ b/src/components/learner-credit-management/cards/AssignmentModalSummary.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Card, Stack, Icon } from '@edx/paragon';
-import { Error } from '@edx/paragon/icons';
+import { Card, Stack, Icon } from '@openedx/paragon';
+import { Error } from '@openedx/paragon/icons';
 
 import { formatPrice } from '../data';
 import AssignmentModalSummaryEmptyState from './AssignmentModalSummaryEmptyState';

--- a/src/components/learner-credit-management/cards/AssignmentModalSummaryErrorState.jsx
+++ b/src/components/learner-credit-management/cards/AssignmentModalSummaryErrorState.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Stack, Icon } from '@edx/paragon';
-import { Error } from '@edx/paragon/icons';
+import { Stack, Icon } from '@openedx/paragon';
+import { Error } from '@openedx/paragon/icons';
 
 const AssignmentModalSummaryErrorState = () => (
   <Stack direction="horizontal" gap={3}>

--- a/src/components/learner-credit-management/cards/AssignmentModalSummaryLearnerList.jsx
+++ b/src/components/learner-credit-management/cards/AssignmentModalSummaryLearnerList.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
 import {
   Button, Stack, Icon,
-} from '@edx/paragon';
-import { Person } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Person } from '@openedx/paragon/icons';
 
 import { MAX_INITIAL_LEARNER_EMAILS_DISPLAYED_COUNT, hasLearnerEmailsSummaryListTruncation } from './data';
 

--- a/src/components/learner-credit-management/cards/BaseCourseCard.jsx
+++ b/src/components/learner-credit-management/cards/BaseCourseCard.jsx
@@ -7,7 +7,7 @@ import {
   Card,
   Stack,
   Badge,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 
 import { useCourseCardMetadata } from './data';

--- a/src/components/learner-credit-management/cards/CourseCardFooterActions.jsx
+++ b/src/components/learner-credit-management/cards/CourseCardFooterActions.jsx
@@ -1,4 +1,4 @@
-import { Button, Hyperlink } from '@edx/paragon';
+import { Button, Hyperlink } from '@openedx/paragon';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
 import PropTypes from 'prop-types';

--- a/src/components/learner-credit-management/cards/CreateAllocationErrorAlertModals.jsx
+++ b/src/components/learner-credit-management/cards/CreateAllocationErrorAlertModals.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { useToggle } from '@edx/paragon';
+import { useToggle } from '@openedx/paragon';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { connect } from 'react-redux';
 import SystemErrorAlertModal from './assignment-allocation-status-modals/SystemErrorAlertModal';

--- a/src/components/learner-credit-management/cards/NewAssignmentModalButton.jsx
+++ b/src/components/learner-credit-management/cards/NewAssignmentModalButton.jsx
@@ -8,7 +8,7 @@ import {
   useToggle,
   Hyperlink,
   StatefulButton,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { camelCaseObject, snakeCaseObject } from '@edx/frontend-platform/utils';

--- a/src/components/learner-credit-management/cards/assignment-allocation-status-modals/ContentNotInCatalogErrorAlertModal.jsx
+++ b/src/components/learner-credit-management/cards/assignment-allocation-status-modals/ContentNotInCatalogErrorAlertModal.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { AlertModal, ActionRow, Button } from '@edx/paragon';
-import { Error } from '@edx/paragon/icons';
+import { AlertModal, ActionRow, Button } from '@openedx/paragon';
+import { Error } from '@openedx/paragon/icons';
 
 import { commonErrorAlertModalPropTypes, getBudgetDisplayName } from '../data';
 import { useBudgetId, useSubsidyAccessPolicy } from '../../data';

--- a/src/components/learner-credit-management/cards/assignment-allocation-status-modals/NotEnoughBalanceAlertModal.jsx
+++ b/src/components/learner-credit-management/cards/assignment-allocation-status-modals/NotEnoughBalanceAlertModal.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { AlertModal, ActionRow, Button } from '@edx/paragon';
-import { Error } from '@edx/paragon/icons';
+import { AlertModal, ActionRow, Button } from '@openedx/paragon';
+import { Error } from '@openedx/paragon/icons';
 
 import { commonErrorAlertModalPropTypes, getBudgetDisplayName } from '../data';
 import { formatPrice, useBudgetId, useSubsidyAccessPolicy } from '../../data';

--- a/src/components/learner-credit-management/cards/assignment-allocation-status-modals/SystemErrorAlertModal.jsx
+++ b/src/components/learner-credit-management/cards/assignment-allocation-status-modals/SystemErrorAlertModal.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ActionRow, AlertModal, Button } from '@edx/paragon';
-import { Error } from '@edx/paragon/icons';
+import { ActionRow, AlertModal, Button } from '@openedx/paragon';
+import { Error } from '@openedx/paragon/icons';
 
 import { commonErrorAlertModalPropTypes } from '../data';
 

--- a/src/components/learner-credit-management/data/hooks/useBudgetDetailTabs.jsx
+++ b/src/components/learner-credit-management/data/hooks/useBudgetDetailTabs.jsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Tab } from '@edx/paragon';
+import { Tab } from '@openedx/paragon';
 
 import {
   BUDGET_DETAIL_ACTIVITY_TAB,

--- a/src/components/learner-credit-management/data/hooks/useCancelContentAssignments.js
+++ b/src/components/learner-credit-management/data/hooks/useCancelContentAssignments.js
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { logError } from '@edx/frontend-platform/logging';
-import { useToggle } from '@edx/paragon';
+import { useToggle } from '@openedx/paragon';
 
 import EnterpriseAccessApiService from '../../../../data/services/EnterpriseAccessApiService';
 import { learnerCreditManagementQueryKeys } from '../constants';

--- a/src/components/learner-credit-management/data/hooks/useIsLargeOrGreater.js
+++ b/src/components/learner-credit-management/data/hooks/useIsLargeOrGreater.js
@@ -1,4 +1,4 @@
-import { breakpoints, useMediaQuery } from '@edx/paragon';
+import { breakpoints, useMediaQuery } from '@openedx/paragon';
 
 const useIsLargeOrGreater = () => useMediaQuery({ query: `(min-width: ${breakpoints.large.minWidth}px)` });
 

--- a/src/components/learner-credit-management/data/hooks/useRemindContentAssignments.js
+++ b/src/components/learner-credit-management/data/hooks/useRemindContentAssignments.js
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { logError } from '@edx/frontend-platform/logging';
-import { useToggle } from '@edx/paragon';
+import { useToggle } from '@openedx/paragon';
 
 import EnterpriseAccessApiService from '../../../../data/services/EnterpriseAccessApiService';
 import { learnerCreditManagementQueryKeys } from '../constants';

--- a/src/components/learner-credit-management/search/CatalogSearchResults.jsx
+++ b/src/components/learner-credit-management/search/CatalogSearchResults.jsx
@@ -6,7 +6,7 @@ import { SearchPagination, SearchContext } from '@edx/frontend-enterprise-catalo
 import { FormattedMessage, injectIntl } from '@edx/frontend-platform/i18n';
 import {
   Alert, CardView, DataTable, TextFilter,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 
 import CourseCard from '../cards/CourseCard';
 import { DEFAULT_PAGE, SEARCH_RESULT_PAGE_SIZE } from '../data';

--- a/src/components/learner-credit-management/tests/BudgetDetailPageWrapper.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPageWrapper.test.jsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { Button } from '@edx/paragon';
+import { Button } from '@openedx/paragon';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import configureMockStore from 'redux-mock-store';

--- a/src/components/learner-credit-management/tests/OfferUtilizationAlerts.test.jsx
+++ b/src/components/learner-credit-management/tests/OfferUtilizationAlerts.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ALERT_CLOSE_LABEL_TEXT } from '@edx/paragon';
+import { ALERT_CLOSE_LABEL_TEXT } from '@openedx/paragon';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/src/components/settings/ConfigErrorModal.tsx
+++ b/src/components/settings/ConfigErrorModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   AlertModal, ActionRow, Button, Hyperlink,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { HELP_CENTER_LINK } from './data/constants';
 
 const cardText = 'We were unable to process your request to submit a new LMS configuration. Please try submitting again or contact support for help.';

--- a/src/components/settings/HelpCenterButton.jsx
+++ b/src/components/settings/HelpCenterButton.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Hyperlink } from '@edx/paragon';
+import { Hyperlink } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 
 const HelpCenterButton = ({

--- a/src/components/settings/SettingsAccessTab/ActionsTableCell.jsx
+++ b/src/components/settings/SettingsAccessTab/ActionsTableCell.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { ActionRow, Button } from '@edx/paragon';
+import { ActionRow, Button } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import { getConfig } from '@edx/frontend-platform/config';
 import { logError } from '@edx/frontend-platform/logging';

--- a/src/components/settings/SettingsAccessTab/DisableLinkManagementAlertModal.jsx
+++ b/src/components/settings/SettingsAccessTab/DisableLinkManagementAlertModal.jsx
@@ -6,8 +6,8 @@ import {
   Alert,
   Button,
   StatefulButton,
-} from '@edx/paragon';
-import { Info } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Info } from '@openedx/paragon/icons';
 
 const DisableLinkManagementAlertModal = ({
   isOpen,

--- a/src/components/settings/SettingsAccessTab/LinkCopiedToast.jsx
+++ b/src/components/settings/SettingsAccessTab/LinkCopiedToast.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Toast } from '@edx/paragon';
+import { Toast } from '@openedx/paragon';
 
 const LinkCopiedToast = (props) => (
   <Toast {...props}>

--- a/src/components/settings/SettingsAccessTab/LinkDeactivationAlertModal.jsx
+++ b/src/components/settings/SettingsAccessTab/LinkDeactivationAlertModal.jsx
@@ -5,7 +5,7 @@ import {
   AlertModal,
   Button,
   StatefulButton,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { logError } from '@edx/frontend-platform/logging';
 import LmsApiService from '../../../data/services/LmsApiService';
 

--- a/src/components/settings/SettingsAccessTab/SettingsAccessConfiguredSubsidyType.jsx
+++ b/src/components/settings/SettingsAccessTab/SettingsAccessConfiguredSubsidyType.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { CheckCircle } from '@edx/paragon/icons';
+import { CheckCircle } from '@openedx/paragon/icons';
 import {
   OverlayTrigger,
   Tooltip,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import { SUBSIDY_TYPE_LABELS } from '../data/constants';
 

--- a/src/components/settings/SettingsAccessTab/SettingsAccessGenerateLinkButton.jsx
+++ b/src/components/settings/SettingsAccessTab/SettingsAccessGenerateLinkButton.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   StatefulButton,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { logError } from '@edx/frontend-platform/logging';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 

--- a/src/components/settings/SettingsAccessTab/SettingsAccessLinkManagement.jsx
+++ b/src/components/settings/SettingsAccessTab/SettingsAccessLinkManagement.jsx
@@ -4,8 +4,8 @@ import { connect } from 'react-redux';
 import {
   DataTable,
   Alert,
-} from '@edx/paragon';
-import { Info } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Info } from '@openedx/paragon/icons';
 import { logError } from '@edx/frontend-platform/logging';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 

--- a/src/components/settings/SettingsAccessTab/SettingsAccessSSOManagement.jsx
+++ b/src/components/settings/SettingsAccessTab/SettingsAccessSSOManagement.jsx
@@ -1,10 +1,10 @@
 import React, { useState, useCallback } from 'react';
 
 import PropTypes from 'prop-types';
-import { Info } from '@edx/paragon/icons';
+import { Info } from '@openedx/paragon/icons';
 import {
   Alert,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import SettingsAccessTabSection from './SettingsAccessTabSection';
 import LmsApiService from '../../../data/services/LmsApiService';
 

--- a/src/components/settings/SettingsAccessTab/SettingsAccessSubsidyRequestManagement.jsx
+++ b/src/components/settings/SettingsAccessTab/SettingsAccessSubsidyRequestManagement.jsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { Info } from '@edx/paragon/icons';
+import { Info } from '@openedx/paragon/icons';
 import {
   Alert,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { SUPPORTED_SUBSIDY_TYPES } from '../../../data/constants/subsidyRequests';
 import SettingsAccessTabSection from './SettingsAccessTabSection';
 

--- a/src/components/settings/SettingsAccessTab/SettingsAccessSubsidyTypeSelection.jsx
+++ b/src/components/settings/SettingsAccessTab/SettingsAccessSubsidyTypeSelection.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState, useMemo } from 'react';
 import {
   Form,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import { SUPPORTED_SUBSIDY_TYPES } from '../../../data/constants/subsidyRequests';
 import ConfirmationModal, { CONFIRM_BUTTON_STATES } from '../../ConfirmationModal';

--- a/src/components/settings/SettingsAccessTab/SettingsAccessTabSection.jsx
+++ b/src/components/settings/SettingsAccessTab/SettingsAccessTabSection.jsx
@@ -4,7 +4,7 @@ import {
   Collapsible,
   Form,
   Spinner,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 
 const SettingsAccessTabSection = ({
   title,

--- a/src/components/settings/SettingsAccessTab/StatusTableCell.jsx
+++ b/src/components/settings/SettingsAccessTab/StatusTableCell.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Badge } from '@edx/paragon';
+import { Badge } from '@openedx/paragon';
 
 const StatusTableCell = ({ row }) => {
   const { isValid } = row.original;

--- a/src/components/settings/SettingsAccessTab/index.jsx
+++ b/src/components/settings/SettingsAccessTab/index.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { Col, Row } from '@edx/paragon';
+import { Col, Row } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 

--- a/src/components/settings/SettingsApiCredentialsTab/APICredentialsPage.jsx
+++ b/src/components/settings/SettingsApiCredentialsTab/APICredentialsPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
-import { Form, Hyperlink } from '@edx/paragon';
+import { Form, Hyperlink } from '@openedx/paragon';
 import { dataPropType } from './constants';
 import RegenerateCredentialWarningModal from './RegenerateCredentialWarningModal';
 import CopyButton from './CopyButton';

--- a/src/components/settings/SettingsApiCredentialsTab/CopiedToast.jsx
+++ b/src/components/settings/SettingsApiCredentialsTab/CopiedToast.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Toast } from '@edx/paragon';
+import { Toast } from '@openedx/paragon';
 
 const CopiedToast = ({ content, ...rest }) => (
   <Toast {...rest}>

--- a/src/components/settings/SettingsApiCredentialsTab/CopyButton.jsx
+++ b/src/components/settings/SettingsApiCredentialsTab/CopyButton.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
-import { Button } from '@edx/paragon';
-import { ContentCopy } from '@edx/paragon/icons';
+import { Button } from '@openedx/paragon';
+import { ContentCopy } from '@openedx/paragon/icons';
 import CopiedToast from './CopiedToast';
 import { dataPropType } from './constants';
 

--- a/src/components/settings/SettingsApiCredentialsTab/FailedAlert.jsx
+++ b/src/components/settings/SettingsApiCredentialsTab/FailedAlert.jsx
@@ -1,5 +1,5 @@
-import { Alert } from '@edx/paragon';
-import { Error } from '@edx/paragon/icons';
+import { Alert } from '@openedx/paragon';
+import { Error } from '@openedx/paragon/icons';
 import { credentialErrorMessage } from './constants';
 
 const FailedAlert = () => (

--- a/src/components/settings/SettingsApiCredentialsTab/RegenerateCredentialWarningModal.jsx
+++ b/src/components/settings/SettingsApiCredentialsTab/RegenerateCredentialWarningModal.jsx
@@ -2,8 +2,8 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import {
   ActionRow, Button, Icon, ModalDialog, useToggle,
-} from '@edx/paragon';
-import { Warning } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Warning } from '@openedx/paragon/icons';
 
 import {
   ErrorContext,

--- a/src/components/settings/SettingsApiCredentialsTab/ZeroStateCard.jsx
+++ b/src/components/settings/SettingsApiCredentialsTab/ZeroStateCard.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 
 import {
   Button, Card, Hyperlink, Icon, Spinner,
-} from '@edx/paragon';
-import { Add, Error } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Add, Error } from '@openedx/paragon/icons';
 
 import { credentialErrorMessage } from './constants';
 import cardImage from '../../../data/images/ZeroState.svg';

--- a/src/components/settings/SettingsApiCredentialsTab/index.jsx
+++ b/src/components/settings/SettingsApiCredentialsTab/index.jsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { logError } from '@edx/frontend-platform/logging';
-import { ActionRow, Toast } from '@edx/paragon';
+import { ActionRow, Toast } from '@openedx/paragon';
 import ZeroStateCard from './ZeroStateCard';
 import APICredentialsPage from './APICredentialsPage';
 import FailedAlert from './FailedAlert';

--- a/src/components/settings/SettingsAppearanceTab/CustomThemeModal.jsx
+++ b/src/components/settings/SettingsAppearanceTab/CustomThemeModal.jsx
@@ -4,8 +4,8 @@ import Color from 'color';
 import ColorContrastChecker from 'color-contrast-checker';
 import {
   ActionRow, Button, Form, Hyperlink, Icon, ModalDialog,
-} from '@edx/paragon';
-import { InfoOutline } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { InfoOutline } from '@openedx/paragon/icons';
 import {
   CUSTOM_THEME_LABEL, HELP_CENTER_BRANDING_LINK, DARK_COLOR, WHITE_COLOR,
 } from '../data/constants';

--- a/src/components/settings/SettingsAppearanceTab/ThemeCard.jsx
+++ b/src/components/settings/SettingsAppearanceTab/ThemeCard.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import {
   ActionRow, Button, Card, Form,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import ThemeSvg from './ThemeSvg';
 import { CUSTOM_THEME_LABEL, SCHOLAR_THEME } from '../data/constants';
 

--- a/src/components/settings/SettingsAppearanceTab/index.jsx
+++ b/src/components/settings/SettingsAppearanceTab/index.jsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   Alert, Button, CardGrid, Dropzone, Image, Toast, useToggle,
-} from '@edx/paragon';
-import { Info } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Info } from '@openedx/paragon/icons';
 
 import InfoHover from '../../InfoHover';
 import LmsApiService from '../../../data/services/LmsApiService';

--- a/src/components/settings/SettingsLMSTab/ErrorReporting/ContentMetadataTable.jsx
+++ b/src/components/settings/SettingsLMSTab/ErrorReporting/ContentMetadataTable.jsx
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import React, { useCallback, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
-import { DataTable, TextFilter } from '@edx/paragon';
+import { DataTable, TextFilter } from '@openedx/paragon';
 import { logError } from '@edx/frontend-platform/logging';
 import LmsApiService from '../../../../data/services/LmsApiService';
 import DownloadCsvButton from './DownloadCsvButton';

--- a/src/components/settings/SettingsLMSTab/ErrorReporting/DownloadCsvButton.jsx
+++ b/src/components/settings/SettingsLMSTab/ErrorReporting/DownloadCsvButton.jsx
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 
 import {
   Toast, StatefulButton, Icon, Spinner, useToggle,
-} from '@edx/paragon';
-import { Download, Check } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Download, Check } from '@openedx/paragon/icons';
 import { logError } from '@edx/frontend-platform/logging';
 import { isStrictlyArray } from './utils';
 

--- a/src/components/settings/SettingsLMSTab/ErrorReporting/ErrorReportingTable.jsx
+++ b/src/components/settings/SettingsLMSTab/ErrorReporting/ErrorReportingTable.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Tab, Tabs } from '@edx/paragon';
+import { Tab, Tabs } from '@openedx/paragon';
 import ContentMetadataTable from './ContentMetadataTable';
 import LearnerMetadataTable from './LearnerMetadataTable';
 

--- a/src/components/settings/SettingsLMSTab/ErrorReporting/LearnerMetadataTable.jsx
+++ b/src/components/settings/SettingsLMSTab/ErrorReporting/LearnerMetadataTable.jsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React, { useCallback, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { DataTable, TextFilter } from '@edx/paragon';
+import { DataTable, TextFilter } from '@openedx/paragon';
 import { logError } from '@edx/frontend-platform/logging';
 import LmsApiService from '../../../../data/services/LmsApiService';
 import { createLookup, getSyncStatus, getTimeAgo } from './utils';

--- a/src/components/settings/SettingsLMSTab/ErrorReporting/SyncHistory.jsx
+++ b/src/components/settings/SettingsLMSTab/ErrorReporting/SyncHistory.jsx
@@ -4,8 +4,8 @@ import { camelCaseObject } from '@edx/frontend-platform/utils';
 import {
   ActionRow, AlertModal, Badge, Breadcrumb, Button, Card, Hyperlink,
   Icon, Image, Skeleton, Toast, useToggle,
-} from '@edx/paragon';
-import { CheckCircle, Error, Sync } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { CheckCircle, Error, Sync } from '@openedx/paragon/icons';
 import { getStatus } from '../utils';
 import { getTimeAgo } from './utils';
 import handleErrors from '../../utils';

--- a/src/components/settings/SettingsLMSTab/ErrorReporting/utils.jsx
+++ b/src/components/settings/SettingsLMSTab/ErrorReporting/utils.jsx
@@ -1,6 +1,6 @@
 import * as timeago from 'timeago.js';
-import { Hyperlink, OverlayTrigger, Popover } from '@edx/paragon';
-import { CheckCircle, Error, Sync } from '@edx/paragon/icons';
+import { Hyperlink, OverlayTrigger, Popover } from '@openedx/paragon';
+import { CheckCircle, Error, Sync } from '@openedx/paragon/icons';
 
 timeago.register('time-locale');
 /**

--- a/src/components/settings/SettingsLMSTab/ExistingCard.jsx
+++ b/src/components/settings/SettingsLMSTab/ExistingCard.jsx
@@ -4,10 +4,10 @@ import { useRouteMatch } from 'react-router-dom';
 import {
   ActionRow, AlertModal, Badge, Button, Card, Dropdown, Icon,
   IconButton, Image, OverlayTrigger, Popover,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import {
   CheckCircle, Error, MoreVert, Sync,
-} from '@edx/paragon/icons';
+} from '@openedx/paragon/icons';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { features } from '../../../config';
 import { channelMapping } from '../../../utils';

--- a/src/components/settings/SettingsLMSTab/ExistingLMSCardDeck.jsx
+++ b/src/components/settings/SettingsLMSTab/ExistingLMSCardDeck.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { CardGrid, useToggle } from '@edx/paragon';
+import { CardGrid, useToggle } from '@openedx/paragon';
 import { getStatus } from './utils';
 import ExistingCard from './ExistingCard';
 import ConfigErrorModal from '../ConfigErrorModal';

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/Blackboard/BlackboardConfigAuthorizePage.tsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/Blackboard/BlackboardConfigAuthorizePage.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {
   Alert, Container, Form, Image,
-} from '@edx/paragon';
-import { Info } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Info } from '@openedx/paragon/icons';
 
 import ValidatedFormControl from '../../../../forms/ValidatedFormControl';
 import { BLACKBOARD_TYPE, INVALID_LINK, INVALID_NAME } from '../../../data/constants';

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/Canvas/CanvasConfigAuthorizePage.tsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/Canvas/CanvasConfigAuthorizePage.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import {
   Alert, Container, Form, Image,
-} from '@edx/paragon';
-import { Info } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Info } from '@openedx/paragon/icons';
 
 import { CANVAS_TYPE, INVALID_LINK, INVALID_NAME } from '../../../data/constants';
 import ValidatedFormControl from '../../../../forms/ValidatedFormControl';

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/ConfigBasePages/ConfigActivatePage.tsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/ConfigBasePages/ConfigActivatePage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Container, Form, Image } from '@edx/paragon';
+import { Container, Form, Image } from '@openedx/paragon';
 import { BLACKBOARD_TYPE, CANVAS_TYPE } from '../../../data/constants';
 import { channelMapping } from '../../../../../utils';
 

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/Cornerstone/CornerstoneConfigEnablePage.tsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/Cornerstone/CornerstoneConfigEnablePage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Container, Form, Image } from '@edx/paragon';
+import { Container, Form, Image } from '@openedx/paragon';
 
 import { CORNERSTONE_TYPE, INVALID_LINK, INVALID_NAME } from '../../../data/constants';
 import ValidatedFormControl from '../../../../forms/ValidatedFormControl';

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/Degreed/DegreedConfigEnablePage.tsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/Degreed/DegreedConfigEnablePage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Container, Form, Image } from '@edx/paragon';
+import { Container, Form, Image } from '@openedx/paragon';
 
 import { DEGREED2_TYPE, INVALID_LINK, INVALID_NAME } from '../../../data/constants';
 import ValidatedFormControl from '../../../../forms/ValidatedFormControl';

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/Moodle/MoodleConfigEnablePage.tsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/Moodle/MoodleConfigEnablePage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Container, Form, Image } from '@edx/paragon';
+import { Container, Form, Image } from '@openedx/paragon';
 
 import ValidatedFormControl from '../../../../forms/ValidatedFormControl';
 import { channelMapping, urlValidation } from '../../../../../utils';

--- a/src/components/settings/SettingsLMSTab/LMSConfigs/SAP/SAPConfigEnablePage.tsx
+++ b/src/components/settings/SettingsLMSTab/LMSConfigs/SAP/SAPConfigEnablePage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Container, Form, Image } from '@edx/paragon';
+import { Container, Form, Image } from '@openedx/paragon';
 
 import ValidatedFormControl from '../../../../forms/ValidatedFormControl';
 import ValidatedFormRadio from '../../../../forms/ValidatedFormRadio';

--- a/src/components/settings/SettingsLMSTab/LMSSelectorPage.tsx
+++ b/src/components/settings/SettingsLMSTab/LMSSelectorPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Container, Image, SelectableBox } from '@edx/paragon';
+import { Container, Image, SelectableBox } from '@openedx/paragon';
 
 import { channelMapping } from '../../../utils';
 import { LMS_KEYS } from '../data/constants';

--- a/src/components/settings/SettingsLMSTab/NoConfigCard.jsx
+++ b/src/components/settings/SettingsLMSTab/NoConfigCard.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 
-import { Button, Card, Icon } from '@edx/paragon';
+import { Button, Card, Icon } from '@openedx/paragon';
 
-import { Add, Error } from '@edx/paragon/icons';
+import { Add, Error } from '@openedx/paragon/icons';
 import cardImage from '../../../data/images/NoConfig.svg';
 
 const NoConfigCard = ({

--- a/src/components/settings/SettingsLMSTab/UnsavedChangesModal.tsx
+++ b/src/components/settings/SettingsLMSTab/UnsavedChangesModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ModalDialog, ActionRow, Button } from '@edx/paragon';
+import { ModalDialog, ActionRow, Button } from '@openedx/paragon';
 import { UnsavedChangesModalProps } from '../../forms/FormWorkflow';
 
 const MODAL_TITLE = 'Exit configuration';

--- a/src/components/settings/SettingsLMSTab/index.jsx
+++ b/src/components/settings/SettingsLMSTab/index.jsx
@@ -8,8 +8,8 @@ import PropTypes from 'prop-types';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 import {
   Alert, Button, Toast, Skeleton, useToggle,
-} from '@edx/paragon';
-import { Add, Info } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Add, Info } from '@openedx/paragon/icons';
 import { logError } from '@edx/frontend-platform/logging';
 
 import HelpCenterButton from '../HelpCenterButton';

--- a/src/components/settings/SettingsSSOTab/ExistingSSOConfigs.jsx
+++ b/src/components/settings/SettingsSSOTab/ExistingSSOConfigs.jsx
@@ -3,10 +3,10 @@ import { useState, useContext } from 'react';
 import { connect } from 'react-redux';
 import {
   Badge, Card, CardGrid, Dropdown, Icon, IconButton, useToggle,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import {
   Delete, Edit, MoreVert, PlayCircleFilled, RemoveCircle,
-} from '@edx/paragon/icons';
+} from '@openedx/paragon/icons';
 import { SSOConfigContext } from './SSOConfigContext';
 import ConfigErrorModal from '../ConfigErrorModal';
 import handleErrors from '../utils';

--- a/src/components/settings/SettingsSSOTab/NewExistingSSOConfigs.jsx
+++ b/src/components/settings/SettingsSSOTab/NewExistingSSOConfigs.jsx
@@ -4,8 +4,8 @@ import {
   CardGrid,
   Skeleton,
   useToggle,
-} from '@edx/paragon';
-import { Info } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Info } from '@openedx/paragon/icons';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';

--- a/src/components/settings/SettingsSSOTab/NewSSOConfigAlerts.jsx
+++ b/src/components/settings/SettingsSSOTab/NewSSOConfigAlerts.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import {
   CheckCircle, Info, Warning,
-} from '@edx/paragon/icons';
-import { Alert, Button } from '@edx/paragon';
+} from '@openedx/paragon/icons';
+import { Alert, Button } from '@openedx/paragon';
 import Cookies from 'universal-cookie';
 import { SSOConfigContext } from './SSOConfigContext';
 

--- a/src/components/settings/SettingsSSOTab/NewSSOConfigCard.jsx
+++ b/src/components/settings/SettingsSSOTab/NewSSOConfigCard.jsx
@@ -1,11 +1,11 @@
 import React, { useContext } from 'react';
 import {
   Card, Badge, Button, Dropdown, IconButton, Icon, Tooltip, OverlayTrigger,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import {
   Key, KeyOff, MoreVert,
-} from '@edx/paragon/icons';
+} from '@openedx/paragon/icons';
 import { SSOConfigContext } from './SSOConfigContext';
 import LmsApiService from '../../../data/services/LmsApiService';
 

--- a/src/components/settings/SettingsSSOTab/NewSSOConfigForm.jsx
+++ b/src/components/settings/SettingsSSOTab/NewSSOConfigForm.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { Alert, Hyperlink } from '@edx/paragon';
-import { WarningFilled } from '@edx/paragon/icons';
+import { Alert, Hyperlink } from '@openedx/paragon';
+import { WarningFilled } from '@openedx/paragon/icons';
 import { SSOConfigContext } from './SSOConfigContext';
 import SSOStepper from './SSOStepper';
 import { HELP_CENTER_SAML_LINK } from '../data/constants';

--- a/src/components/settings/SettingsSSOTab/NoSSOCard.jsx
+++ b/src/components/settings/SettingsSSOTab/NoSSOCard.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Button, Card } from '@edx/paragon';
-import { Add } from '@edx/paragon/icons';
+import { Button, Card } from '@openedx/paragon';
+import { Add } from '@openedx/paragon/icons';
 import cardImage from '../../../data/images/NoSSO.svg';
 
 const NoSSOCard = ({

--- a/src/components/settings/SettingsSSOTab/SSOConfigConfiguredCard.jsx
+++ b/src/components/settings/SettingsSSOTab/SSOConfigConfiguredCard.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import {
   Form, Icon, OverlayTrigger, Popover, Button,
-} from '@edx/paragon';
-import { AddCircle, CheckCircle } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { AddCircle, CheckCircle } from '@openedx/paragon/icons';
 import React, { useContext, useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { SSOConfigContext } from './SSOConfigContext';

--- a/src/components/settings/SettingsSSOTab/SSOStepper.jsx
+++ b/src/components/settings/SettingsSSOTab/SSOStepper.jsx
@@ -1,8 +1,8 @@
 import {
   Button, Container, Stepper,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import PropTypes from 'prop-types';
-import { ArrowBack, ArrowForward } from '@edx/paragon/icons';
+import { ArrowBack, ArrowForward } from '@openedx/paragon/icons';
 import isEmpty from 'validator/lib/isEmpty';
 import isURL from 'validator/lib/isURL';
 import React, {

--- a/src/components/settings/SettingsSSOTab/SsoErrorPage.jsx
+++ b/src/components/settings/SettingsSSOTab/SsoErrorPage.jsx
@@ -6,7 +6,7 @@ import {
   FullscreenModal,
   Image,
   Stack,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { configuration } from '../../../config';
 import { ssoStepperNetworkErrorText, ssoLPNetworkErrorText, HELP_CENTER_SAML_LINK } from '../data/constants';
 import cardImage from '../../../data/images/SomethingWentWrong.svg';

--- a/src/components/settings/SettingsSSOTab/UnsavedSSOChangesModal.tsx
+++ b/src/components/settings/SettingsSSOTab/UnsavedSSOChangesModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ModalDialog, ActionRow, Button } from '@edx/paragon';
+import { ModalDialog, ActionRow, Button } from '@openedx/paragon';
 import { UnsavedChangesModalProps } from '../../forms/FormWorkflow';
 
 const UnsavedSSOChangesModal = ({

--- a/src/components/settings/SettingsSSOTab/index.jsx
+++ b/src/components/settings/SettingsSSOTab/index.jsx
@@ -2,8 +2,8 @@ import React, { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   Alert, ActionRow, Button, Hyperlink, ModalDialog, Toast, Skeleton, Spinner, useToggle,
-} from '@edx/paragon';
-import { Add, WarningFilled } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Add, WarningFilled } from '@openedx/paragon/icons';
 import { HELP_CENTER_SAML_LINK } from '../data/constants';
 import { useExistingSSOConfigs, useExistingProviderData } from './hooks';
 import NoSSOCard from './NoSSOCard';

--- a/src/components/settings/SettingsSSOTab/steps/NewSSOConfigAuthorizeStep.tsx
+++ b/src/components/settings/SettingsSSOTab/steps/NewSSOConfigAuthorizeStep.tsx
@@ -2,8 +2,8 @@ import React, { useContext } from 'react';
 import { useParams } from 'react-router-dom';
 import {
   Alert, Hyperlink, Button, Row,
-} from '@edx/paragon';
-import { Info, Download } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Info, Download } from '@openedx/paragon/icons';
 import { getConfig } from '@edx/frontend-platform/config';
 import { createSAMLURLs } from '../utils';
 import { SSOConfigContext } from '../SSOConfigContext';

--- a/src/components/settings/SettingsSSOTab/steps/NewSSOConfigConfigureStep.tsx
+++ b/src/components/settings/SettingsSSOTab/steps/NewSSOConfigConfigureStep.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {
   Alert, Button, Form, Container,
-} from '@edx/paragon';
-import { Info } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Info } from '@openedx/paragon/icons';
 
 import ValidatedFormControl from '../../../forms/ValidatedFormControl';
 import { FormContext, FormFieldValidation, useFormContext } from '../../../forms/FormContext';

--- a/src/components/settings/SettingsSSOTab/steps/NewSSOConfigConfirmStep.tsx
+++ b/src/components/settings/SettingsSSOTab/steps/NewSSOConfigConfirmStep.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {
   Alert, Hyperlink, OverlayTrigger, Popover,
-} from '@edx/paragon';
-import { Info } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Info } from '@openedx/paragon/icons';
 
 const IncognitoPopover = () => (
   <OverlayTrigger

--- a/src/components/settings/SettingsSSOTab/steps/NewSSOConfigConnectStep.tsx
+++ b/src/components/settings/SettingsSSOTab/steps/NewSSOConfigConnectStep.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Container, Dropzone, Form, Stack } from '@edx/paragon';
+import { Container, Dropzone, Form, Stack } from '@openedx/paragon';
 
 import ValidatedFormRadio from '../../../forms/ValidatedFormRadio';
 import ValidatedFormControl from '../../../forms/ValidatedFormControl';

--- a/src/components/settings/SettingsSSOTab/steps/SSOConfigConfigureStep.jsx
+++ b/src/components/settings/SettingsSSOTab/steps/SSOConfigConfigureStep.jsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from 'react';
 import {
   Alert, Button, Form, Hyperlink, ModalDialog,
-} from '@edx/paragon';
-import { Info } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Info } from '@openedx/paragon/icons';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import isURL from 'validator/lib/isURL';

--- a/src/components/settings/SettingsSSOTab/steps/SSOConfigConnectStep.jsx
+++ b/src/components/settings/SettingsSSOTab/steps/SSOConfigConnectStep.jsx
@@ -1,5 +1,5 @@
 import { getConfig } from '@edx/frontend-platform/config';
-import { Alert } from '@edx/paragon';
+import { Alert } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import { useContext, useEffect } from 'react';
 import { connect } from 'react-redux';

--- a/src/components/settings/SettingsSSOTab/steps/SSOConfigIDPStep.jsx
+++ b/src/components/settings/SettingsSSOTab/steps/SSOConfigIDPStep.jsx
@@ -1,4 +1,4 @@
-import { Form } from '@edx/paragon';
+import { Form } from '@openedx/paragon';
 import React, { useContext } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';

--- a/src/components/settings/SettingsSSOTab/steps/SSOConfigServiceProviderStep.jsx
+++ b/src/components/settings/SettingsSSOTab/steps/SSOConfigServiceProviderStep.jsx
@@ -1,5 +1,5 @@
 import { getConfig } from '@edx/frontend-platform/config';
-import { Form, Hyperlink } from '@edx/paragon';
+import { Form, Hyperlink } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import { useContext } from 'react';
 import { connect } from 'react-redux';

--- a/src/components/settings/SettingsTabs.jsx
+++ b/src/components/settings/SettingsTabs.jsx
@@ -3,7 +3,7 @@ import {
   Container,
   Tabs,
   Tab,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import {
   useHistory,
   generatePath,

--- a/src/components/subscriptions/MultipleSubscriptionPicker.jsx
+++ b/src/components/subscriptions/MultipleSubscriptionPicker.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {
   Row,
   Col,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 
 import SubscriptionCard from './SubscriptionCard';
 import { DEFAULT_LEAD_TEXT } from './data/constants';

--- a/src/components/subscriptions/MultipleSubscriptionsPage.jsx
+++ b/src/components/subscriptions/MultipleSubscriptionsPage.jsx
@@ -6,7 +6,7 @@ import {
   Col,
   Card,
   Hyperlink,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { connect } from 'react-redux';
 
 import LoadingMessage from '../LoadingMessage';

--- a/src/components/subscriptions/SubscriptionCard.jsx
+++ b/src/components/subscriptions/SubscriptionCard.jsx
@@ -4,7 +4,7 @@ import dayjs from 'dayjs';
 import { Link } from 'react-router-dom';
 import {
   Card, Badge, Button, Stack, Row, Col,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 
 import classNames from 'classnames';
 import { getSubscriptionStatus } from './data/utils';

--- a/src/components/subscriptions/SubscriptionData.jsx
+++ b/src/components/subscriptions/SubscriptionData.jsx
@@ -1,6 +1,6 @@
 import React, { createContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { Alert } from '@edx/paragon';
+import { Alert } from '@openedx/paragon';
 
 import { useSubscriptionData } from './data/hooks';
 

--- a/src/components/subscriptions/SubscriptionDetails.jsx
+++ b/src/components/subscriptions/SubscriptionDetails.jsx
@@ -5,8 +5,8 @@ import { connect } from 'react-redux';
 import dayjs from 'dayjs';
 import {
   Button, Row, Col, Toast, Icon,
-} from '@edx/paragon';
-import { ArrowBackIos } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { ArrowBackIos } from '@openedx/paragon/icons';
 
 import { SubscriptionDetailContext } from './SubscriptionDetailContextProvider';
 import InviteLearnersButton from './buttons/InviteLearnersButton';

--- a/src/components/subscriptions/SubscriptionDetailsSkeleton.jsx
+++ b/src/components/subscriptions/SubscriptionDetailsSkeleton.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Skeleton } from '@edx/paragon';
+import { Skeleton } from '@openedx/paragon';
 
 const tableRowHeight = 50;
 const tableRowCount = 10;

--- a/src/components/subscriptions/SubscriptionManagementPage.jsx
+++ b/src/components/subscriptions/SubscriptionManagementPage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
-import { Container } from '@edx/paragon';
+import { Container } from '@openedx/paragon';
 
 import Hero from '../Hero';
 import SubscriptionData from './SubscriptionData';

--- a/src/components/subscriptions/SubscriptionSubsidyRequests.jsx
+++ b/src/components/subscriptions/SubscriptionSubsidyRequests.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
-import { Stack } from '@edx/paragon';
+import { Stack } from '@openedx/paragon';
 import { connect } from 'react-redux';
 
 import { SubsidyRequestsContext } from '../subsidy-requests';

--- a/src/components/subscriptions/SubscriptionTabs.jsx
+++ b/src/components/subscriptions/SubscriptionTabs.jsx
@@ -1,7 +1,7 @@
 import React, { useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Tabs, Tab } from '@edx/paragon';
+import { Tabs, Tab } from '@openedx/paragon';
 import {
   useHistory,
   Route,

--- a/src/components/subscriptions/SubscriptionZeroStateMessage.jsx
+++ b/src/components/subscriptions/SubscriptionZeroStateMessage.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react';
-import { Card, Toast } from '@edx/paragon';
+import { Card, Toast } from '@openedx/paragon';
 import InviteLearnersButton from './buttons/InviteLearnersButton';
 import { SubscriptionContext } from './SubscriptionData';
 import { SubscriptionDetailContext } from './SubscriptionDetailContextProvider';

--- a/src/components/subscriptions/buttons/DownloadCsvButton.jsx
+++ b/src/components/subscriptions/buttons/DownloadCsvButton.jsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState } from 'react';
-import { StatefulButton, Icon, Spinner } from '@edx/paragon';
-import { Download, Check } from '@edx/paragon/icons';
+import { StatefulButton, Icon, Spinner } from '@openedx/paragon';
+import { Download, Check } from '@openedx/paragon/icons';
 
 import { logError } from '@edx/frontend-platform/logging';
 import { saveAs } from 'file-saver';

--- a/src/components/subscriptions/expiration/SubscriptionExpirationBanner.jsx
+++ b/src/components/subscriptions/expiration/SubscriptionExpirationBanner.jsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react';
-import { Alert } from '@edx/paragon';
+import { Alert } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 

--- a/src/components/subscriptions/expiration/SubscriptionExpirationModals.jsx
+++ b/src/components/subscriptions/expiration/SubscriptionExpirationModals.jsx
@@ -2,7 +2,7 @@ import React, { useContext, useMemo, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Cookies from 'universal-cookie';
-import { useToggle } from '@edx/paragon';
+import { useToggle } from '@openedx/paragon';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
 import SubscriptionExpiredModal from './SubscriptionExpiredModal';

--- a/src/components/subscriptions/expiration/SubscriptionExpiredModal.jsx
+++ b/src/components/subscriptions/expiration/SubscriptionExpiredModal.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { ModalDialog, ActionRow } from '@edx/paragon';
+import { ModalDialog, ActionRow } from '@openedx/paragon';
 
 import { configuration } from '../../../config';
 import Img from '../../Img';

--- a/src/components/subscriptions/expiration/SubscriptionExpiringModal.jsx
+++ b/src/components/subscriptions/expiration/SubscriptionExpiringModal.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { ActionRow, ModalDialog } from '@edx/paragon';
+import { ActionRow, ModalDialog } from '@openedx/paragon';
 
 import { SubscriptionDetailContext } from '../SubscriptionDetailContextProvider';
 import { getSubscriptionExpiringCookieName } from '../data/utils';

--- a/src/components/subscriptions/licenses/LicenseManagementModals/LicenseManagementRemindModal.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementModals/LicenseManagementRemindModal.jsx
@@ -10,7 +10,7 @@ import {
   Spinner,
   Form,
   Hyperlink,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { logError } from '@edx/frontend-platform/logging';
 
 import { useRequestState } from './LicenseManagementModalHook';

--- a/src/components/subscriptions/licenses/LicenseManagementModals/LicenseManagementRevokeModal.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementModals/LicenseManagementRevokeModal.jsx
@@ -10,10 +10,10 @@ import {
   Hyperlink,
   Icon,
   Spinner,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import {
   RemoveCircle,
-} from '@edx/paragon/icons';
+} from '@openedx/paragon/icons';
 import { logError } from '@edx/frontend-platform/logging';
 
 import { useRequestState } from './LicenseManagementModalHook';

--- a/src/components/subscriptions/licenses/LicenseManagementTable/LicenseManagementTableActionColumn.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/LicenseManagementTableActionColumn.jsx
@@ -6,11 +6,11 @@ import {
   Tooltip,
   OverlayTrigger,
   DataTableContext,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import {
   Email,
   RemoveCircle,
-} from '@edx/paragon/icons';
+} from '@openedx/paragon/icons';
 
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import LicenseManagementRevokeModal from '../LicenseManagementModals/LicenseManagementRevokeModal';

--- a/src/components/subscriptions/licenses/LicenseManagementTable/LicenseManagementUserBadge.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/LicenseManagementUserBadge.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Badge,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 
 import {
   USER_STATUS_BADGE_MAP,

--- a/src/components/subscriptions/licenses/LicenseManagementTable/bulk-actions/EnrollBulkAction.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/bulk-actions/EnrollBulkAction.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Button } from '@edx/paragon';
-import { BookOpen } from '@edx/paragon/icons';
+import { Button } from '@openedx/paragon';
+import { BookOpen } from '@openedx/paragon/icons';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
 import BulkEnrollWarningModal from '../../../../BulkEnrollmentPage/BulkEnrollmentWarningModal';

--- a/src/components/subscriptions/licenses/LicenseManagementTable/bulk-actions/RemindBulkAction.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/bulk-actions/RemindBulkAction.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button } from '@edx/paragon';
-import { Email } from '@edx/paragon/icons';
+import { Button } from '@openedx/paragon';
+import { Email } from '@openedx/paragon/icons';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
 import {

--- a/src/components/subscriptions/licenses/LicenseManagementTable/bulk-actions/RevokeBulkAction.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/bulk-actions/RevokeBulkAction.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button } from '@edx/paragon';
-import { RemoveCircle } from '@edx/paragon/icons';
+import { Button } from '@openedx/paragon';
+import { RemoveCircle } from '@openedx/paragon/icons';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
 import {

--- a/src/components/subscriptions/licenses/LicenseManagementTable/index.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/index.jsx
@@ -10,7 +10,7 @@ import {
   useWindowSize,
   breakpoints,
   Toast,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
 import { SubscriptionContext } from '../../SubscriptionData';

--- a/src/components/subscriptions/tests/SubscriptionCard.test.jsx
+++ b/src/components/subscriptions/tests/SubscriptionCard.test.jsx
@@ -6,7 +6,7 @@ import '@testing-library/jest-dom/extend-expect';
 import {
   breakpoints,
   ResponsiveContext,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { renderWithRouter } from '../../test/testUtils';
 import SubscriptionCard from '../SubscriptionCard';
 

--- a/src/components/subsidy-request-management-alerts/NoAvailableCodesBanner.jsx
+++ b/src/components/subsidy-request-management-alerts/NoAvailableCodesBanner.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
-import { Alert } from '@edx/paragon';
+import { Alert } from '@openedx/paragon';
 
 import ContactCustomerSupportButton from '../ContactCustomerSupportButton';
 

--- a/src/components/subsidy-request-management-alerts/NoAvailableLicensesBanner.jsx
+++ b/src/components/subsidy-request-management-alerts/NoAvailableLicensesBanner.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Alert } from '@edx/paragon';
+import { Alert } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 
 import ContactCustomerSupportButton from '../ContactCustomerSupportButton';

--- a/src/components/subsidy-request-modals/ApproveCouponCodeRequestModal.jsx
+++ b/src/components/subsidy-request-modals/ApproveCouponCodeRequestModal.jsx
@@ -8,9 +8,9 @@ import {
   Form,
   StatefulButton,
   Skeleton,
-} from '@edx/paragon';
+} from '@openedx/paragon';
 import { connect } from 'react-redux';
-import { Info } from '@edx/paragon/icons';
+import { Info } from '@openedx/paragon/icons';
 import { logError } from '@edx/frontend-platform/logging';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 import { useApplicableCoupons } from './data/hooks';

--- a/src/components/subsidy-request-modals/ApproveLicenseRequestModal.jsx
+++ b/src/components/subsidy-request-modals/ApproveLicenseRequestModal.jsx
@@ -8,8 +8,8 @@ import {
   StatefulButton,
   Alert,
   Skeleton,
-} from '@edx/paragon';
-import { Info } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Info } from '@openedx/paragon/icons';
 import { logError } from '@edx/frontend-platform/logging';
 import { SubscriptionContext } from '../subscriptions/SubscriptionData';
 import { useApplicableSubscriptions } from './data/hooks';

--- a/src/components/subsidy-request-modals/DeclineSubsidyRequestModal.jsx
+++ b/src/components/subsidy-request-modals/DeclineSubsidyRequestModal.jsx
@@ -2,8 +2,8 @@ import React, { useState, useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import {
   ModalDialog, ActionRow, Button, Form, Alert, StatefulButton,
-} from '@edx/paragon';
-import { Info } from '@edx/paragon/icons';
+} from '@openedx/paragon';
+import { Info } from '@openedx/paragon/icons';
 import { logError } from '@edx/frontend-platform/logging';
 
 const DeclineSubsidyRequestModal = ({

--- a/src/components/system-wide-banner/SystemWideWarningBanner.jsx
+++ b/src/components/system-wide-banner/SystemWideWarningBanner.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { PageBanner, Icon } from '@edx/paragon';
-import { WarningFilled } from '@edx/paragon/icons';
+import { PageBanner, Icon } from '@openedx/paragon';
+import { WarningFilled } from '@openedx/paragon/icons';
 
 const SystemWideWarningBanner = ({ children }) => (
   <PageBanner variant="warning">

--- a/src/containers/CouponDetails/CouponDetails.test.jsx
+++ b/src/containers/CouponDetails/CouponDetails.test.jsx
@@ -10,7 +10,7 @@ import { mount } from 'enzyme';
 import { render, screen } from '@testing-library/react';
 
 import '@testing-library/jest-dom/extend-expect';
-import { Alert } from '@edx/paragon';
+import { Alert } from '@openedx/paragon';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 
 import { SINGLE_USE, MULTI_USE, ONCE_PER_CUSTOMER } from '../../data/constants/coupons';

--- a/src/containers/EnterpriseApp/EnterpriseApp.test.jsx
+++ b/src/containers/EnterpriseApp/EnterpriseApp.test.jsx
@@ -6,7 +6,7 @@ import { MemoryRouter, Route } from 'react-router-dom';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { mount } from 'enzyme';
-import { breakpoints, Skeleton } from '@edx/paragon';
+import { breakpoints, Skeleton } from '@openedx/paragon';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { axiosMock } from '../../setupTest';

--- a/src/containers/Header/Header.test.jsx
+++ b/src/containers/Header/Header.test.jsx
@@ -7,7 +7,7 @@ import { Provider } from 'react-redux';
 import { mount } from 'enzyme';
 
 import { getAuthenticatedUser, hydrateAuthenticatedUser } from '@edx/frontend-platform/auth';
-import { AvatarButton } from '@edx/paragon';
+import { AvatarButton } from '@openedx/paragon';
 import Header from './index';
 import { Logo, HeaderDropdown } from '../../components/Header';
 import SidebarToggle from '../SidebarToggle';

--- a/src/containers/SidebarToggle/SidebarToggle.test.jsx
+++ b/src/containers/SidebarToggle/SidebarToggle.test.jsx
@@ -5,7 +5,7 @@ import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import { mount } from 'enzyme';
 
-import { Close, MenuIcon } from '@edx/paragon/icons';
+import { Close, MenuIcon } from '@openedx/paragon/icons';
 
 import SidebarToggle from './index';
 import {

--- a/src/index.scss
+++ b/src/index.scss
@@ -3,7 +3,7 @@ $modal-max-width: 650px;
 
 @import "~@edx/brand/paragon/fonts";
 @import "~@edx/brand/paragon/variables";
-@import "~@edx/paragon/scss/core/core";
+@import "~@openedx/paragon/scss/core/core";
 @import "~@edx/frontend-enterprise-catalog-search";
 @import "~@edx/brand/paragon/overrides";
 


### PR DESCRIPTION
Part of https://github.com/openedx/axim-engineering/issues/23

This replaces the `@edx/paragon` packag to point to the `paragon` package at
the `openedx` scope(`@openedx/paragon`). Imports have been updated to use the
same locations in the new package.
