### PR TITLE
fix: extract subscription uuid correctly

### DIFF
--- a/src/components/Admin/SubscriptionDetailPage.jsx
+++ b/src/components/Admin/SubscriptionDetailPage.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import { useParams } from 'react-router-dom';
 import SubscriptionExpirationModals from '../subscriptions/expiration/SubscriptionExpirationModals';
 import SubscriptionDetails from './SubscriptionDetails';
 import LicenseAllocationDetails from './licenses/LicenseAllocationDetails';
@@ -12,8 +11,8 @@ import SubscriptionDetailsSkeleton from '../subscriptions/SubscriptionDetailsSke
 import { LPR_SUBSCRIPTION_PAGE_SIZE } from '../subscriptions/data/constants';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const SubscriptionDetailPage = ({ enterpriseSlug }) => {
-  const { subscriptionUUID } = useParams();
+export const SubscriptionDetailPage = ({ enterpriseSlug, match }) => {
+  const { params: { subscriptionUUID } } = match;
   const [subscription, loadingSubscription] = useSubscriptionFromParams({ subscriptionUUID });
 
   if (!subscription && !loadingSubscription) {
@@ -43,6 +42,11 @@ export const SubscriptionDetailPage = ({ enterpriseSlug }) => {
 
 SubscriptionDetailPage.propTypes = {
   enterpriseSlug: PropTypes.string.isRequired,
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      subscriptionUUID: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
 };
 
 const mapStateToProps = state => ({

--- a/src/components/Admin/SubscriptionDetailPage.test.jsx
+++ b/src/components/Admin/SubscriptionDetailPage.test.jsx
@@ -1,7 +1,8 @@
 /* eslint-disable react/jsx-no-constructed-context-values */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
 import { AppContext } from '@edx/frontend-platform/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { SubscriptionDetailPage } from './SubscriptionDetailPage';
@@ -11,6 +12,7 @@ import {
   mockSubscriptionHooks,
   MockSubscriptionContext,
 } from '../subscriptions/tests/TestUtilities';
+import * as hooks from '../subscriptions/data/contextHooks';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -34,6 +36,11 @@ const defaultAppContext = {
   enterpriseSlug: 'test-enterprise',
   enterpriseConfig: {
     slug: 'test-enterprise',
+  },
+  match: {
+    params: {
+      subscriptionUUID: '28d4dcdc-c026-4c02-a263-82dd9c0d8b43',
+    },
   },
 };
 
@@ -77,5 +84,14 @@ describe('SubscriptionDetailPage', () => {
     expect(document.querySelector('h2').textContent).toEqual(
       'Get Started',
     );
+  });
+
+  it('renders correct message if no subscriptions', () => {
+    jest.spyOn(hooks, 'useSubscriptionFromParams').mockImplementation(
+      () => [false, false],
+    );
+    render(<SubscriptionDetailPageWrapper />);
+
+    expect(screen.getByText('No subscription available')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
**Description:** Subscriptions UI component was not showing on the LPR page. Subscription UUID was parsed incorrectly.

**JIRA:** https://2u-internal.atlassian.net/browse/ENT-8600

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
