### PR TITLE
fix: remove comma from hyperlinked titles

### DIFF
--- a/src/components/ContentHighlights/ContentHighlightCardItem.jsx
+++ b/src/components/ContentHighlights/ContentHighlightCardItem.jsx
@@ -18,15 +18,14 @@ const ContentHighlightCardItem = ({
     cardImgSrc: cardImageUrl,
     cardLogoSrc: partners.length === 1 ? partners[0].logoImageUrl : undefined,
     cardLogoAlt: partners.length === 1 ? `${partners[0].name}'s logo` : undefined,
-    cardTitle:
-  <Truncate lines={3} title={title}>{title}</Truncate>,
+    cardTitle: <Truncate lines={3} title={title}>{title}</Truncate>,
     cardSubtitle: partners.map(p => p.name).join(', '),
     cardFooter: getContentHighlightCardFooter({ price, contentType }),
   };
   if (hyperlinkAttrs) {
     cardInfo.cardTitle = (
       <Hyperlink onClick={hyperlinkAttrs.onClick} destination={hyperlinkAttrs.href} target={hyperlinkAttrs.target} data-testid="hyperlink-title">
-        <Truncate lines={3} title={title}>{title}</Truncate>,
+        <Truncate lines={3} title={title}>{title}</Truncate>
       </Hyperlink>
     );
   }

--- a/src/components/ContentHighlights/ContentHighlightCardItem.jsx
+++ b/src/components/ContentHighlights/ContentHighlightCardItem.jsx
@@ -25,7 +25,7 @@ const ContentHighlightCardItem = ({
   if (hyperlinkAttrs) {
     cardInfo.cardTitle = (
       <Hyperlink onClick={hyperlinkAttrs.onClick} destination={hyperlinkAttrs.href} target={hyperlinkAttrs.target} data-testid="hyperlink-title">
-        <Truncate lines={3} title={title}>{title}</Truncate>
+        <Truncate elementType="span" lines={3} title={title}>{title}</Truncate>
       </Hyperlink>
     );
   }


### PR DESCRIPTION
Part of QAing react 17 upgrade in stage resulted in the discovery of a trailing comma in the highlights card component.

Before Fix:
![Screenshot 2024-01-05 at 9 28 22 AM](https://github.com/openedx/frontend-app-admin-portal/assets/82611798/27aec478-7180-467d-a57c-0f66a5dafb4e)

With fix updating  element type of truncate component to a `span` on card titles as hyperlinks
![Screenshot 2024-01-05 at 9 56 19 AM](https://github.com/openedx/frontend-app-admin-portal/assets/82611798/c5e9e63f-99c2-431d-a8f1-25422d03e191)

With fix testing ellipses on course card.
![Screenshot 2024-01-05 at 9 52 06 AM](https://github.com/openedx/frontend-app-admin-portal/assets/82611798/8850284d-4b79-4440-b37b-265366bcf8d7)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
