### PR TITLE
feat: display retired badge on retired budgets

### DIFF
--- a/src/components/ContentHighlights/ContentHighlightCardItem.jsx
+++ b/src/components/ContentHighlights/ContentHighlightCardItem.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Card, Hyperlink, Icon, Truncate } from '@edx/paragon';
+import {
+  Card, Hyperlink, Icon, Truncate,
+} from '@edx/paragon';
 import { Archive } from '@edx/paragon/icons';
 import cardImageCapFallbackSrc from '@edx/brand/paragon/images/card-imagecap-fallback.png';
 

--- a/src/components/EnterpriseApp/data/constants.js
+++ b/src/components/EnterpriseApp/data/constants.js
@@ -18,6 +18,7 @@ export const BUDGET_STATUSES = {
   active: 'Active',
   expired: 'Expired',
   scheduled: 'Scheduled',
+  retired: 'Retired',
 };
 
 export const BUDGET_TYPES = {

--- a/src/components/EnterpriseSubsidiesContext/data/hooks.js
+++ b/src/components/EnterpriseSubsidiesContext/data/hooks.js
@@ -76,6 +76,7 @@ async function fetchEnterpriseBudgets({
         pending: result.aggregates.amountAllocatedUsd,
       },
       isAssignable: isAssignableSubsidyAccessPolicyType(result),
+      isRetired: result.retired,
     });
   });
   enterpriseSubsidyResults?.forEach((result) => {

--- a/src/components/learner-credit-management/BudgetCard.jsx
+++ b/src/components/learner-credit-management/BudgetCard.jsx
@@ -41,6 +41,7 @@ const BudgetCard = ({
         displayName={budget.name}
         enterpriseSlug={enterpriseSlug}
         isAssignable={budget.isAssignable}
+        isRetired={budget.isRetired}
       />
     );
   }
@@ -96,6 +97,7 @@ BudgetCard.propTypes = {
       pending: PropTypes.number,
     }),
     isAssignable: PropTypes.bool,
+    isRetired: PropTypes.bool,
   }).isRequired,
   enterpriseUUID: PropTypes.string.isRequired,
   enterpriseSlug: PropTypes.string.isRequired,

--- a/src/components/learner-credit-management/BudgetDetailPageHeader.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPageHeader.jsx
@@ -23,8 +23,10 @@ const BudgetStatusBadge = ({
   badgeVariant, status, term, date,
 }) => (
   <Stack direction="horizontal" gap={2}>
-    <Badge variant={badgeVariant}>{ status }</Badge>
-    <span className="small">{term} { formatDate(date) }</span>
+    <Badge variant={badgeVariant}>{status}</Badge>
+    {(term && date) && (
+      <span className="small">{term} {formatDate(date)}</span>
+    )}
   </Stack>
 );
 
