### PR TITLE
fix: update info icon color

### DIFF
--- a/src/components/learner-credit-management/invite-modal/InviteModalSummaryDuplicate.jsx
+++ b/src/components/learner-credit-management/invite-modal/InviteModalSummaryDuplicate.jsx
@@ -4,7 +4,7 @@ import { Error } from '@openedx/paragon/icons';
 
 const InviteModalSummaryDuplicate = () => (
   <Stack className="duplicate-warning" direction="horizontal" gap={3}>
-    <Icon className="text-info" src={Error} />
+    <Icon className="text-info-500" src={Error} />
     <div>
       <div className="h4 mb-1">Only 1 invite per email address will be sent.</div>
       <span className="small">One or more duplicate emails were detected. Ensure that your entry is correct before proceeding.</span>


### PR DESCRIPTION
# Description
Update info icon color to darker blue to match figma mocks.
https://2u-internal.atlassian.net/browse/ENT-9013

# UI Changes
|figma|before|after|
|-----|------|-----|
|![Screenshot 2024-05-24 at 1 18 41 PM](https://github.com/openedx/frontend-app-admin-portal/assets/71999631/5c528ce6-bba4-45b0-a8cc-672d8589593a)|![Screenshot 2024-05-24 at 1 13 16 PM](https://github.com/openedx/frontend-app-admin-portal/assets/71999631/8eeedcbb-3ef8-40f4-b050-646aae6f08bb)|![Screenshot 2024-05-24 at 1 20 21 PM](https://github.com/openedx/frontend-app-admin-portal/assets/71999631/27b6a47d-3599-4868-9a0d-d3c0ebdba906)|

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
