### PR TITLE
fix: remove extraneous comma in budget card

### DIFF
--- a/src/components/learner-credit-management/BudgetDetailPageOverviewAvailability.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPageOverviewAvailability.jsx
@@ -154,7 +154,7 @@ const BudgetActions = ({
                     description="Configure access button on the budget detail page overview"
                   />
                 </Button>
-              </Link>,
+              </Link>
             </div>
           </div>
         );


### PR DESCRIPTION
# Description
In the budget card, there is an extraneous comma after the 'Configure access' button that is removed.
https://2u-internal.atlassian.net/jira/software/c/projects/ENT/boards/630?assignee=712020%3A008f4187-4536-4e5b-ae31-b8cd7792730c&selectedIssue=ENT-9012 

#UI changes
|before|after|
|------|----
|![Screenshot 2024-05-23 at 3 44 13 PM](https://github.com/openedx/frontend-app-admin-portal/assets/71999631/4c93578f-ee24-4546-ad27-f28307e2b266)|![Screenshot 2024-05-23 at 3 48 21 PM](https://github.com/openedx/frontend-app-admin-portal/assets/71999631/a87ad8ef-b96e-4846-b35a-1dba0097d849)|


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
