### PR TITLE
fix: Headless ManageAccounts icon

### DIFF
--- a/patches/@edx+paragon+20.46.3.patch
+++ b/patches/@edx+paragon+20.46.3.patch
@@ -27,3 +27,30 @@ index 00c4c4b..426ca4e 100644
      }
    })), numSelectedRows > 0 && /*#__PURE__*/React.createElement(Button, {
      className: CLEAR_SELECTION_TEST_ID,
+diff --git a/node_modules/@edx/paragon/icons/es5/ManageAccounts.js b/node_modules/@edx/paragon/icons/es5/ManageAccounts.js
+index 2246911..8940d48 100644
+--- a/node_modules/@edx/paragon/icons/es5/ManageAccounts.js
++++ b/node_modules/@edx/paragon/icons/es5/ManageAccounts.js
+@@ -12,7 +12,8 @@ const SvgManageAccounts = props => /*#__PURE__*/React.createElement("svg", _exte
+ }), /*#__PURE__*/React.createElement("circle", {
+   cx: 10,
+   cy: 8,
+-  r: 4
++  r: 4,
++  fill: "currentColor"
+ }), /*#__PURE__*/React.createElement("path", {
+   d: "M20.75 16c0-.22-.03-.42-.06-.63l1.14-1.01-1-1.73-1.45.49c-.32-.27-.68-.48-1.08-.63L18 11h-2l-.3 1.49c-.4.15-.76.36-1.08.63l-1.45-.49-1 1.73 1.14 1.01c-.03.21-.06.41-.06.63s.03.42.06.63l-1.14 1.01 1 1.73 1.45-.49c.32.27.68.48 1.08.63L16 21h2l.3-1.49c.4-.15.76-.36 1.08-.63l1.45.49 1-1.73-1.14-1.01c.03-.21.06-.41.06-.63zM17 18c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2z",
+   fill: "currentColor"
+diff --git a/node_modules/@edx/paragon/icons/jsx/ManageAccounts.jsx b/node_modules/@edx/paragon/icons/jsx/ManageAccounts.jsx
+index 5491289..c1f8773 100644
+--- a/node_modules/@edx/paragon/icons/jsx/ManageAccounts.jsx
++++ b/node_modules/@edx/paragon/icons/jsx/ManageAccounts.jsx
+@@ -12,7 +12,7 @@ const SvgManageAccounts = (props) => (
+       d="M10.67 13.02c-.22-.01-.44-.02-.67-.02-2.42 0-4.68.67-6.61 1.82-.88.52-1.39 1.5-1.39 2.53V20h9.26a6.963 6.963 0 0 1-.59-6.98z"
+       fill="currentColor"
+     />
+-    <circle cx={10} cy={8} r={4} />
++    <circle cx={10} cy={8} r={4} fill="currentColor"/>
+     <path
+       d="M20.75 16c0-.22-.03-.42-.06-.63l1.14-1.01-1-1.73-1.45.49c-.32-.27-.68-.48-1.08-.63L18 11h-2l-.3 1.49c-.4.15-.76.36-1.08.63l-1.45-.49-1 1.73 1.14 1.01c-.03.21-.06.41-.06.63s.03.42.06.63l-1.14 1.01 1 1.73 1.45-.49c.32.27.68.48 1.08.63L16 21h2l.3-1.49c.4-.15.76-.36 1.08-.63l1.45.49 1-1.73-1.14-1.01c.03-.21.06-.41.06-.63zM17 18c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2z"
+       fill="currentColor"

--- a/src/components/learner-credit-management/BudgetStatusSubtitle.jsx
+++ b/src/components/learner-credit-management/BudgetStatusSubtitle.jsx
@@ -31,8 +31,7 @@ const BudgetStatusSubtitle = ({
         defaultMessage: 'Available to people in your organization based on settings configured in your integrated learning platform',
         description: 'Popover text for budgets that are assigned via an integrated learning platform',
       }),
-      icon: <Icon size="xs" src={ManageAccounts} className="ml-1 mt-4 d-inline-flex" />,
-
+      icon: <Icon size="xs" src={ManageAccounts} className="ml-1 mt-4 d-inline-flex" svgAttrs={{ transform: 'translate(0,2)' }} />,
     },
     assignable: {
       enrollmentType:
@@ -47,7 +46,7 @@ const BudgetStatusSubtitle = ({
         defaultMessage: 'Available to members added to this budget',
         description: 'Popover text for budgets that are assignable',
       }),
-      icon: <Icon size="xs" src={GroupAdd} className="ml-1 d-inline-flex" />,
+      icon: <Icon size="xs" src={GroupAdd} className="ml-1 d-inline-flex" svgAttrs={{ transform: 'translate(0,2)' }} />,
     },
     browseAndEnroll: {
       enrollmentType:
@@ -62,7 +61,7 @@ const BudgetStatusSubtitle = ({
         defaultMessage: 'Available to all people in your organization',
         description: 'Popover text for budgets that are browsable and enrollable',
       }),
-      icon: <Icon size="xs" src={Groups} className="ml-1 d-inline-flex" />,
+      icon: <Icon size="xs" src={Groups} className="ml-1 d-inline-flex" svgAttrs={{ transform: 'translate(0,2)' }} />,
     },
   };
   let budgetTypeToRender;


### PR DESCRIPTION
[Jira Ticket](https://2u-internal.atlassian.net/browse/ENT-8893)

[Local Stage Example](https://localhost.stage.edx.org:1991/pawnee-parks/admin/learner-credit/6acd1860-d0a5-4e35-a529-5b3dd589c1db)

This patches a bug in the ManageAccounts icon svg that has been fixed in Paragon, and also make some positional adjustments to icons.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
