### PR TITLE
fix: ensure subs plans are sorted alphabetically, when appropriate

### DIFF
--- a/src/components/subscriptions/data/utils.js
+++ b/src/components/subscriptions/data/utils.js
@@ -34,24 +34,39 @@ export const getSubscriptionStatus = (subscription) => {
   return ACTIVE;
 };
 
-// Sort plans by statuses, active -> scheduled -> ended.
-export const sortSubscriptionsByStatus = (subscriptions) => subscriptions.slice().sort(
-  (sub1, sub2) => {
-    const orderByStatus = {
-      [ACTIVE]: 0,
-      [SCHEDULED]: 1,
-      [ENDED]: 2,
-    };
-    const sub1Status = getSubscriptionStatus(sub1);
-    const sub2Status = getSubscriptionStatus(sub2);
+/**
+ * Sort subscription plans by:
+ *   - Statuses (active -> scheduled -> ended)
+ *   - Plans within same status, sorted by expiration date (ascending)
+ *   - Plans within same status and expiration date, sorted by title (ascending)
+ *
+ * @param {Array} subscriptions - List of subscription plans.
+ *
+ * @returns Ordered list of subscription plans.
+ */
+export const sortSubscriptionsByStatus = (subscriptions) => {
+  const statusOrder = {
+    [ACTIVE]: 0,
+    [SCHEDULED]: 1,
+    [ENDED]: 2,
+  };
+  return subscriptions.slice().sort(
+    (sub1, sub2) => {
+      const sub1Status = getSubscriptionStatus(sub1);
+      const sub2Status = getSubscriptionStatus(sub2);
 
-    if (sub1Status === sub2Status) {
-      return dayjs(sub1.startDate) - dayjs(sub2.startDate);
-    }
+      if (statusOrder[sub1Status] !== statusOrder[sub2Status]) {
+        return statusOrder[sub1Status] - statusOrder[sub2Status];
+      }
 
-    return orderByStatus[sub1Status] - orderByStatus[sub2Status];
-  },
-);
+      if (sub1.expirationDate !== sub2.expirationDate) {
+        return sub1.expirationDate.localeCompare(sub2.expirationDate);
+      }
+
+      return sub1.title.localeCompare(sub2.title);
+    },
+  );
+};
 
 export const transformFiltersForRequest = (filters) => {
   const nameMappings = {

--- a/src/components/subscriptions/tests/data/utils.test.js
+++ b/src/components/subscriptions/tests/data/utils.test.js
@@ -4,16 +4,19 @@ import { sortSubscriptionsByStatus, getSubscriptionStatus } from '../../data/uti
 
 describe('utils', () => {
   const scheduledSub = {
-    startDate: dayjs().add(1, 'days'),
-    expirationDate: dayjs().add(10, 'days'),
+    startDate: dayjs().add(1, 'days').toISOString(),
+    expirationDate: dayjs().add(10, 'days').toISOString(),
+    title: 'Test Scheduled Plan',
   };
   const activeSub = {
-    startDate: dayjs().subtract(1, 'days'),
-    expirationDate: dayjs().add(10, 'days'),
+    startDate: dayjs().subtract(1, 'days').toISOString(),
+    expirationDate: dayjs().add(10, 'days').toISOString(),
+    title: 'Test Active Plan',
   };
   const expiredSub = {
-    startDate: dayjs().subtract(10, 'days'),
-    expirationDate: dayjs().subtract(1, 'days'),
+    startDate: dayjs().subtract(10, 'days').toISOString(),
+    expirationDate: dayjs().subtract(1, 'days').toISOString(),
+    title: 'Test Expired Plan',
   };
 
   describe('getSubscriptionStatus', () => {
@@ -28,18 +31,26 @@ describe('utils', () => {
     it('should sort subscriptions by status', () => {
       const initialOrder = [expiredSub, activeSub, scheduledSub];
       const expectedOrder = [activeSub, scheduledSub, expiredSub];
-
       expect(sortSubscriptionsByStatus(initialOrder)).toEqual(expectedOrder);
     });
 
-    it('should sort subscriptions by start date after status', () => {
+    it('should sort subscriptions by expiration date after status', () => {
       const activeSub2 = {
-        startDate: dayjs().subtract(2, 'days'),
-        expirationDate: dayjs().add(10, 'days'),
+        ...activeSub,
+        expirationDate: dayjs().add(1, 'days').toISOString(), // expires sooner than other active subs plan
       };
       const initialOrder = [expiredSub, activeSub, scheduledSub, activeSub2];
       const expectedOrder = [activeSub2, activeSub, scheduledSub, expiredSub];
+      expect(sortSubscriptionsByStatus(initialOrder)).toEqual(expectedOrder);
+    });
 
+    it('should sort subscriptions by plan title after status and date', () => {
+      const activeSub2 = {
+        ...activeSub,
+        title: 'Another Active Plan', // title alphabetically comes before other active subs plan title
+      };
+      const initialOrder = [expiredSub, activeSub, scheduledSub, activeSub2];
+      const expectedOrder = [activeSub2, activeSub, scheduledSub, expiredSub];
       expect(sortSubscriptionsByStatus(initialOrder)).toEqual(expectedOrder);
     });
   });


### PR DESCRIPTION
# Description

Ensures subscription plans in the Subscription Management feature list page route are ordered as follows:

1. First by subscription plan status (active/current, scheduled/upcoming, expired).
2. Then, break ties between same-status plans with plan expiration dates (plans expiring first, shown first).
3. Then, break ties between same-status and same-expiration plans with alphabetical plan title (ascending).

This update brings the Subscription Management feature to have parity with the ordering logic for budgets displayed in the Learner Credit Management feature.

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
