### PR TITLE
fix: not throwing errors if user isn't linked to enterprise while setting active

### DIFF
--- a/src/components/EnterpriseApp/data/hooks/useUpdateActiveEnterpriseForUser.js
+++ b/src/components/EnterpriseApp/data/hooks/useUpdateActiveEnterpriseForUser.js
@@ -21,15 +21,21 @@ const useUpdateActiveEnterpriseForUser = ({ enterpriseId, user }) => {
     isLoading: isLoadingActiveEnterprise,
   } = useQuery({
     queryKey: ['activeLinkedEnterpriseCustomer', username],
-    queryFn: () => LmsApiService.getActiveLinkedEnterprise(username),
+    queryFn: () => LmsApiService.fetchEnterpriseLearnerData({ username }),
     meta: {
       errorMessage: "Failed to fetch user's active enterprise",
     },
   });
 
   useEffect(() => {
-    if (!data) { return; }
-    if (data.uuid !== enterpriseId) {
+    if (!data || !enterpriseId) { return; }
+    // Ensure that the current enterprise is linked and can be activated for the user
+    if (!data.find(enterprise => enterprise.enterpriseCustomer.uuid === enterpriseId)) {
+      return;
+    }
+    const activeLinkedEnterprise = data.find(enterprise => enterprise.active);
+    if (!activeLinkedEnterprise) { return; }
+    if (activeLinkedEnterprise.enterpriseCustomer.uuid !== enterpriseId) {
       mutate(enterpriseId);
     }
   }, [data, enterpriseId, mutate]);

--- a/src/components/EnterpriseApp/data/hooks/useUpdateActiveEnterpriseForUser.test.jsx
+++ b/src/components/EnterpriseApp/data/hooks/useUpdateActiveEnterpriseForUser.test.jsx
@@ -21,12 +21,20 @@ describe('useUpdateActiveEnterpriseForUser', () => {
   const mockUser = { username: 'joe_shmoe' };
   const connectedEnterprise = 'someID';
   beforeEach(() => {
-    LmsApiService.getActiveLinkedEnterprise.mockResolvedValue({ uuid: connectedEnterprise });
+    LmsApiService.fetchEnterpriseLearnerData.mockResolvedValue(
+      [{ enterpriseCustomer: { uuid: mockEnterpriseId }, active: true }],
+    );
   });
 
   afterEach(() => jest.clearAllMocks());
 
   it("should update user's active enterprise if it differs from the current enterprise", async () => {
+    LmsApiService.fetchEnterpriseLearnerData.mockResolvedValue(
+      [
+        { enterpriseCustomer: { uuid: mockEnterpriseId }, active: false },
+        { enterpriseCustomer: { uuid: 'some-other-uuid' }, active: true },
+      ],
+    );
     const { result, waitForNextUpdate } = renderHook(
       () => useUpdateActiveEnterpriseForUser({
         enterpriseId: mockEnterpriseId,
@@ -56,6 +64,12 @@ describe('useUpdateActiveEnterpriseForUser', () => {
   });
 
   it('should handle useMutation errors', async () => {
+    LmsApiService.fetchEnterpriseLearnerData.mockResolvedValue(
+      [
+        { enterpriseCustomer: { uuid: mockEnterpriseId }, active: false },
+        { enterpriseCustomer: { uuid: 'some-other-uuid' }, active: true },
+      ],
+    );
     LmsApiService.updateUserActiveEnterprise.mockRejectedValueOnce(Error('uh oh'));
     const { result, waitForNextUpdate } = renderHook(
       () => useUpdateActiveEnterpriseForUser({
@@ -73,7 +87,7 @@ describe('useUpdateActiveEnterpriseForUser', () => {
     expect(logError).toHaveBeenCalledTimes(1);
   });
   it('should handle useQuery errors', async () => {
-    LmsApiService.getActiveLinkedEnterprise.mockRejectedValueOnce(Error('uh oh'));
+    LmsApiService.fetchEnterpriseLearnerData.mockRejectedValueOnce(Error('uh oh'));
     const { result, waitForNextUpdate } = renderHook(
       () => useUpdateActiveEnterpriseForUser({
         enterpriseId: mockEnterpriseId,
@@ -85,7 +99,7 @@ describe('useUpdateActiveEnterpriseForUser', () => {
 
     await waitForNextUpdate();
 
-    expect(LmsApiService.getActiveLinkedEnterprise).toHaveBeenCalledTimes(1);
+    expect(LmsApiService.fetchEnterpriseLearnerData).toHaveBeenCalledTimes(1);
     expect(result.current.isLoading).toBe(false);
     expect(logError).toHaveBeenCalledWith("Failed to fetch user's active enterprise");
   });

--- a/src/data/services/LmsApiService.js
+++ b/src/data/services/LmsApiService.js
@@ -1,6 +1,5 @@
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
-import { logError } from '@edx/frontend-platform/logging';
 
 import { configuration } from '../../config';
 import generateFormattedStatusUrl from './apiServiceUtils';
@@ -397,27 +396,27 @@ class LmsApiService {
     );
   };
 
-  static fetchEnterpriseLearnerData(options) {
+  static async fetchData(url, linkedEnterprises = []) {
+    const response = await getAuthenticatedHttpClient().get(url);
+    const responseData = camelCaseObject(response.data);
+    const linkedEnterprisesCopy = [...linkedEnterprises];
+    linkedEnterprisesCopy.push(...responseData.results);
+    if (responseData.next) {
+      return LmsApiService.fetchData(responseData.next, linkedEnterprisesCopy);
+    }
+    return linkedEnterprisesCopy;
+  }
+
+  static fetchEnterpriseLearnerData = async (options) => {
     const enterpriseLearnerUrl = `${configuration.LMS_BASE_URL}/enterprise/api/v1/enterprise-learner/`;
     const queryParams = new URLSearchParams({
       ...options,
       page: 1,
     });
     const url = `${enterpriseLearnerUrl}?${queryParams.toString()}`;
-    return LmsApiService.apiClient().get(url);
-  }
-
-  static async getActiveLinkedEnterprise(username) {
-    const response = await this.fetchEnterpriseLearnerData({ username });
-    const transformedResponse = camelCaseObject(response.data);
-    const enterprisesForLearner = transformedResponse.results;
-    const activeLinkedEnterprise = enterprisesForLearner.find(enterprise => enterprise.active);
-    if (!activeLinkedEnterprise) {
-      logError(`${username} does not have any active linked enterprise customers`);
-      return null;
-    }
-    return activeLinkedEnterprise.enterpriseCustomer;
-  }
+    const response = await LmsApiService.fetchData(url);
+    return response;
+  };
 }
 
 export default LmsApiService;

--- a/src/data/services/tests/LmsApiService.test.js
+++ b/src/data/services/tests/LmsApiService.test.js
@@ -45,6 +45,14 @@ describe('LmsApiService', () => {
     );
   });
   test('updateUserActiveEnterprise calls the LMS to update the active linked enterprise org', () => {
+    axios.get.mockReturnValue({
+      data: {
+        results: [{
+          active: true,
+          enterpriseCustomer: { uuid: 'test-uuid' },
+        }],
+      },
+    });
     LmsApiService.updateUserActiveEnterprise(
       mockEnterpriseUUID,
     );
@@ -56,6 +64,14 @@ describe('LmsApiService', () => {
     );
   });
   test('fetchEnterpriseLearnerData calls the LMS to fetch learner data', () => {
+    axios.get.mockReturnValue({
+      data: {
+        results: [{
+          active: true,
+          enterpriseCustomer: { uuid: 'test-uuid' },
+        }],
+      },
+    });
     LmsApiService.fetchEnterpriseLearnerData({ username: mockUsername });
     expect(axios.get).toBeCalledWith(
       `${lmsBaseUrl}/enterprise/api/v1/enterprise-learner/?username=${mockUsername}&page=1`,
@@ -70,7 +86,7 @@ describe('LmsApiService', () => {
         }],
       },
     });
-    const activeCustomer = await LmsApiService.getActiveLinkedEnterprise(mockUsername);
-    expect(activeCustomer).toEqual({ uuid: 'test-uuid' });
+    const activeCustomer = await LmsApiService.fetchEnterpriseLearnerData({ username: mockUsername });
+    expect(activeCustomer).toEqual([{ active: true, enterpriseCustomer: { uuid: 'test-uuid' } }]);
   });
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -407,7 +407,7 @@ const pollAsync = async (pollFunc, timeout, interval, checkFunc) => {
  * may be overridden per-query, as needed.
  */
 function defaultQueryClientRetryHandler(failureCount, err) {
-  if (failureCount >= 3 || err.customAttributes.httpErrorStatus === 404) {
+  if (failureCount >= 3 || err.customAttributes?.httpErrorStatus === 404) {
     return false;
   }
   return true;


### PR DESCRIPTION

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
