### PR TITLE
fix: linting and JS errors due to paragon modal deprecation pr

### DIFF
--- a/src/components/CodeAssignmentModal/index.jsx
+++ b/src/components/CodeAssignmentModal/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm, SubmissionError } from 'redux-form';
 import {
-  Button, Icon, ModalDialog, ActionRow, Form,
+  Button, ModalDialog, ActionRow, Form, Spinner,
 } from '@edx/paragon';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 
@@ -423,7 +423,7 @@ export class BaseCodeAssignmentModal extends React.Component {
               data-testid={SUBMIT_BUTTON_TEST_ID}
             >
               <>
-              {mode === MODAL_TYPES.assign && submitting && <Spinner animation="border" className="mr-2" variant="light" size="sm" />}
+                {mode === MODAL_TYPES.assign && submitting && <Spinner animation="border" className="mr-2" variant="light" size="sm" />}
                 {`Assign ${isBulkAssign ? 'Codes' : 'Code'}`}
               </>
             </Button>,

--- a/src/components/CodeReminderModal/index.jsx
+++ b/src/components/CodeReminderModal/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { reduxForm, SubmissionError } from 'redux-form';
 import {
-  Button, Icon, ModalDialog, ActionRow,
+  Button, ModalDialog, ActionRow, Spinner,
 } from '@edx/paragon';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 

--- a/src/components/CodeRevokeModal/index.jsx
+++ b/src/components/CodeRevokeModal/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Field, reduxForm, SubmissionError } from 'redux-form';
 import {
-  Button, Icon, ModalDialog, ActionRow,
+  Button, ModalDialog, ActionRow, Spinner,
 } from '@edx/paragon';
 import { Info } from '@edx/paragon/icons';
 

--- a/src/components/InviteLearnersModal/index.jsx
+++ b/src/components/InviteLearnersModal/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Field, reduxForm, SubmissionError } from 'redux-form';
 import {
-  Button, Icon, Alert, ModalDialog, ActionRow,
+  Button, Alert, ModalDialog, ActionRow, Spinner,
 } from '@edx/paragon';
 import { Cancel as ErrorIcon } from '@edx/paragon/icons';
 
@@ -204,7 +204,7 @@ class InviteLearnersModal extends React.Component {
               onClick={handleSubmit(this.handleModalSubmit)}
             >
               <>
-              {submitting && <Spinner animation="border" className="mr-2" variant="primary" size="sm" />}
+                {submitting && <Spinner animation="border" className="mr-2" variant="primary" size="sm" />}
                 Invite learners
               </>
             </Button>,

--- a/src/components/settings/SettingsLMSTab/ErrorReporting/tests/ErrorReporting.test.jsx
+++ b/src/components/settings/SettingsLMSTab/ErrorReporting/tests/ErrorReporting.test.jsx
@@ -9,7 +9,6 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 
 import LmsApiService from '../../../../../data/services/LmsApiService';
-import { features } from '../../../../../config';
 import SyncHistory from '../SyncHistory';
 
 const enterpriseCustomerUuid = 'test-enterprise-id';

--- a/src/components/settings/SettingsLMSTab/ErrorReporting/tests/SyncHistory.test.jsx
+++ b/src/components/settings/SettingsLMSTab/ErrorReporting/tests/SyncHistory.test.jsx
@@ -9,7 +9,6 @@ import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
-import { features } from '../../../../../config';
 
 import { renderWithRouter } from '../../../../test/testUtils';
 import SettingsLMSTab from '../..';


### PR DESCRIPTION
# Description

A [PR](https://github.com/openedx/frontend-app-admin-portal/pull/872) was merged a few days ago with several linting issues, many of which would result in JS errors. These changes were released to production about 8 hours ago. We are seeing these errors creep up in New Relic reporting, preventing critical user flows.

This PR ensures all linting errors are resolved for this project, resolving those code paths with possible JS bugs due to missing `Spinner` imports.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
