### PR TITLE
feat: apply filters to cancel/remind all

### DIFF
--- a/src/components/forms/FormWorkflow.tsx
+++ b/src/components/forms/FormWorkflow.tsx
@@ -138,8 +138,8 @@ const FormWorkflow = <FormConfigData extends unknown>({
         const newFormFields: FormConfigData = await nextButtonConfig.onClick({
           formFields,
           errHandler: (error) => {
-            setFormError(error); 
-            if (!!error) {
+            setFormError(error);
+            if (error) {
               advance = false;
             }
           },

--- a/src/components/learner-credit-management/AssignmentTableCancel.jsx
+++ b/src/components/learner-credit-management/AssignmentTableCancel.jsx
@@ -8,7 +8,6 @@ import CancelAssignmentModal from './CancelAssignmentModal';
 import useCancelContentAssignments from './data/hooks/useCancelContentAssignments';
 import { transformSelectedRows, useBudgetId, useSubsidyAccessPolicy } from './data';
 import EVENT_NAMES from '../../eventTracking';
-import { getActiveTableColumnFilters } from '../../utils';
 
 const calculateTotalToCancel = ({
   assignmentUuids,
@@ -39,10 +38,7 @@ const AssignmentTableCancelAction = ({
     totalSelectedRows,
   } = transformSelectedRows(selectedFlatRows);
 
-  const activeFilters = getActiveTableColumnFilters(tableInstance.columns);
-
-  // If entire table is selected and there are NO filters, hit cancel-all endpoint. Otherwise, hit usual bulk cancel.
-  const shouldCancelAll = isEntireTableSelected && activeFilters.length === 0;
+  const { state: dataTableState } = tableInstance;
 
   const {
     cancelButtonState,
@@ -50,7 +46,12 @@ const AssignmentTableCancelAction = ({
     close,
     isOpen,
     open,
-  } = useCancelContentAssignments(assignmentConfiguration.uuid, assignmentUuids, shouldCancelAll);
+  } = useCancelContentAssignments(
+    assignmentConfiguration.uuid,
+    assignmentUuids,
+    isEntireTableSelected,
+    dataTableState.filters,
+  );
 
   const {
     BUDGET_DETAILS_ASSIGNED_DATATABLE_OPEN_BULK_CANCEL_MODAL,
@@ -114,7 +115,7 @@ const AssignmentTableCancelAction = ({
   const tableItemCount = tableInstance.itemCount;
   const totalToCancel = calculateTotalToCancel({
     assignmentUuids,
-    isEntireTableSelected: shouldCancelAll,
+    isEntireTableSelected,
     tableItemCount,
   });
 
@@ -146,6 +147,9 @@ AssignmentTableCancelAction.propTypes = {
   tableInstance: PropTypes.shape({
     itemCount: PropTypes.number.isRequired,
     columns: PropTypes.arrayOf(PropTypes.shape()).isRequired,
+    state: PropTypes.shape({
+      filters: PropTypes.arrayOf(PropTypes.shape()).isRequired,
+    }).isRequired,
   }).isRequired,
 };
 

--- a/src/components/learner-credit-management/AssignmentTableRemind.jsx
+++ b/src/components/learner-credit-management/AssignmentTableRemind.jsx
@@ -8,7 +8,6 @@ import useRemindContentAssignments from './data/hooks/useRemindContentAssignment
 import RemindAssignmentModal from './RemindAssignmentModal';
 import { transformSelectedRows, useBudgetId, useSubsidyAccessPolicy } from './data';
 import EVENT_NAMES from '../../eventTracking';
-import { getActiveTableColumnFilters } from '../../utils';
 
 const calculateTotalToRemind = ({
   assignmentUuids,
@@ -41,10 +40,7 @@ const AssignmentTableRemindAction = ({
     totalSelectedRows,
   } = transformSelectedRows(remindableRows);
 
-  const activeFilters = getActiveTableColumnFilters(tableInstance.columns);
-
-  // If entire table is selected and there are NO filters, hit remind-all endpoint. Otherwise, hit usual bulk remind.
-  const shouldRemindAll = isEntireTableSelected && activeFilters.length === 0;
+  const { state: dataTableState } = tableInstance;
 
   const {
     remindButtonState,
@@ -52,11 +48,16 @@ const AssignmentTableRemindAction = ({
     close,
     isOpen,
     open,
-  } = useRemindContentAssignments(assignmentConfiguration.uuid, assignmentUuids, shouldRemindAll);
+  } = useRemindContentAssignments(
+    assignmentConfiguration.uuid,
+    assignmentUuids,
+    isEntireTableSelected,
+    dataTableState.filters,
+  );
 
   const selectedRemindableRowCount = calculateTotalToRemind({
     assignmentUuids,
-    isEntireTableSelected: shouldRemindAll,
+    isEntireTableSelected,
     learnerStateCounts,
   });
 
@@ -152,6 +153,9 @@ AssignmentTableRemindAction.propTypes = {
   tableInstance: PropTypes.shape({
     columns: PropTypes.arrayOf(PropTypes.shape()).isRequired,
     itemCount: PropTypes.number.isRequired,
+    state: PropTypes.shape({
+      filters: PropTypes.arrayOf(PropTypes.shape()).isRequired,
+    }).isRequired,
   }).isRequired,
 };
 

--- a/src/components/learner-credit-management/PendingAssignmentCancelButton.jsx
+++ b/src/components/learner-credit-management/PendingAssignmentCancelButton.jsx
@@ -33,7 +33,7 @@ const PendingAssignmentCancelButton = ({ row, enterpriseId }) => {
     close,
     isOpen,
     open,
-  } = useCancelContentAssignments(assignmentConfiguration, [uuid]);
+  } = useCancelContentAssignments(assignmentConfiguration.uuid, [uuid]);
 
   const sharedTrackEventMetadata = {
     subsidyUuid,
@@ -117,7 +117,9 @@ PendingAssignmentCancelButton.propTypes = {
       contentQuantity: PropTypes.number.isRequired,
       learnerState: PropTypes.string.isRequired,
       state: PropTypes.string.isRequired,
-      assignmentConfiguration: PropTypes.string.isRequired,
+      assignmentConfiguration: PropTypes.shape({
+        uuid: PropTypes.string.isRequired,
+      }).isRequired,
       learnerEmail: PropTypes.string,
       uuid: PropTypes.string.isRequired,
     }).isRequired,

--- a/src/components/learner-credit-management/PendingAssignmentRemindButton.jsx
+++ b/src/components/learner-credit-management/PendingAssignmentRemindButton.jsx
@@ -32,7 +32,7 @@ const PendingAssignmentRemindButton = ({ row, enterpriseId }) => {
     close,
     isOpen,
     open,
-  } = useRemindContentAssignments(assignmentConfiguration, [uuid]);
+  } = useRemindContentAssignments(assignmentConfiguration.uuid, [uuid]);
 
   const sharedTrackEventMetadata = {
     subsidyUuid,
@@ -115,7 +115,9 @@ PendingAssignmentRemindButton.propTypes = {
       contentQuantity: PropTypes.number.isRequired,
       learnerState: PropTypes.string.isRequired,
       state: PropTypes.string.isRequired,
-      assignmentConfiguration: PropTypes.string.isRequired,
+      assignmentConfiguration: PropTypes.shape({
+        uuid: PropTypes.string.isRequired,
+      }).isRequired,
       learnerEmail: PropTypes.string,
       uuid: PropTypes.string.isRequired,
     }).isRequired,

--- a/src/components/learner-credit-management/data/hooks/useCancelContentAssignments.js
+++ b/src/components/learner-credit-management/data/hooks/useCancelContentAssignments.js
@@ -6,11 +6,13 @@ import { useToggle } from '@edx/paragon';
 import EnterpriseAccessApiService from '../../../../data/services/EnterpriseAccessApiService';
 import { learnerCreditManagementQueryKeys } from '../constants';
 import useBudgetId from './useBudgetId';
+import { applyFiltersToOptions } from './useBudgetContentAssignments';
 
 const useCancelContentAssignments = (
   assignmentConfigurationUuid,
   assignmentUuids,
-  cancelAll = false,
+  cancelAll,
+  tableFilters,
 ) => {
   const [isOpen, open, close] = useToggle(false);
   const [cancelButtonState, setCancelButtonState] = useState('default');
@@ -21,7 +23,9 @@ const useCancelContentAssignments = (
     setCancelButtonState('pending');
     try {
       if (cancelAll) {
-        await EnterpriseAccessApiService.cancelAllContentAssignments(assignmentConfigurationUuid);
+        const options = {};
+        applyFiltersToOptions(tableFilters, options);
+        await EnterpriseAccessApiService.cancelAllContentAssignments(assignmentConfigurationUuid, options);
       } else {
         await EnterpriseAccessApiService.cancelContentAssignments(assignmentConfigurationUuid, assignmentUuids);
       }
@@ -33,7 +37,7 @@ const useCancelContentAssignments = (
       logError(err);
       setCancelButtonState('error');
     }
-  }, [assignmentConfigurationUuid, assignmentUuids, cancelAll, queryClient, subsidyAccessPolicyId]);
+  }, [assignmentConfigurationUuid, assignmentUuids, cancelAll, tableFilters, queryClient, subsidyAccessPolicyId]);
 
   return {
     cancelButtonState,

--- a/src/components/learner-credit-management/data/hooks/useCancelContentAssignments.test.jsx
+++ b/src/components/learner-credit-management/data/hooks/useCancelContentAssignments.test.jsx
@@ -104,6 +104,47 @@ describe('useCancelContentAssignments', () => {
     });
   });
 
+  it('should send a post request to cancel all assignments with filters', async () => {
+    EnterpriseAccessApiService.cancelAllContentAssignments.mockResolvedValueOnce({ status: 200 });
+    const tableFilters = [{
+      id: 'learnerState',
+      value: ['waiting'],
+    }];
+    const cancelAll = true;
+    const { result } = renderHook(
+      () => useCancelContentAssignments(
+        TEST_ASSIGNMENT_CONFIGURATION_UUID,
+        [TEST_PENDING_ASSIGNMENT_UUID_1, TEST_PENDING_ASSIGNMENT_UUID_2],
+        cancelAll,
+        tableFilters,
+      ),
+      { wrapper },
+    );
+
+    expect(result.current).toEqual({
+      cancelButtonState: 'default',
+      cancelContentAssignments: expect.any(Function),
+      close: expect.any(Function),
+      isOpen: false,
+      open: expect.any(Function),
+    });
+
+    await waitFor(() => act(() => result.current.cancelContentAssignments()));
+    const expectedFilterParams = { learnerState: 'waiting' };
+    expect(
+      EnterpriseAccessApiService.cancelAllContentAssignments,
+    ).toHaveBeenCalledWith(TEST_ASSIGNMENT_CONFIGURATION_UUID, expectedFilterParams);
+    expect(logError).toBeCalledTimes(0);
+
+    expect(result.current).toEqual({
+      cancelButtonState: 'complete',
+      cancelContentAssignments: expect.any(Function),
+      close: expect.any(Function),
+      isOpen: false,
+      open: expect.any(Function),
+    });
+  });
+
   it('should handle assignment cancellation error', async () => {
     const error = new Error('An error occurred');
     EnterpriseAccessApiService.cancelContentAssignments.mockRejectedValueOnce(error);

--- a/src/components/learner-credit-management/data/hooks/useRemindContentAssignments.js
+++ b/src/components/learner-credit-management/data/hooks/useRemindContentAssignments.js
@@ -6,11 +6,13 @@ import { useToggle } from '@edx/paragon';
 import EnterpriseAccessApiService from '../../../../data/services/EnterpriseAccessApiService';
 import { learnerCreditManagementQueryKeys } from '../constants';
 import useBudgetId from './useBudgetId';
+import { applyFiltersToOptions } from './useBudgetContentAssignments';
 
 const useRemindContentAssignments = (
   assignmentConfigurationUuid,
   assignmentUuids,
-  remindAll = false,
+  remindAll,
+  tableFilters,
 ) => {
   const [isOpen, open, close] = useToggle(false);
   const [remindButtonState, setRemindButtonState] = useState('default');
@@ -21,7 +23,9 @@ const useRemindContentAssignments = (
     setRemindButtonState('pending');
     try {
       if (remindAll) {
-        await EnterpriseAccessApiService.remindAllContentAssignments(assignmentConfigurationUuid);
+        const options = {};
+        applyFiltersToOptions(tableFilters, options);
+        await EnterpriseAccessApiService.remindAllContentAssignments(assignmentConfigurationUuid, options);
       } else {
         await EnterpriseAccessApiService.remindContentAssignments(assignmentConfigurationUuid, assignmentUuids);
       }
@@ -33,7 +37,7 @@ const useRemindContentAssignments = (
       logError(err);
       setRemindButtonState('error');
     }
-  }, [assignmentConfigurationUuid, assignmentUuids, remindAll, queryClient, subsidyAccessPolicyId]);
+  }, [assignmentConfigurationUuid, assignmentUuids, remindAll, tableFilters, queryClient, subsidyAccessPolicyId]);
 
   return {
     remindButtonState,

--- a/src/components/learner-credit-management/data/hooks/useRemindContentAssignments.test.jsx
+++ b/src/components/learner-credit-management/data/hooks/useRemindContentAssignments.test.jsx
@@ -104,6 +104,47 @@ describe('useRemindContentAssignments', () => {
     });
   });
 
+  it('should send a post request to remind all assignments with filters', async () => {
+    EnterpriseAccessApiService.remindAllContentAssignments.mockResolvedValueOnce({ status: 200 });
+    const tableFilters = [{
+      id: 'learnerState',
+      value: ['waiting'],
+    }];
+    const remindAll = true;
+    const { result } = renderHook(
+      () => useRemindContentAssignments(
+        TEST_ASSIGNMENT_CONFIGURATION_UUID,
+        [TEST_PENDING_ASSIGNMENT_UUID_1, TEST_PENDING_ASSIGNMENT_UUID_2],
+        remindAll,
+        tableFilters,
+      ),
+      { wrapper },
+    );
+
+    expect(result.current).toEqual({
+      remindButtonState: 'default',
+      remindContentAssignments: expect.any(Function),
+      close: expect.any(Function),
+      isOpen: false,
+      open: expect.any(Function),
+    });
+
+    await waitFor(() => result.current.remindContentAssignments());
+    const expectedFilterParams = { learnerState: 'waiting' };
+    expect(
+      EnterpriseAccessApiService.remindAllContentAssignments,
+    ).toHaveBeenCalledWith(TEST_ASSIGNMENT_CONFIGURATION_UUID, expectedFilterParams);
+    expect(logError).toBeCalledTimes(0);
+
+    expect(result.current).toEqual({
+      remindButtonState: 'complete',
+      remindContentAssignments: expect.any(Function),
+      close: expect.any(Function),
+      isOpen: false,
+      open: expect.any(Function),
+    });
+  });
+
   it('should handle assignment reminder error', async () => {
     const error = new Error('An error occurred');
     EnterpriseAccessApiService.remindContentAssignments.mockRejectedValueOnce(error);

--- a/src/components/settings/SettingsSSOTab/steps/NewSSOConfigConfigureStep.tsx
+++ b/src/components/settings/SettingsSSOTab/steps/NewSSOConfigConfigureStep.tsx
@@ -166,7 +166,7 @@ const SSOConfigConfigureStep = () => {
   const returnToConnectStep = () => {
     const connectStep = allSteps?.[0] as FormWorkflowStep<SSOConfigCamelCase>;
     dispatch?.(
-      setStepAction({ step: connectStep })
+      setStepAction({ step: connectStep }),
     );
   };
 

--- a/src/components/settings/SettingsSSOTab/steps/NewSSOConfigConnectStep.tsx
+++ b/src/components/settings/SettingsSSOTab/steps/NewSSOConfigConnectStep.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
-import { Container, Dropzone, Form, Stack } from '@edx/paragon';
+import {
+  Container, Dropzone, Form, Stack,
+} from '@edx/paragon';
 
 import ValidatedFormRadio from '../../../forms/ValidatedFormRadio';
 import ValidatedFormControl from '../../../forms/ValidatedFormControl';

--- a/src/data/services/EnterpriseAccessApiService.js
+++ b/src/data/services/EnterpriseAccessApiService.js
@@ -187,8 +187,19 @@ class EnterpriseAccessApiService {
   /**
    * Cancel ALL content assignments for a specific AssignmentConfiguration.
    */
-  static cancelAllContentAssignments(assignmentConfigurationUUID) {
-    const url = `${EnterpriseAccessApiService.baseUrl}/assignment-configurations/${assignmentConfigurationUUID}/admin/assignments/cancel-all/`;
+  static cancelAllContentAssignments(assignmentConfigurationUUID, options = {}) {
+    const { learnerState, ...optionsRest } = options;
+    const params = {
+      ...snakeCaseObject(optionsRest),
+    };
+    if (learnerState) {
+      params.learner_state__in = learnerState;
+    }
+    const urlParams = new URLSearchParams(params);
+    let url = `${EnterpriseAccessApiService.baseUrl}/assignment-configurations/${assignmentConfigurationUUID}/admin/assignments/cancel-all/`;
+    if (Object.keys(params).length > 0) {
+      url += `?${urlParams.toString()}`;
+    }
     return EnterpriseAccessApiService.apiClient().post(url);
   }
 
@@ -206,8 +217,19 @@ class EnterpriseAccessApiService {
   /**
    * Remind ALL content assignments for a specific AssignmentConfiguration.
    */
-  static remindAllContentAssignments(assignmentConfigurationUUID) {
-    const url = `${EnterpriseAccessApiService.baseUrl}/assignment-configurations/${assignmentConfigurationUUID}/admin/assignments/remind-all/`;
+  static remindAllContentAssignments(assignmentConfigurationUUID, options = {}) {
+    const { learnerState, ...optionsRest } = options;
+    const params = {
+      ...snakeCaseObject(optionsRest),
+    };
+    if (learnerState) {
+      params.learner_state__in = learnerState;
+    }
+    const urlParams = new URLSearchParams(params);
+    let url = `${EnterpriseAccessApiService.baseUrl}/assignment-configurations/${assignmentConfigurationUUID}/admin/assignments/remind-all/`;
+    if (Object.keys(params).length > 0) {
+      url += `?${urlParams.toString()}`;
+    }
     return EnterpriseAccessApiService.apiClient().post(url);
   }
 

--- a/src/data/services/tests/EnterpriseAccessApiService.test.js
+++ b/src/data/services/tests/EnterpriseAccessApiService.test.js
@@ -213,16 +213,22 @@ describe('EnterpriseAccessApiService', () => {
   });
 
   test('cancelAllContentAssignments calls enterprise-access cancel-all POST API to cancel all assignments', () => {
-    EnterpriseAccessApiService.cancelAllContentAssignments(mockAssignmentConfigurationUUID);
+    const options = {
+      learnerState: 'pending,waiting',
+    };
+    EnterpriseAccessApiService.cancelAllContentAssignments(mockAssignmentConfigurationUUID, options);
     expect(axios.post).toBeCalledWith(
-      `${enterpriseAccessBaseUrl}/api/v1/assignment-configurations/${mockAssignmentConfigurationUUID}/admin/assignments/cancel-all/`,
+      `${enterpriseAccessBaseUrl}/api/v1/assignment-configurations/${mockAssignmentConfigurationUUID}/admin/assignments/cancel-all/?learner_state__in=pending%2Cwaiting`,
     );
   });
 
   test('remindAllContentAssignments calls enterprise-access remind-all POST API to remind all learners', () => {
-    EnterpriseAccessApiService.remindAllContentAssignments(mockAssignmentConfigurationUUID);
+    const options = {
+      learnerState: 'pending,waiting',
+    };
+    EnterpriseAccessApiService.remindAllContentAssignments(mockAssignmentConfigurationUUID, options);
     expect(axios.post).toBeCalledWith(
-      `${enterpriseAccessBaseUrl}/api/v1/assignment-configurations/${mockAssignmentConfigurationUUID}/admin/assignments/remind-all/`,
+      `${enterpriseAccessBaseUrl}/api/v1/assignment-configurations/${mockAssignmentConfigurationUUID}/admin/assignments/remind-all/?learner_state__in=pending%2Cwaiting`,
     );
   });
 });


### PR DESCRIPTION
ENT-8156 | Pass the appropriate content assignment filter state to the `cancel-all` and `remind-all` endpoints.

Here's a recording of me canceling all "notifying" assignments, then reminding all "waiting" assignments.

https://github.com/openedx/frontend-app-admin-portal/assets/2307986/05cb8605-a496-4a0d-9254-4a564af2c15b


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
