### PR TITLE
fix: account for filters in select all bulk actions assigned table

### DIFF
--- a/src/components/learner-credit-management/AssignmentTableCancel.jsx
+++ b/src/components/learner-credit-management/AssignmentTableCancel.jsx
@@ -4,6 +4,7 @@ import { Button } from '@edx/paragon';
 import { DoNotDisturbOn } from '@edx/paragon/icons';
 import CancelAssignmentModal from './CancelAssignmentModal';
 import useCancelContentAssignments from './data/hooks/useCancelContentAssignments';
+import { getActiveTableColumnFilters } from '../../utils';
 
 const calculateTotalToCancel = ({
   assignmentUuids,
@@ -19,18 +20,24 @@ const calculateTotalToCancel = ({
 const AssignmentTableCancelAction = ({ selectedFlatRows, isEntireTableSelected, tableInstance }) => {
   const assignmentUuids = selectedFlatRows.map(row => row.id);
   const assignmentConfigurationUuid = selectedFlatRows[0].original.assignmentConfiguration;
+
+  const activeFilters = getActiveTableColumnFilters(tableInstance.columns);
+
+  // If entire table is selected and there are NO filters, hit cancel-all endpoint. Otherwise, hit usual bulk cancel.
+  const shouldCancelAll = isEntireTableSelected && activeFilters.length === 0;
+
   const {
     cancelButtonState,
     cancelContentAssignments,
     close,
     isOpen,
     open,
-  } = useCancelContentAssignments(assignmentConfigurationUuid, assignmentUuids, isEntireTableSelected);
+  } = useCancelContentAssignments(assignmentConfigurationUuid, assignmentUuids, shouldCancelAll);
 
   const tableItemCount = tableInstance.itemCount;
   const totalToCancel = calculateTotalToCancel({
     assignmentUuids,
-    isEntireTableSelected,
+    isEntireTableSelected: shouldCancelAll,
     tableItemCount,
   });
 
@@ -51,19 +58,12 @@ const AssignmentTableCancelAction = ({ selectedFlatRows, isEntireTableSelected, 
 };
 
 AssignmentTableCancelAction.propTypes = {
-  selectedFlatRows: PropTypes.arrayOf(PropTypes.shape()),
-  isEntireTableSelected: PropTypes.bool,
+  selectedFlatRows: PropTypes.arrayOf(PropTypes.shape()).isRequired,
+  isEntireTableSelected: PropTypes.bool.isRequired,
   tableInstance: PropTypes.shape({
     itemCount: PropTypes.number.isRequired,
-  }),
-};
-
-AssignmentTableCancelAction.defaultProps = {
-  selectedFlatRows: [],
-  isEntireTableSelected: false,
-  tableInstance: {
-    itemCount: 0,
-  },
+    columns: PropTypes.arrayOf(PropTypes.shape()).isRequired,
+  }).isRequired,
 };
 
 export default AssignmentTableCancelAction;

--- a/src/components/subscriptions/data/utils.js
+++ b/src/components/subscriptions/data/utils.js
@@ -65,15 +65,3 @@ export const transformFiltersForRequest = (filters) => {
     }),
   );
 };
-
-/**
- * Helper to determine which table columns have an active filter applied.
- *
- * @param {object} columns Array of column objects (e.g., { id, filter, filterValue })
- * @returns Array of column objects with an active filter applied.
- */
-export const getActiveFilters = columns => columns.map(column => ({
-  name: column.id,
-  filter: column.filter,
-  filterValue: column.filterValue,
-})).filter(filter => !!filter.filterValue);

--- a/src/components/subscriptions/licenses/LicenseManagementTable/bulk-actions/RemindBulkAction.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/bulk-actions/RemindBulkAction.jsx
@@ -9,9 +9,10 @@ import {
   licenseManagementModalZeroState as modalZeroState,
 } from '../../LicenseManagementModals/LicenseManagementModalHook';
 import LicenseManagementRemindModal from '../../LicenseManagementModals/LicenseManagementRemindModal';
-import { canRemindLicense, getActiveFilters } from '../../../data/utils';
+import { canRemindLicense } from '../../../data/utils';
 import { ACTIVATED, REVOKED } from '../../../data/constants';
 import { SUBSCRIPTION_TABLE_EVENTS } from '../../../../../eventTracking';