@@ -74,7 +76,7 @@ const BudgetDetailPageHeader = ({ enterpriseUUID, enterpriseFeatures }) => {
       <BudgetDetailPageBreadcrumbs budgetDisplayName={budgetDisplayName} />
       <Card className="budget-overview-card">
         <Card.Section>
-          <h2>{ budgetDisplayName }</h2>
+          <h2>{budgetDisplayName}</h2>
           <BudgetStatusBadge badgeVariant={badgeVariant} status={status} term={term} date={date} />
           <BudgetDetailPageOverviewAvailability
             budgetId={budgetId}

--- a/src/components/learner-credit-management/SubBudgetCard.jsx
+++ b/src/components/learner-credit-management/SubBudgetCard.jsx
@@ -94,7 +94,7 @@ const BaseSubBudgetCard = ({
     const subtitle = (
       <Stack direction="horizontal" gap={2.5}>
         <Badge variant={budgetLabel.badgeVariant}>{budgetLabel.status}</Badge>
-        {budgetLabel.term && formattedDate && (
+        {(budgetLabel.term && formattedDate) && (
           <span data-testid="budget-date">
             {budgetLabel.term} {formattedDate}
           </span>

--- a/src/components/learner-credit-management/SubBudgetCard.jsx
+++ b/src/components/learner-credit-management/SubBudgetCard.jsx
@@ -65,21 +65,26 @@ const BaseSubBudgetCard = ({
   enablePortalLearnerCreditManagementScreen,
   isLoading,
   isAssignable,
+  isRetired,
 }) => {
   const { isFetching: isFetchingBudgets } = useEnterpriseBudgets({
     enablePortalLearnerCreditManagementScreen,
     enterpriseId,
     isTopDownAssignmentEnabled,
   });
-  const budgetLabel = getBudgetStatus(start, end);
-  const formattedDate = dayjs(budgetLabel?.date).format('MMMM D, YYYY');
+  const budgetLabel = getBudgetStatus({
+    startDateStr: start,
+    endDateStr: end,
+    isBudgetRetired: isRetired,
+  });
+  const formattedDate = budgetLabel?.date ? dayjs(budgetLabel?.date).format('MMMM D, YYYY') : undefined;
 
   const renderActions = (budgetId) => (
     <Button
       data-testid="view-budget"
       as={Link}
       to={`/${enterpriseSlug}/admin/${ROUTE_NAMES.learnerCredit}/${budgetId}`}
-      variant={budgetLabel.status === BUDGET_STATUSES.expired ? 'outline-primary' : 'primary'}
+      variant={[BUDGET_STATUSES.expired, BUDGET_STATUSES.retired].includes(budgetLabel.status) ? 'outline-primary' : 'primary'}
     >
       View budget
     </Button>
@@ -89,9 +94,11 @@ const BaseSubBudgetCard = ({
     const subtitle = (
       <Stack direction="horizontal" gap={2.5}>
         <Badge variant={budgetLabel.badgeVariant}>{budgetLabel.status}</Badge>
-        <span data-testid="budget-date">
-          {budgetLabel.term} {formattedDate}
-        </span>
+        {budgetLabel.term && formattedDate && (
+          <span data-testid="budget-date">
+            {budgetLabel.term} {formattedDate}
+          </span>
+        )}
       </Stack>
     );
 
@@ -170,6 +177,7 @@ BaseSubBudgetCard.propTypes = {
   pending: PropTypes.number,
   displayName: PropTypes.string,
   isAssignable: PropTypes.bool,
+  isRetired: PropTypes.bool,
 };
 
 BaseSubBudgetCard.defaultProps = {

--- a/src/components/learner-credit-management/data/hooks/useBudgetDetailHeaderData.js
+++ b/src/components/learner-credit-management/data/hooks/useBudgetDetailHeaderData.js
@@ -26,13 +26,17 @@ const transformSubsidySummaryToPolicy = (subsidySummary, enterpriseOfferMetadata
 const assignBudgetStatus = (policy) => {
   const {
     status, badgeVariant, term, date,
-  } = getBudgetStatus(
-    policy.subsidyActiveDatetime,
-    policy.subsidyExpirationDatetime,
-  );
+  } = getBudgetStatus({
+    startDateStr: policy.subsidyActiveDatetime,
+    endDateStr: policy.subsidyExpirationDatetime,
+    isBudgetRetired: policy.retired,
+  });
 
   return {
-    status, badgeVariant, term, date,
+    status,
+    badgeVariant,
+    term,
+    date,
   };
 };
 

--- a/src/components/learner-credit-management/data/tests/utils.test.js
+++ b/src/components/learner-credit-management/data/tests/utils.test.js
@@ -1,4 +1,8 @@
-import { transformSubsidySummary, getBudgetStatus, orderBudgets } from '../utils';
+import {
+  transformSubsidySummary,
+  getBudgetStatus,
+  orderBudgets,
+} from '../utils';
 import { EXEC_ED_OFFER_TYPE } from '../constants';
 
 describe('transformSubsidySummary', () => {
@@ -97,7 +101,11 @@ describe('getBudgetStatus', () => {
     const startDateStr = '2024-09-30';
     const endDateStr = '2027-10-30';
     const currentDateStr = '2023-09-28';
-    const result = getBudgetStatus(startDateStr, endDateStr, new Date(currentDateStr));
+    const result = getBudgetStatus({
+      startDateStr,
+      endDateStr,
+      currentDate: new Date(currentDateStr),
+    });
     expect(result.status).toEqual('Scheduled');
   });
 
@@ -105,7 +113,11 @@ describe('getBudgetStatus', () => {
     const startDateStr = '2023-08-01';
     const endDateStr = '2027-10-30';
     const currentDateStr = '2023-09-28';
-    const result = getBudgetStatus(startDateStr, endDateStr, new Date(currentDateStr));
+    const result = getBudgetStatus({
+      startDateStr,
+      endDateStr,
+      currentDate: new Date(currentDateStr),
+    });
     expect(result.status).toEqual('Active');
   });
 
@@ -113,8 +125,25 @@ describe('getBudgetStatus', () => {
     const startDateStr = '2023-08-01';
     const endDateStr = '2023-08-31';
     const currentDateStr = '2023-09-28';
-    const result = getBudgetStatus(startDateStr, endDateStr, new Date(currentDateStr));
+    const result = getBudgetStatus({
+      startDateStr,
+      endDateStr,
+      currentDate: new Date(currentDateStr),
+    });
     expect(result.status).toEqual('Expired');
+  });
+
+  it('should return "Retired" when `isBudgetRetired=true`', () => {
+    const startDateStr = '2023-08-01';
+    const endDateStr = '2023-08-31';
+    const currentDateStr = '2023-09-28';
+    const result = getBudgetStatus({
+      startDateStr,
+      endDateStr,
+      currentDate: new Date(currentDateStr),
+      isBudgetRetired: true,
+    });
+    expect(result.status).toEqual('Retired');
   });
 });
 
@@ -132,11 +161,17 @@ const budgets = [
   },
   {
     name: 'Budget 3',
+    start: '2023-01-01T00:00:00Z',
+    end: '2023-01-10T00:00:00Z',
+    isRetired: true,
+  },
+  {
+    name: 'Budget 4',
     start: '2023-02-01T00:00:00Z',
     end: '2023-02-15T00:00:00Z',
   },
   {
-    name: 'Budget 4',
+    name: 'Budget 5',
     start: '2023-01-15T00:00:00Z',
     end: '2023-01-25T00:00:00Z',
   },
@@ -146,8 +181,12 @@ describe('orderBudgets', () => {
   it('should sort offers correctly', () => {
     const sortedBudgets = orderBudgets(budgets);
 
-    // Expected order: Active budgets (Budget 2), Upcoming budgets (Budget 1, Budget 4), Expired budgets (Budget 3)
-    expect(sortedBudgets.map((budget) => budget.name)).toEqual(['Budget 2', 'Budget 1', 'Budget 4', 'Budget 3']);
+    // Expected order:
+    // Active budgets (Budget 2)
+    // Upcoming budgets (Budget 1, Budget 5)
+    // Expired budgets (Budget 4)
+    // Retired budgets (Budget 3)
+    expect(sortedBudgets.map((budget) => budget.name)).toEqual(['Budget 2', 'Budget 1', 'Budget 5', 'Budget 4', 'Budget 3']);
   });
 
   it('should handle empty input', () => {

--- a/src/components/learner-credit-management/data/utils.js
+++ b/src/components/learner-credit-management/data/utils.js
@@ -213,7 +213,6 @@ export const orderBudgets = (budgets) => {
   };
 
   budgets?.sort((budgetA, budgetB) => {
-    // console.log('BUDGETS!!!', budgetA, budgetB);
     const statusA = getBudgetStatus({
       startDateStr: budgetA.start,
       endDateStr: budgetA.end,

--- a/src/components/learner-credit-management/data/utils.js
+++ b/src/components/learner-credit-management/data/utils.js
@@ -137,10 +137,27 @@ export const getProgressBarVariant = ({ percentUtilized, remainingFunds }) => {
 export const isUUID = (id) => /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(id);
 
 //  Utility function to check the budget status
-export const getBudgetStatus = (startDateStr, endDateStr, currentDate = new Date()) => {
+export const getBudgetStatus = ({
+  startDateStr,
+  endDateStr,
+  isBudgetRetired,
+  currentDate = new Date(),
+}) => {
   const startDate = new Date(startDateStr);
   const endDate = new Date(endDateStr);
 
+  // Check if budget is retired
+  if (isBudgetRetired) {
+    return {
+      status: BUDGET_STATUSES.retired,
+      badgeVariant: 'info',
+      // no term or date for retired budgets
+      term: null,
+      date: null,
+    };
+  }
+
+  // Check if budget has not yet started
   if (currentDate < startDate) {
     return {
       status: BUDGET_STATUSES.scheduled,
@@ -149,6 +166,8 @@ export const getBudgetStatus = (startDateStr, endDateStr, currentDate = new Date
       date: startDateStr,
     };
   }
+
+  // Check if budget is current (today's date between start/end dates)
   if (currentDate >= startDate && currentDate <= endDate) {
     return {
       status: BUDGET_STATUSES.active,
@@ -157,6 +176,8 @@ export const getBudgetStatus = (startDateStr, endDateStr, currentDate = new Date
       date: endDateStr,
     };
   }
+
+  // Otherwise, budget must be expired
   return {
     status: BUDGET_STATUSES.expired,
     badgeVariant: 'light',
@@ -188,11 +209,21 @@ export const orderBudgets = (budgets) => {
     Active: 0,
     Scheduled: 1,
     Expired: 2,
+    Retired: 3,
   };
 
   budgets?.sort((budgetA, budgetB) => {
-    const statusA = getBudgetStatus(budgetA.start, budgetA.end).status;
-    const statusB = getBudgetStatus(budgetB.start, budgetB.end).status;
+    // console.log('BUDGETS!!!', budgetA, budgetB);
+    const statusA = getBudgetStatus({
+      startDateStr: budgetA.start,
+      endDateStr: budgetA.end,
+      isBudgetRetired: budgetA.isRetired,
+    }).status;
+    const statusB = getBudgetStatus({
+      startDateStr: budgetB.start,
+      endDateStr: budgetB.end,
+      isBudgetRetired: budgetB.isRetired,
+    }).status;
 
     if (statusOrder[statusA] !== statusOrder[statusB]) {
       return statusOrder[statusA] - statusOrder[statusB];


### PR DESCRIPTION
# Description

Ticket: https://2u-internal.atlassian.net/browse/ENT-8303

## Changes

* Retired budgets have an `info` variant `Badge` on the budget cards in the overview page route and no date displayed. The CTA is using the `outline-primary` button variant.

<img width="925" alt="image" src="https://github.com/openedx/frontend-app-admin-portal/assets/2828721/17699fa8-eef3-44e3-9632-d58fcbefc828">

* Retired budgets have an `info` variant `Badge` on the budget detail page and no date displayed.

<img width="897" alt="image" src="https://github.com/openedx/frontend-app-admin-portal/assets/2828721/25d7dd83-bc52-4ac5-ae9b-22fd6d3da973">

* Retired budgets display last in the sort order.

![image](https://github.com/openedx/frontend-app-admin-portal/assets/2828721/e9ed34b3-52bc-4724-8fdb-92e0e4fa1d6b)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
