### PR TITLE
feat: add filtering and search to budget landing page

### DIFF
--- a/src/components/learner-credit-management/BudgetCard.jsx
+++ b/src/components/learner-credit-management/BudgetCard.jsx
@@ -17,46 +17,55 @@ import { BUDGET_TYPES } from '../EnterpriseApp/data/constants';
  *
  * @returns Budget card component(s).
  */
-const BudgetCard = ({
-  budget,
-  enterpriseUUID,
-  enterpriseSlug,
-}) => {
+const BudgetCard = ({ original }) => {
+  const {
+    aggregates,
+    end,
+    enterpriseSlug,
+    enterpriseUUID,
+    id,
+    isAssignable,
+    isRetired,
+    name,
+    source,
+    start,
+  } = original;
+
   const {
     isLoading: isLoadingSubsidySummaryAnalyticsApi,
     subsidySummary: subsidySummaryAnalyticsApi,
-  } = useSubsidySummaryAnalyticsApi(enterpriseUUID, budget.id, budget.source);
+  } = useSubsidySummaryAnalyticsApi(enterpriseUUID, id, source);
 
   // Subsidy Access Policies will always have a single budget, so we can render a single card
   // without relying on `useSubsidySummaryAnalyticsApi`.
-  if (budget.source === BUDGET_TYPES.policy) {
+  if (source === BUDGET_TYPES.policy) {
     return (
       <SubBudgetCard
-        id={budget.id}
-        start={budget.start}
-        end={budget.end}
-        available={budget.aggregates.available}
-        spent={budget.aggregates.spent}
-        pending={budget.aggregates.pending}
-        displayName={budget.name}
+        id={id}
+        start={start}
+        end={end}
+        available={aggregates.available}
+        spent={aggregates.spent}
+        pending={aggregates.pending}
+        displayName={name}
         enterpriseSlug={enterpriseSlug}
-        isAssignable={budget.isAssignable}
-        isRetired={budget.isRetired}
+        isAssignable={isAssignable}
+        isRetired={isRetired}
       />
     );
   }
 
   // Enterprise Offers (ecommerce) will always have a single budget, so we can render a single card.
-  if (budget.source === BUDGET_TYPES.ecommerce) {
+  if (source === BUDGET_TYPES.ecommerce) {
     return (
       <SubBudgetCard
         isLoading={isLoadingSubsidySummaryAnalyticsApi}
         id={subsidySummaryAnalyticsApi?.offerId}
-        start={budget.start}
-        end={budget.end}
+        start={start}
+        end={end}
         available={subsidySummaryAnalyticsApi?.remainingFunds}
         spent={subsidySummaryAnalyticsApi?.redeemedFunds}
-        displayName={budget.name}
+        displayName={name}
         enterpriseSlug={enterpriseSlug}
       />
     );
@@ -74,8 +83,8 @@ const BudgetCard = ({
       isLoading={isLoadingSubsidySummaryAnalyticsApi}
       key={subBudget.subsidyAccessPolicyUuid}
       id={subBudget.subsidyAccessPolicyUuid}
-      start={budget.start}
-      end={budget.end}
+      start={start}
+      end={end}
       available={subBudget.remainingFunds}
       spent={subBudget.redeemedFunds}
       displayName={subBudget.subsidyAccessPolicyDisplayName}
@@ -85,7 +94,7 @@ const BudgetCard = ({
 };
 
 BudgetCard.propTypes = {
-  budget: PropTypes.shape({
+  original: PropTypes.shape({
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     name: PropTypes.string.isRequired,
     start: PropTypes.string.isRequired,
@@ -98,9 +107,10 @@ BudgetCard.propTypes = {
     }),
     isAssignable: PropTypes.bool,
     isRetired: PropTypes.bool,
+    enterpriseUUID: PropTypes.string.isRequired,
+    enterpriseSlug: PropTypes.string.isRequired,
+    status: PropTypes.string,
   }).isRequired,
-  enterpriseUUID: PropTypes.string.isRequired,
-  enterpriseSlug: PropTypes.string.isRequired,
 };
 
 export default BudgetCard;

--- a/src/components/learner-credit-management/MultipleBudgetsPicker.jsx
+++ b/src/components/learner-credit-management/MultipleBudgetsPicker.jsx
@@ -40,13 +40,13 @@ const MultipleBudgetsPicker = ({
     [orderedBudgets, enterpriseUUID, enterpriseSlug, enableLearnerPortal],
   );
 
-  const budgetLabels = orderedBudgets.map(budget => {
-    return getBudgetStatus({
+  const budgetLabels = orderedBudgets.map(budget => (
+    getBudgetStatus({
       startDateStr: budget.start,
       endDateStr: budget.end,
       isBudgetRetired: budget.isRetired,
     })
-  });
+  ));
   const budgetLabelsByStatus = groupBy(budgetLabels, 'status');
   const reducedChoices = Object.keys(budgetLabelsByStatus).map(budgetLabel => ({
     name: budgetLabel,

--- a/src/components/learner-credit-management/MultipleBudgetsPicker.jsx
+++ b/src/components/learner-credit-management/MultipleBudgetsPicker.jsx
@@ -8,6 +8,7 @@ import {
   Row,
   Col,
 } from '@edx/paragon';
+import groupBy from 'lodash/groupBy';
 
 import BudgetCard from './BudgetCard';
 import { getBudgetStatus, orderBudgets } from './data/utils';
@@ -39,24 +40,19 @@ const MultipleBudgetsPicker = ({
     [orderedBudgets, enterpriseUUID, enterpriseSlug, enableLearnerPortal],
   );
 
-  const reducedChoices = orderedBudgets.reduce((acc, currentObject) => {
-    const budgetLabel = getBudgetStatus({
-      startDateStr: currentObject.start,
-      endDateStr: currentObject.end,
-      isBudgetRetired: currentObject.isRetired,
-    });
-
-    if (budgetLabel.status in acc) {
-      acc[budgetLabel.status].number += 1;
-    } else {
-      acc[budgetLabel.status] = {
-        name: budgetLabel.status,
-        number: 1,
-        value: budgetLabel.status,
-      };
-    }
-    return acc;
-  }, {});
+  const budgetLabels = orderedBudgets.map(budget => {
+    return getBudgetStatus({
+      startDateStr: budget.start,
+      endDateStr: budget.end,
+      isBudgetRetired: budget.isRetired,
+    })
+  });
+  const budgetLabelsByStatus = groupBy(budgetLabels, 'status');
+  const reducedChoices = Object.keys(budgetLabelsByStatus).map(budgetLabel => ({
+    name: budgetLabel,
+    number: budgetLabelsByStatus[budgetLabel].length,
+    value: budgetLabel,
+  }));
 
   return (
     <>
@@ -77,7 +73,7 @@ const MultipleBudgetsPicker = ({
             Header: 'Status',
             accessor: 'status',
             Filter: CheckboxFilter,
-            filterChoices: Object.values(reducedChoices),
+            filterChoices: reducedChoices,
           },
         ]}
       >

--- a/src/components/learner-credit-management/SubBudgetCard.jsx
+++ b/src/components/learner-credit-management/SubBudgetCard.jsx
@@ -6,7 +6,6 @@ import classNames from 'classnames';
 import {
   Card,
   Button,
-  Row,
   Col,
   Badge,
   Stack,
@@ -123,8 +122,8 @@ const BaseSubBudgetCard = ({
       title={<h4>Balance</h4>}
       muted
     >
-      <Row className="d-flex flex-row justify-content-start w-md-75">
-        <Col xs="6" md="auto" className="mb-3 mb-md-0">
+      <Col className="d-flex justify-content-start w-md-75">
+        <Col xs="6" md="auto" className="mb-3 mb-md-0 ml-n4.5">
           <div className="small font-weight-bold">Available</div>
           <span className="small">
             {isFetchingBudgets ? <Skeleton /> : formatPrice(available)}
@@ -144,7 +143,7 @@ const BaseSubBudgetCard = ({
             {isFetchingBudgets ? <Skeleton /> : formatPrice(spent)}
           </span>
         </Col>
-      </Row>
+      </Col>
     </Card.Section>
   );
 

--- a/src/components/learner-credit-management/tests/BudgetCard.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetCard.test.jsx
@@ -90,18 +90,20 @@ describe('<BudgetCard />', () => {
   });
 
   it('displays correctly for a scheduled Enterprise Offers (ecommerce)', () => {
+    const mockBudgetAggregates = {
+      total: 5000,
+      spent: 200,
+      available: 4800,
+    };
     const mockBudget = {
       id: mockEnterpriseOfferId,
       name: mockBudgetDisplayName,
       start: '3022-01-01',
       end: '3023-01-01',
       source: BUDGET_TYPES.ecommerce,
+      aggregates: mockBudgetAggregates,
     };
-    const mockBudgetAggregates = {
-      total: 5000,
-      spent: 200,
-      available: 4800,
-    };
+
     useSubsidySummaryAnalyticsApi.mockReturnValue({
       isLoading: false,
       subsidySummary: {
@@ -116,9 +118,7 @@ describe('<BudgetCard />', () => {
     });
 
     render(<BudgetCardWrapper
-      budget={mockBudget}
-      enterpriseUUID={enterpriseUUID}
-      enterpriseSlug={enterpriseSlug}
+      original={mockBudget}
     />);
 
     expect(screen.getByText(mockBudgetDisplayName)).toBeInTheDocument();
@@ -130,17 +130,18 @@ describe('<BudgetCard />', () => {
   });
 
   it('displays correctly for a scheduled Subsidy (enterprise-subsidy)', () => {
+    const mockBudgetAggregates = {
+      total: 5000,
+      spent: 200,
+      available: 4800,
+    };
     const mockBudget = {
       id: mockEnterpriseOfferId,
       name: mockBudgetDisplayName,
       start: '3022-01-01',
       end: '4023-01-01',
       source: BUDGET_TYPES.subsidy,
-    };
-    const mockBudgetAggregates = {
-      total: 5000,
-      spent: 200,
-      available: 4800,
+      aggregates: mockBudgetAggregates,
     };
     useSubsidySummaryAnalyticsApi.mockReturnValue({
       isLoading: false,
@@ -167,9 +168,7 @@ describe('<BudgetCard />', () => {
     });
 
     render(<BudgetCardWrapper
-      budget={mockBudget}
-      enterpriseUUID={enterpriseUUID}
-      enterpriseSlug={enterpriseSlug}
+      original={mockBudget}
     />);
 
     expect(screen.getByText(mockBudgetDisplayName)).toBeInTheDocument();
@@ -202,6 +201,8 @@ describe('<BudgetCard />', () => {
         spent: mockBudgetAggregates.spent,
       },
       isAssignable: isAssignableBudget,
+      enterpriseSlug,
+      enterpriseUUID,
     };
     useSubsidySummaryAnalyticsApi.mockReturnValue({
       isLoading: false,
@@ -209,9 +210,7 @@ describe('<BudgetCard />', () => {
     });
 
     render(<BudgetCardWrapper
-      budget={mockBudget}
-      enterpriseUUID={enterpriseUUID}
-      enterpriseSlug={enterpriseSlug}
+      original={mockBudget}
     />);
 
     expect(screen.getByText(mockBudgetDisplayName)).toBeInTheDocument();
@@ -223,17 +222,20 @@ describe('<BudgetCard />', () => {
   });
 
   it('displays correctly for an expired Enterprise Offers (ecommerce)', () => {
+    const mockBudgetAggregates = {
+      total: 5000,
+      spent: 200,
+      available: 4800,
+    };
     const mockBudget = {
       id: mockEnterpriseOfferId,
       name: mockBudgetDisplayName,
       start: '2022-01-01',
       end: '2023-01-01',
       source: BUDGET_TYPES.ecommerce,
-    };
-    const mockBudgetAggregates = {
-      total: 5000,
-      spent: 200,
-      available: 4800,
+      aggregates: mockBudgetAggregates,
+      enterpriseSlug,
+      enterpriseUUID,
     };
     useSubsidySummaryAnalyticsApi.mockReturnValue({
       isLoading: false,
@@ -249,9 +251,7 @@ describe('<BudgetCard />', () => {
     });
 
     render(<BudgetCardWrapper
-      budget={mockBudget}
-      enterpriseUUID={enterpriseUUID}
-      enterpriseSlug={enterpriseSlug}
+      original={mockBudget}
     />);
 
     expect(screen.getByText(mockBudgetDisplayName)).toBeInTheDocument();
@@ -268,17 +268,20 @@ describe('<BudgetCard />', () => {
   });
 
   it('displays correctly for an expired Subsidy (enterprise-subsidy)', () => {
+    const mockBudgetAggregates = {
+      total: 5000,
+      spent: 200,
+      available: 4800,
+    };
     const mockBudget = {
       id: mockEnterpriseOfferId,
       name: mockBudgetDisplayName,
       start: '2022-01-01',
       end: '2023-01-01',
       source: BUDGET_TYPES.subsidy,
-    };
-    const mockBudgetAggregates = {
-      total: 5000,
-      spent: 200,
-      available: 4800,
+      aggregates: mockBudgetAggregates,
+      enterpriseSlug,
+      enterpriseUUID,
     };
     useSubsidySummaryAnalyticsApi.mockReturnValue({
       isLoading: false,
@@ -305,9 +308,7 @@ describe('<BudgetCard />', () => {
     });
 
     render(<BudgetCardWrapper
-      budget={mockBudget}
-      enterpriseUUID={enterpriseUUID}
-      enterpriseSlug={enterpriseSlug}
+      original={mockBudget}
     />);
 
     expect(screen.getByText(mockBudgetDisplayName)).toBeInTheDocument();
@@ -345,6 +346,8 @@ describe('<BudgetCard />', () => {
         spent: mockBudgetAggregates.spent,
       },
       isAssignable: isAssignableBudget,
+      enterpriseSlug,
+      enterpriseUUID,
     };
     useSubsidySummaryAnalyticsApi.mockReturnValue({
       isLoading: false,
@@ -352,9 +355,7 @@ describe('<BudgetCard />', () => {
     });
 
     render(<BudgetCardWrapper
-      budget={mockBudget}
-      enterpriseUUID={enterpriseUUID}
-      enterpriseSlug={enterpriseSlug}
+      original={mockBudget}
     />);
 
     expect(screen.getByText(mockBudgetDisplayName)).toBeInTheDocument();
@@ -371,17 +372,20 @@ describe('<BudgetCard />', () => {
   });
 
   it('displays correctly for a current Enterprise Offers (ecommerce)', () => {
+    const mockBudgetAggregates = {
+      total: 5000,
+      spent: 200,
+      available: 4800,
+    };
     const mockBudget = {
       id: mockEnterpriseOfferId,
       name: mockBudgetDisplayName,
       start: '2022-01-01',
       end: '3022-01-01',
       source: BUDGET_TYPES.ecommerce,
-    };
-    const mockBudgetAggregates = {
-      total: 5000,
-      spent: 200,
-      available: 4800,
+      aggregates: mockBudgetAggregates,
+      enterpriseSlug,
+      enterpriseUUID,
     };
     useSubsidySummaryAnalyticsApi.mockReturnValue({
       isLoading: false,
@@ -397,9 +401,7 @@ describe('<BudgetCard />', () => {
     });
 
     render(<BudgetCardWrapper
-      budget={mockBudget}
-      enterpriseUUID={enterpriseUUID}
-      enterpriseSlug={enterpriseSlug}
+      original={mockBudget}
     />);
 
     expect(screen.getByText(mockBudgetDisplayName)).toBeInTheDocument();
@@ -423,17 +425,20 @@ describe('<BudgetCard />', () => {
   });
 
   it('displays correctly for a current Subsidy (enterprise-subsidy)', () => {
+    const mockBudgetAggregates = {
+      total: 5000,
+      spent: 200,
+      available: 4800,
+    };
     const mockBudget = {
       id: mockEnterpriseOfferId,
       name: mockBudgetDisplayName,
       start: '2022-01-01',
       end: '3023-01-01',
       source: BUDGET_TYPES.subsidy,
-    };
-    const mockBudgetAggregates = {
-      total: 5000,
-      spent: 200,
-      available: 4800,
+      aggregates: mockBudgetAggregates,
+      enterpriseSlug,
+      enterpriseUUID,
     };
     useSubsidySummaryAnalyticsApi.mockReturnValue({
       isLoading: false,
@@ -460,9 +465,7 @@ describe('<BudgetCard />', () => {
     });
 
     render(<BudgetCardWrapper
-      budget={mockBudget}
-      enterpriseUUID={enterpriseUUID}
-      enterpriseSlug={enterpriseSlug}
+      original={mockBudget}
     />);
 
     expect(screen.getByText(mockBudgetDisplayName)).toBeInTheDocument();
@@ -507,6 +510,8 @@ describe('<BudgetCard />', () => {
         spent: mockBudgetAggregates.spent,
       },
       isAssignable: isAssignableBudget,
+      enterpriseSlug,
+      enterpriseUUID,
     };
     useSubsidySummaryAnalyticsApi.mockReturnValue({
       isLoading: false,
@@ -514,9 +519,7 @@ describe('<BudgetCard />', () => {
     });
 
     render(<BudgetCardWrapper
-      budget={mockBudget}
-      enterpriseUUID={enterpriseUUID}
-      enterpriseSlug={enterpriseSlug}
+      original={mockBudget}
     />);
 
     expect(screen.getByText(mockBudgetDisplayName)).toBeInTheDocument();

--- a/src/components/learner-credit-management/tests/MultipleBudgetsPage.test.jsx
+++ b/src/components/learner-credit-management/tests/MultipleBudgetsPage.test.jsx
@@ -10,6 +10,8 @@ import {
 } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+
 import { EnterpriseSubsidiesContext } from '../../EnterpriseSubsidiesContext';
 import MultipleBudgetsPage from '../MultipleBudgetsPage';
 import { queryClient } from '../../test/testUtils';
@@ -61,9 +63,11 @@ const MultipleBudgetsPageWrapper = ({
 }) => (
   <QueryClientProvider client={queryClient()}>
     <Provider store={store}>
-      <EnterpriseSubsidiesContext.Provider value={enterpriseSubsidiesContextValue}>
-        <MultipleBudgetsPage {...rest} />
-      </EnterpriseSubsidiesContext.Provider>
+      <IntlProvider locale="en">
+        <EnterpriseSubsidiesContext.Provider value={enterpriseSubsidiesContextValue}>
+          <MultipleBudgetsPage {...rest} />
+        </EnterpriseSubsidiesContext.Provider>
+      </IntlProvider>
     </Provider>
   </QueryClientProvider>
 );


### PR DESCRIPTION
# Description
 Adds filtering and search functionality to the budget landing page by putting the budget cards into a `DataTable`. 

https://2u-internal.atlassian.net/browse/ENT-8502

# UI
|before|after|
|-------|-----|
|![Screenshot 2024-03-07 at 11 20 24 AM](https://github.com/openedx/frontend-app-admin-portal/assets/71999631/a42fb416-93fa-4bb7-953a-bfa2dc860e6a)|![Screenshot 2024-03-07 at 11 16 23 AM](https://github.com/openedx/frontend-app-admin-portal/assets/71999631/15e2fe1f-f283-4190-a4dc-223d3b9d9dfd)|

https://github.com/openedx/frontend-app-admin-portal/assets/71999631/b7f3b68f-13b5-4843-8ef5-45e6d75a7b39

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
