### PR TITLE
fix: removed margin and added danger color

### DIFF
--- a/src/components/learner-credit-management/invite-modal/InviteModalBudgetCard.jsx
+++ b/src/components/learner-credit-management/invite-modal/InviteModalBudgetCard.jsx
@@ -64,7 +64,7 @@ const InviteModalBudgetCard = ({
 
   const { available, utilized, limit } = budgetTotalSummary;
   return (
-    <Card className="budget-overview-card m-3">
+    <Card className="budget-overview-card">
       <Card.Section>
         <Row>
           <Col lg={5}>

--- a/src/components/learner-credit-management/styles/index.scss
+++ b/src/components/learner-credit-management/styles/index.scss
@@ -30,7 +30,7 @@
 }
 
 .assignment-modal-summary-card,
-.assignment-modal-total-assignment-cost-card
+.assignment-modal-total-assignment-cost-card,
 .invite-modal-summary-card {
   &.invalid {
     background-color: $danger-100;


### PR DESCRIPTION
# Description
Fixed styling issue around container width in Invite members modal and added danger color "Members can't be invited as entered" warning.
https://2u-internal.atlassian.net/browse/ENT-9018

# UI Changes
|description|figma|before|after|
|-----------|------|------|-----|
|Fixed card alignment|<img width="762" alt="Screenshot 2024-05-28 at 4 31 57 PM" src="https://github.com/openedx/frontend-app-admin-portal/assets/71999631/878c418a-21f1-447d-b88f-c85303dd1e17">|<img width="1141" alt="Screenshot 2024-05-28 at 4 24 35 PM" src="https://github.com/openedx/frontend-app-admin-portal/assets/71999631/a7192a8b-7ea8-4a4d-8a5e-ef7fb34acc3e">|<img width="1148" alt="Screenshot 2024-05-28 at 3 55 05 PM" src="https://github.com/openedx/frontend-app-admin-portal/assets/71999631/aab0503f-e6b4-4ace-940f-773d3bb6dc98">|
|added danger color "Members can't be invited as entered" warning|<img width="436" alt="Screenshot 2024-05-28 at 4 33 46 PM" src="https://github.com/openedx/frontend-app-admin-portal/assets/71999631/3fc39be8-68f6-497d-8b30-0737b3087c0d">|<img width="1145" alt="Screenshot 2024-05-28 at 4 25 07 PM" src="https://github.com/openedx/frontend-app-admin-portal/assets/71999631/ad372099-2ab8-420d-a809-df8104d1bb86">|<img width="1174" alt="Screenshot 2024-05-28 at 4 22 42 PM" src="https://github.com/openedx/frontend-app-admin-portal/assets/71999631/39f324e6-8102-47f7-8170-5feb7999becd">|

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
