### PR TITLE
feat: subsidy group members download csv functionality

### DIFF
--- a/src/components/learner-credit-management/data/utils.js
+++ b/src/components/learner-credit-management/data/utils.js
@@ -107,6 +107,7 @@ export const transformGroupMembersTableResults = results => results.map(result =
   status: result.status,
   recentAction: result.recentAction,
   memberEnrollments: result.memberEnrollments,
+  enrollmentCount: result.enrollmentCount,
 }));
 
 /**

--- a/src/components/learner-credit-management/members-tab/BudgetDetailMembersTabContents.jsx
+++ b/src/components/learner-credit-management/members-tab/BudgetDetailMembersTabContents.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Form } from '@edx/paragon';
 
 import LearnerCreditGroupMembersTable from './LearnerCreditGroupMembersTable';
 import { useEnterpriseGroupMembersTableData, useBudgetId, useSubsidyAccessPolicy } from '../data';
@@ -12,13 +11,12 @@ const BudgetDetailMembersTabContents = ({ enterpriseUUID, refresh, setRefresh })
   const groupId = subsidyAccessPolicy.groupAssociations[0];
   const {
     isLoading,
-    showRemoved,
-    handleSwitchChange,
     enterpriseGroupMembersTableData,
     fetchEnterpriseGroupMembersTableData,
   } = useEnterpriseGroupMembersTableData({
     enterpriseUUID,
     subsidyAccessPolicyId,
+    policyUuid: subsidyAccessPolicy.uuid,
     groupId,
     refresh,
   });
@@ -31,14 +29,6 @@ const BudgetDetailMembersTabContents = ({ enterpriseUUID, refresh, setRefresh })
           Members choose what to learn from the catalog and spend from the budget to enroll.
         </p>
       </div>
-      <Form.Switch
-        className="ml-2.5"
-        checked={showRemoved}
-        onChange={handleSwitchChange}
-        data-testid="show-removed-toggle"
-      >
-        Show removed
-      </Form.Switch>
       <LearnerCreditGroupMembersTable
         isLoading={isLoading}
         tableData={enterpriseGroupMembersTableData}

--- a/src/components/learner-credit-management/members-tab/GroupMembersCsvDownloadTableAction.jsx
+++ b/src/components/learner-credit-management/members-tab/GroupMembersCsvDownloadTableAction.jsx
@@ -1,0 +1,132 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { ActionRow, AlertModal, Button } from '@edx/paragon';
+import { Download } from '@edx/paragon/icons';
+import { logError } from '@edx/frontend-platform/logging';
+import snakeCase from 'lodash/snakeCase';
+import { saveAs } from 'file-saver';
+import EnterpriseAccessApiService from '../../../data/services/EnterpriseAccessApiService';
+import { useBudgetId, useSubsidyAccessPolicy } from '../data';
+
+const GroupMembersCsvDownloadTableAction = ({
+  tableInstance,
+}) => {
+  const [alertModalOpen, setAlertModalOpen] = useState(false);
+  const [alertModalExc, setAlertModalException] = useState('');
+  const { subsidyAccessPolicyId } = useBudgetId();
+  const { data: subsidyAccessPolicy } = useSubsidyAccessPolicy(subsidyAccessPolicyId);
+  const groupId = subsidyAccessPolicy.groupAssociations[0];
+
+  const getCsvFileName = () => {
+    const titleNoWhitespace = subsidyAccessPolicy.displayName.replace(/\s+/g, '');
+    const currentDate = new Date();
+    const year = currentDate.getUTCFullYear();
+    const month = currentDate.getUTCMonth() + 1;
+    const day = currentDate.getUTCDate();
+    return `${titleNoWhitespace}-${year}-${month}-${day}.csv`;
+  };
+
+  const csvDownloadOnClick = () => {
+    const options = {
+      format_csv: true,
+      traverse_pagination: true,
+      group_uuid: groupId,
+    };
+    // Apply the table state to the request args
+    // sortBy can support multiple values, the members table will only ever have one applied
+    // so we can grab the data from the first index should it exist
+    if (tableInstance.state.sortBy[0]) {
+      options.sort_by = snakeCase(tableInstance.state.sortBy[0].id);
+      // IFF we're doing sorting, check if it's in reverse order
+      if (!tableInstance.state.sortBy[0].desc) {
+        options.is_reversed = !tableInstance.state.sortBy[0].desc;
+      }
+    }
+    tableInstance.state.filters.forEach((filter) => {
+      if (filter.id === 'status') {
+        options.show_removed = filter.value;
+      } else if (filter.id === 'memberDetails') {
+        options.user_query = snakeCase(filter.value);
+      }
+    });
+
+    EnterpriseAccessApiService.fetchSubsidyHydratedGroupMembersData(
+      subsidyAccessPolicyId,
+      options,
+    ).then(response => {
+      // download CSV
+      const blob = new Blob([response.data], {
+        type: 'text/csv',
+      });
+      saveAs(blob, getCsvFileName());
+    }).catch(err => {
+      logError(err);
+      setAlertModalOpen(true);
+      setAlertModalException(err.message);
+    });
+  };
+
+  return (
+    <>
+      <AlertModal
+        title="Something went wrong"
+        isOpen={alertModalOpen}
+        onClose={() => setAlertModalOpen(false)}
+        footerNode={(
+          <ActionRow>
+            <Button
+              variant="tertiary"
+              onClick={() => setAlertModalOpen(false)}
+            >
+              Close
+            </Button>
+          </ActionRow>
+        )}
+      >
+        <p>
+          We&apos;re sorry but something went wrong while downloading your CSV.
+          Please refer to the error below and try again later.
+        </p>
+        <p>{alertModalExc}</p>
+      </AlertModal>
+      <Button
+        onClick={csvDownloadOnClick}
+        iconBefore={Download}
+        variant="inverse-primary"
+        className="border rounded-0 border-dark-500"
+        disabled={tableInstance.itemCount === 0}
+      >
+        Download all ({tableInstance.itemCount})
+      </Button>
+    </>
+  );
+};
+
+GroupMembersCsvDownloadTableAction.propTypes = {
+  tableInstance: PropTypes.shape({
+    itemCount: PropTypes.number,
+    state: PropTypes.shape({
+      filters: PropTypes.arrayOf(PropTypes.shape({
+        id: PropTypes.string,
+        // Can be a string for user queries or bool for show removed toggle
+        value: PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.bool,
+        ]),
+      })),
+      sortBy: PropTypes.arrayOf(PropTypes.shape({
+        id: PropTypes.string,
+        desc: PropTypes.bool,
+      })),
+    }),
+  }),
+};
+
+GroupMembersCsvDownloadTableAction.defaultProps = {
+  tableInstance: {
+    itemCount: 0,
+    state: {},
+  },
+};
+
+export default GroupMembersCsvDownloadTableAction;

--- a/src/components/learner-credit-management/members-tab/LearnerCreditGroupMembersTable.jsx
+++ b/src/components/learner-credit-management/members-tab/LearnerCreditGroupMembersTable.jsx
@@ -14,6 +14,8 @@ import MemberRemoveAction from './bulk-actions/MemberRemoveAction';
 import MemberRemoveModal from './bulk-actions/MemberRemoveModal';
 import { DEFAULT_PAGE, MEMBERS_TABLE_PAGE_SIZE } from '../data';
 import useRemoveMember from '../data/hooks/useRemoveMember';
+import GroupMembersCsvDownloadTableAction from './GroupMembersCsvDownloadTableAction';
+import MembersTableSwitchFilter from './MembersTableSwitchFilter';
 
 const FilterStatus = (rest) => <DataTable.FilterStatus showFilteredFields={false} {...rest} />;
 
@@ -75,6 +77,8 @@ const LearnerCreditGroupMembersTable = ({
     isLoading={isLoading}
     defaultColumnValues={{ Filter: TableTextFilter }}
     FilterStatusComponent={FilterStatus}
+    numBreakoutFilters={2}
+    tableActions={[<GroupMembersCsvDownloadTableAction />]}
     columns={[
       {
         Header: 'Member Details',
@@ -85,7 +89,8 @@ const LearnerCreditGroupMembersTable = ({
         Header: MemberStatusTableColumnHeader,
         accessor: 'status',
         Cell: MemberStatusTableCell,
-        disableFilters: true,
+        Filter: MembersTableSwitchFilter,
+        filter: 'status',
       },
       {
         Header: 'Recent action',
@@ -95,14 +100,15 @@ const LearnerCreditGroupMembersTable = ({
       },
       {
         Header: MemberEnrollmentsTableColumnHeader,
-        accessor: 'memberEnrollment',
-        // TODO:
-        Cell: () => ('0'),
+        accessor: 'enrollmentCount',
+        Cell: ({ row }) => row.original.enrollmentCount,
         disableFilters: true,
+        disableSortBy: true,
       },
     ]}
     initialTableOptions={{
       getRowId: row => row?.memberDetails.userEmail,
+      autoResetPage: true,
     }}
     initialState={{
       pageSize: MEMBERS_TABLE_PAGE_SIZE,

--- a/src/components/learner-credit-management/members-tab/MembersTableSwitchFilter.jsx
+++ b/src/components/learner-credit-management/members-tab/MembersTableSwitchFilter.jsx
@@ -1,0 +1,32 @@
+import { Form } from '@edx/paragon';
+import PropTypes from 'prop-types';
+
+const MembersTableSwitchFilter = ({ column: { filterValue, setFilter } }) => (
+  <Form.Switch
+    className="ml-2.5 mt-2.5"
+    checked={filterValue || false}
+    onChange={() => {
+      setFilter(!filterValue || false); // Set undefined to remove the filter entirely
+    }}
+    data-testid="show-removed-toggle"
+  >
+    Show removed
+  </Form.Switch>
+);
+
+MembersTableSwitchFilter.propTypes = {
+  /**
+   * Specifies a column object.
+   *
+   * `setFilter`: Function to set the filter value.
+   *
+   * `filterValue`: Value for the filter input.
+   */
+  column: PropTypes.shape({
+    setFilter: PropTypes.func.isRequired,
+    Header: PropTypes.oneOfType([PropTypes.elementType, PropTypes.node]).isRequired,
+    filterValue: PropTypes.bool,
+  }).isRequired,
+};
+
+export default MembersTableSwitchFilter;

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -695,10 +695,10 @@ describe('<BudgetDetailPage />', () => {
     const spentSection = within(screen.getByTestId('spent-section'));
     expect(spentSection.getByText('No results found')).toBeInTheDocument();
     expect(spentSection.getByText('Spent activity is driven by completed enrollments.', { exact: false })).toBeInTheDocument();
-    const isSubsidyAccessPolicyWithAnalyicsApi = (
+    const isSubsidyAccessPolicyWithAnalyticsApi = (
       budgetId === mockSubsidyAccessPolicyUUID && !isTopDownAssignmentEnabled
     );
-    if (budgetId === mockEnterpriseOfferId || isSubsidyAccessPolicyWithAnalyicsApi) {
+    if (budgetId === mockEnterpriseOfferId || isSubsidyAccessPolicyWithAnalyticsApi) {
       // This copy is only present when the "Spent" table is backed by the
       // analytics API (i.e., budget is an enterprise offer or a subsidy access
       // policy with the LC2 feature flag disabled).

--- a/src/data/services/EnterpriseAccessApiService.js
+++ b/src/data/services/EnterpriseAccessApiService.js
@@ -253,6 +253,12 @@ class EnterpriseAccessApiService {
     const url = `${EnterpriseAccessApiService.baseUrl}/policy-allocation/${subsidyAccessPolicyUUID}/allocate/`;
     return EnterpriseAccessApiService.apiClient().post(url, payload);
   }
+
+  static fetchSubsidyHydratedGroupMembersData(subsidyAccessPolicyUUID, options) {
+    const queryParams = new URLSearchParams(options);
+    const subsidyHydratedGroupLearnersEndpoint = `${EnterpriseAccessApiService.baseUrl}/subsidy-access-policies/${subsidyAccessPolicyUUID}/group-members?${queryParams.toString()}`;
+    return EnterpriseAccessApiService.apiClient().get(subsidyHydratedGroupLearnersEndpoint);
+  }
 }
 
 export default EnterpriseAccessApiService;


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-8562

With the new usage of the subisdy access API for group member data, we can implement both csv download as a table action and enrollment count for both csv downloads and displayed table.

CSV download data will apply any filter and sorting currently applied to the table, but will traverse all pages of data.

![image](https://github.com/openedx/frontend-app-admin-portal/assets/67655836/df7ecda6-e6cf-4dbd-8c5c-39fea5ff8943)

![image](https://github.com/openedx/frontend-app-admin-portal/assets/67655836/bd2427f1-935e-4b89-92f0-01db19fb4a29)


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
