### PR TITLE
fix: update path generation to use generatePath

### DIFF
--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
 import {
-  Route, Navigate, Routes, useLocation, generatePath,
+  Route, Navigate, Routes, generatePath, useParams,
 } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import {
@@ -42,10 +42,13 @@ const queryClient = new QueryClient({
 });
 
 const RedirectComponent = () => {
-  const location = useLocation();
+  const { enterpriseSlug } = useParams();
+
   const homePage = generatePath(
-    `${location.pathname}/admin/${ROUTE_NAMES.learners}`,
+    `/:enterpriseSlug/admin/${ROUTE_NAMES.learners}`,
+    { enterpriseSlug },
   );
+
   return <Navigate to={homePage} />;
 };
 
@@ -119,7 +122,7 @@ const AppWrapper = () => {
             element={<PageWrap><UserActivationPage /></PageWrap>}
           />
           <Route
-            path="/:enterpriseSlug"
+            path="/:enterpriseSlug/admin?"
             element={(
               <PageWrap
                 authenticatedAPIClient={apiClient}

--- a/src/components/App/index.jsx
+++ b/src/components/App/index.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
 import {
-  Route, Navigate, Routes, useLocation,
+  Route, Navigate, Routes, useLocation, generatePath,
 } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import {
@@ -43,7 +43,10 @@ const queryClient = new QueryClient({
 
 const RedirectComponent = () => {
   const location = useLocation();
-  return <Navigate to={`${location.pathname}/admin/${ROUTE_NAMES.learners}`} />;
+  const homePage = generatePath(
+    `${location.pathname}/admin/${ROUTE_NAMES.learners}`,
+  );
+  return <Navigate to={homePage} />;
 };
 
 const AppWrapper = () => {

--- a/src/components/settings/index.jsx
+++ b/src/components/settings/index.jsx
@@ -4,7 +4,7 @@ import {
   Route,
   Routes,
   Navigate,
-  useLocation,
+  useLocation, generatePath,
 } from 'react-router-dom';
 
 import Hero from '../Hero';
@@ -24,6 +24,7 @@ const PAGE_TILE = 'Settings';
  */
 const SettingsPage = () => {
   const { pathname } = useLocation();
+  const tabRoute = generatePath(`${pathname}/${DEFAULT_TAB}`);
 
   return (
     <>
@@ -32,7 +33,7 @@ const SettingsPage = () => {
       <Routes>
         <Route
           path="/"
-          element={<Navigate to={`${pathname}/${DEFAULT_TAB}`} />}
+          element={<Navigate to={tabRoute} />}
         />
         {Object.values(SETTINGS_TABS_VALUES).map(path => (
           <Route


### PR DESCRIPTION
Fixes regression where given a url path includes the `pathname` from `useLocation`, a trailing forward slash may or may not exist in the url pathname.  Ex.  URL: `portal.edx.org/test-slug/` , pathname: `/test-slug/`
If a pathname is used with a trailing slash to construct a URL without using the `generatePath` method, an edge case arises where the user may navigate to  `portal.edx.org/test-slug/` and be redirected to `portal.edx.org/test-slug//admin/learners` due to the trailing forward slash.

See video for example.

Before fix:
https://github.com/openedx/frontend-app-admin-portal/assets/82611798/c5a1733c-f4df-46dd-b127-41338fa82eed

Post fix:
https://github.com/openedx/frontend-app-admin-portal/assets/82611798/8877fd2d-92b8-4611-8f7d-04323b63ff9a



# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
