### PR TITLE
fix: pass filters, not emails, when remindAllUsers is selected

### DIFF
--- a/src/components/subscriptions/licenses/LicenseManagementModals/tests/LicenseManagementRemindModal.test.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementModals/tests/LicenseManagementRemindModal.test.jsx
@@ -161,7 +161,13 @@ describe('<LicenseManagementRemindModal />', () => {
 
     it('calls licenseBulkRemind with emails when users are passed in', async () => {
       const props = {
-        ...basicProps, usersToRemind: [sampleUser], totalToRemind: 1, activeFilters: [],
+        ...basicProps,
+        usersToRemind: [sampleUser],
+        totalToRemind: 1,
+        activeFilters: [{  // part of the test is that these activeFilters are not sent in the request body
+          name: 'statusBadge',
+          filterValue: [ASSIGNED],
+        }],
       };
 
       act(() => {
@@ -184,6 +190,7 @@ describe('<LicenseManagementRemindModal />', () => {
       const props = {
         ...basicProps,
         remindAllUsers: true,
+        usersToRemind: [sampleUser],  // part of the test here is that the emails are not sent in the request body
         totalToRemind: null,
         activeFilters: [{
           name: 'statusBadge',


### PR DESCRIPTION
The license-manager [remind view](https://github.com/openedx/license-manager/blob/217d3c67874287c1c544095d0f5ebf0bb1ba02c8/license_manager/apps/api/v1/views.py#L941-L992) already supports bulk operations - a caller can provide filters on either a `user_email` or set of statuses, via `status_in`, with that view’s [serializer.](https://github.com/openedx/license-manager/blob/217d3c67874287c1c544095d0f5ebf0bb1ba02c8/license_manager/apps/api/serializers.py#L400)

Here in the admin portal, the remind modal already makes use of that bulk behavior.

The problem is that selecting all rows in the table causes `usersToRemind` to be populated with the first page of user email addresses, and the logic gives preference to the presence of those emails over the presence of any `activeFilters`.

This PR changes the logic in the `makeRequest()` function to give preference to `remindAllUsers && activeFilters` when determining how to populate options, and continues to rely on the remind endpoint to process reminders for the provided `activeFilters`.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
