### PR TITLE
fix: consider mixed state of budget expiries when rendering expiry modal

### DIFF
--- a/src/components/BudgetExpiryAlertAndModal/data/hooks/useExpiry.test.jsx
+++ b/src/components/BudgetExpiryAlertAndModal/data/hooks/useExpiry.test.jsx
@@ -61,4 +61,15 @@ describe('useExpiry', () => {
     expect(result.current.modal).toEqual(expected.modalTemplate);
     expect(result.current.status).toEqual(expected.status);
   });
+
+  it('displays no notification with both an expired and non-expired budget', () => {
+    const expiredBudget = { end: dayjs().subtract(1, 'day') };
+    const nonExpiredBudget = { end: dayjs().add(200, 'day') };
+    const budgets = [expiredBudget, nonExpiredBudget];
+
+    const { result } = renderHook(() => useExpiry('enterpriseId', budgets, modalOpen, modalClose, alertOpen, alertClose));
+
+    expect(result.current.notification).toEqual(null);
+    expect(result.current.modal).toEqual(null);
+  });
 });

--- a/src/components/BudgetExpiryAlertAndModal/data/utils.js
+++ b/src/components/BudgetExpiryAlertAndModal/data/utils.js
@@ -5,6 +5,11 @@ import ExpiryThresholds from './expiryThresholds';
 
 dayjs.extend(duration);
 
+export const getNonExpiredBudgets = (budgets) => {
+  const today = dayjs();
+  return budgets.filter((budget) => today <= dayjs(budget.end));
+};
+
 export const getExpirationMetadata = (endDateStr) => {
   const endDate = dayjs(endDateStr);
   const today = dayjs();


### PR DESCRIPTION
When determining budget expiry thresholds/modals, We need to consider the special case where there are a mix of expired and non-expired budgets.  In that case, we only want to determine the expiry threshold from the set of *non-expired* budgets, so that the expiry alert and modal below do not falsely indicate that *all* budgets are expired.

Note: this change leaves in place the current preference that we alert on the *earliest* expiring budget (now drawn from the set of only non-expired budgets).
ENT-8834

## Before change (what we want to fix)
![image](https://github.com/openedx/frontend-app-admin-portal/assets/2307986/63bbe8d2-b5da-4761-be13-ed8dec644547)
![image](https://github.com/openedx/frontend-app-admin-portal/assets/2307986/71b53be9-5982-4ef2-b617-945fd4c9358e)


## After change (the proposed fix)
![image](https://github.com/openedx/frontend-app-admin-portal/assets/2307986/6e0e7df3-5159-40af-9cc8-60ee9d0a61e1)
![image](https://github.com/openedx/frontend-app-admin-portal/assets/2307986/3d3cf806-b961-42ca-84b1-9bdee9d34561)


# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