+import { getActiveTableColumnFilters } from '../../../../../utils';
 
 const calculateTotalToRemind = ({
   selectedRemindableRows,
@@ -54,7 +55,7 @@ const RemindBulkAction = ({
   const [remindModal, setRemindModal] = useLicenseManagementModalState();
   const selectedRows = selectedFlatRows.map(selectedRow => selectedRow.original);
   const selectedRemindableRows = selectedRows.filter(row => canRemindLicense(row.status));
-  const activeFilters = getActiveFilters(tableInstance.columns);
+  const activeFilters = getActiveTableColumnFilters(tableInstance.columns);
   const tableItemCount = tableInstance.itemCount;
   const totalToRemind = calculateTotalToRemind({
     selectedRemindableRows,

--- a/src/components/subscriptions/licenses/LicenseManagementTable/bulk-actions/RevokeBulkAction.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/bulk-actions/RevokeBulkAction.jsx
@@ -9,9 +9,10 @@ import {
   licenseManagementModalZeroState as modalZeroState,
 } from '../../LicenseManagementModals/LicenseManagementModalHook';
 import LicenseManagementRevokeModal from '../../LicenseManagementModals/LicenseManagementRevokeModal';
-import { canRevokeLicense, getActiveFilters } from '../../../data/utils';
+import { canRevokeLicense } from '../../../data/utils';
 import { REVOKED } from '../../../data/constants';
 import { SUBSCRIPTION_TABLE_EVENTS } from '../../../../../eventTracking';
+import { getActiveTableColumnFilters } from '../../../../../utils';
 
 const calculateTotalToRevoke = ({
   selectedRevocableRows,
@@ -51,7 +52,7 @@ const RevokeBulkAction = ({
   const [revokeModal, setRevokeModal] = useLicenseManagementModalState();
   const selectedRows = selectedFlatRows.map(selectedRow => selectedRow.original);
   const selectedRevocableRows = selectedRows.filter(row => canRevokeLicense(row.status));
-  const activeFilters = getActiveFilters(tableInstance.columns);
+  const activeFilters = getActiveTableColumnFilters(tableInstance.columns);
   const tableItemCount = tableInstance.itemCount;
   const totalToRevoke = calculateTotalToRevoke({
     selectedRevocableRows,

--- a/src/utils.js
+++ b/src/utils.js
@@ -423,6 +423,20 @@ function isAssignableSubsidyAccessPolicyType(policy) {
   return isAssignable && assignableSubsidyAccessPolicyTypes.includes(policyType);
 }
 
+/**
+ * Helper to determine which table columns have an active filter applied.
+ *
+ * @param {object} columns Array of column objects (e.g., { id, filter, filterValue })
+ * @returns Array of column objects with an active filter applied.
+ */
+function getActiveTableColumnFilters(columns) {
+  return columns.map(column => ({
+    name: column.id,
+    filter: column.filter,
+    filterValue: column.filterValue,
+  })).filter(filter => !!filter.filterValue);
+}
+
 export {
   camelCaseDict,
   camelCaseDictArray,
@@ -458,4 +472,5 @@ export {
   isNotValidNumberString,
   defaultQueryClientRetryHandler,
   isAssignableSubsidyAccessPolicyType,
+  getActiveTableColumnFilters,
 };


### PR DESCRIPTION
# Description

Ticket: [ENT-8155](https://2u-internal.atlassian.net/browse/ENT-8155)

If filters are applied to the "Assigned" table, continue to call the standard bulk action API endpoints. Only call the `{remind/cancel}-all` API endpoints when the entire table is selected with NO filters applied.

In the below screenshot, note the 32 rows selected, but only the 25 rows on current page will be applicable (and shown in the count). This avoids unexpectedly applying bulk actions to non-filtered rows, but is still not quite the right behavior (i.e., the expected behavior would be performing the action on only on all _filtered_ rows). It's at least a short term fix to prevent unexpected cancelations and reminders, until something like [ENT-8156](https://2u-internal.atlassian.net/browse/ENT-8156) is implemented where the `{remind|cancel}-all` API endpoints can accept the state of table filters, if it can't already.

<img width="1430" alt="image" src="https://github.com/openedx/frontend-app-admin-portal/assets/2828721/702edcc8-b880-46c0-b0e2-a3a1ce2ea732">

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
