### PR TITLE
fix: dynamic theme fixes for outline buttons and fullscreen steppers

### DIFF
--- a/src/components/ContentHighlights/HighlightStepper/ContentHighlightStepper.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/ContentHighlightStepper.jsx
@@ -258,7 +258,7 @@ const ContentHighlightStepper = ({ enterpriseId }) => {
       <Stepper activeKey={currentStep}>
         <FullscreenModal
           title="New highlight"
-          className="bg-light-200"
+          className="stepper-modal bg-light-200"
           isOpen={isStepperModalOpen}
           onClose={openCloseConfirmationModal}
           beforeBodyNode={<Stepper.Header className="border-bottom border-light" />}

--- a/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
+++ b/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
@@ -1,6 +1,4 @@
-import {
-  Chip,
-} from '@edx/paragon';
+import { Chip } from '@edx/paragon';
 import PropTypes from 'prop-types';
 import FailedBadEmail from './assignments-status-chips/FailedBadEmail';
 import FailedCancellation from './assignments-status-chips/FailedCancellation';

--- a/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
+++ b/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
@@ -47,6 +47,7 @@ const BudgetAssignmentsTable = ({
       number: count,
       value: learnerState,
     }));
+
   return (
     <DataTable
       isSortable

--- a/src/components/learner-credit-management/assignments-status-chips/FailedCancellation.jsx
+++ b/src/components/learner-credit-management/assignments-status-chips/FailedCancellation.jsx
@@ -12,13 +12,11 @@ const FailedCancellation = () => {
   return (
     <>
       <Chip
-        disabled={false}
+        ref={setTarget}
         iconBefore={Error}
         onClick={open}
         onKeyPress={open}
-        ref={setTarget}
         tabIndex={0}
-        variant="light"
       >
         Failed: Cancellation
       </Chip>

--- a/src/components/learner-credit-management/assignments-status-chips/FailedReminder.jsx
+++ b/src/components/learner-credit-management/assignments-status-chips/FailedReminder.jsx
@@ -10,13 +10,11 @@ const FailedReminder = () => {
   return (
     <>
       <Chip
-        disabled={false}
+        ref={setTarget}
         iconBefore={Error}
         onClick={open}
         onKeyPress={open}
-        ref={setTarget}
         tabIndex={0}
-        variant="light"
       >
         Failed: Reminder
       </Chip>

--- a/src/components/learner-credit-management/cards/NewAssignmentModalButton.jsx
+++ b/src/components/learner-credit-management/cards/NewAssignmentModalButton.jsx
@@ -177,7 +177,7 @@ const NewAssignmentModalButton = ({ enterpriseId, course, children }) => {
     <>
       <Button onClick={handleOpenAssignmentModal}>{children}</Button>
       <FullscreenModal
-        className="bg-light-200 text-left"
+        className="stepper-modal bg-light-200"
         title="Assign this course"
         isOpen={isOpen}
         onClose={() => {

--- a/src/components/settings/data/hooks.js
+++ b/src/components/settings/data/hooks.js
@@ -132,6 +132,17 @@ export const useStylesForCustomBrandColors = (branding) => {
       .btn-brand:focus:before {
         border-color: ${brandColors.secondary.regular.hex()} !important;
       }
+      .btn-outline-brand {
+        color: ${brandColors.secondary.textColor.hex()} !important;
+      }
+      .btn-outline-brand:hover {
+        background-color: ${brandColors.secondary.regular.hex()} !important;
+        color: ${brandColors.secondary.textColor.hex()} !important;
+        border-color: ${brandColors.secondary.regular.hex()} !important;
+      }
+      .btn-outline-brand:focus:before {
+        border-color: ${brandColors.secondary.regular.hex()} !important;
+      }
       .btn-primary {
         background-color: ${brandColors.primary.regular.hex()} !important;
         border-color: ${brandColors.primary.regular.hex()} !important;
@@ -141,26 +152,19 @@ export const useStylesForCustomBrandColors = (branding) => {
         background-color: ${brandColors.primary.dark.hex()} !important;
         border-color: ${brandColors.primary.dark.hex()} !important;
       }
-      .btn-brand-primary {
-        background-color: ${brandColors.primary.regular.hex()} !important;
+      .btn-primary:focus:before {
         border-color: ${brandColors.primary.regular.hex()} !important;
+      }
+      .btn-outline-primary {
         color: ${brandColors.primary.textColor.hex()} !important;
       }
-      .btn-brand-primary:hover {
-        background-color: ${brandColors.primary.dark.hex()} !important;
-        border-color: ${brandColors.primary.dark.hex()} !important;
-      }
-      .btn-brand-primary:focus:before {
-        border-color: ${brandColors.primary.regular.hex()} !important;
-      }
-      .bg-brand-primary {
+      .btn-outline-primary:hover {
         background-color: ${brandColors.primary.regular.hex()} !important;
-      }
-      .border-brand-primary {
+        color: ${brandColors.primary.textColor.hex()} !important;
         border-color: ${brandColors.primary.regular.hex()} !important;
       }
-      .color-brand-tertiary {
-        color: ${brandColors.tertiary.regular.hex()} !important;
+      .btn-outline-primary:focus:before {
+        border-color: ${brandColors.primary.regular.hex()} !important;
       }
       .secondary-background {
         background: ${brandColors.secondary.regular.hex()} !important;

--- a/src/components/settings/settings.scss
+++ b/src/components/settings/settings.scss
@@ -167,10 +167,6 @@
   font-weight: 500;
 }
 
-.stepper-modal .pgn__modal-header {
-  border-bottom: solid 7px;
-}
-
 .warning-icon {
   color: #F0CC00;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,13 +1,14 @@
 // ... Any custom SCSS variables should be defined here
 $modal-max-width: 650px;
 
+// Paragon/Brand
 @import "~@edx/brand/paragon/fonts";
 @import "~@edx/brand/paragon/variables";
 @import "~@edx/paragon/scss/core/core";
 @import "~@edx/frontend-enterprise-catalog-search";
 @import "~@edx/brand/paragon/overrides";
 
-
+// Components
 @import "./components/EnterpriseApp/EnterpriseApp";
 @import "./components/CodeSearchResults/CodeSearchResults";
 @import "./components/Coupon/Coupon";
@@ -26,6 +27,7 @@ $modal-max-width: 650px;
 @import "./components/settings/settings";
 @import "./components/learner-credit-management/styles";
 
+// Global
 body {
   overflow-x: hidden;
 }
@@ -72,4 +74,8 @@ form {
   .modal-dialog {
     max-width: $modal-max-width;
   }
+}
+
+.stepper-modal .pgn__modal-header {
+  border-bottom: solid 7px;
 }


### PR DESCRIPTION
### Assignment stepper modal theming

<img width="1915" alt="image" src="https://github.com/openedx/frontend-app-admin-portal/assets/2828721/02d22bc4-24fe-471c-9b89-79176edbb77e">

### Highlights stepper modal theming

<img width="1915" alt="image" src="https://github.com/openedx/frontend-app-admin-portal/assets/2828721/984df89b-d900-4cb9-b3af-00f15b4a4fa4">

### Hover/focus states on `variant="outline-primary"`

<img width="1008" alt="image" src="https://github.com/openedx/frontend-app-admin-portal/assets/2828721/b94abac6-474f-4792-b3b3-cf446969f1a6">

<img width="691" alt="image" src="https://github.com/openedx/frontend-app-admin-portal/assets/2828721/eb9780ee-f561-4362-9b04-5c1e0cce2347">

### Hover/focus states on `variant="outline-brand"`

_(Note: Illustrative only; keeping the button as primary variant in practice)_

<img width="298" alt="image" src="https://github.com/openedx/frontend-app-admin-portal/assets/2828721/d6b445c1-767f-418e-9853-3d5c06dc960d">

<img width="304" alt="image" src="https://github.com/openedx/frontend-app-admin-portal/assets/2828721/d532b80f-ec40-48c3-90d4-252dc4340105">

<img width="296" alt="image" src="https://github.com/openedx/frontend-app-admin-portal/assets/2828721/ec5d0799-7621-4ac4-9300-28baf6e8955b">


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [x] Ensure to have UX team confirm screenshots
