### PR TITLE
fix: Update help center and hide groups content

### DIFF
--- a/src/components/learner-credit-management/BudgetDetailActivityTabContents.jsx
+++ b/src/components/learner-credit-management/BudgetDetailActivityTabContents.jsx
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import isEmpty from 'lodash/isEmpty';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Stack, Skeleton } from '@openedx/paragon';
@@ -12,10 +13,11 @@ import NoBnEBudgetActivity from './empty-state/NoBnEBudgetActivity';
 
 const BudgetDetailActivityTabContents = ({ enterpriseUUID, enterpriseFeatures }) => {
   const isTopDownAssignmentEnabled = enterpriseFeatures.topDownAssignmentRealTimeLcm;
-  const isEnterpriseGroupsEnabled = enterpriseFeatures.enterpriseGroupsV1;
-  const { openInviteModal } = useContext(BudgetDetailPageContext);
   const { enterpriseOfferId, subsidyAccessPolicyId } = useBudgetId();
   const { data: subsidyAccessPolicy } = useSubsidyAccessPolicy(subsidyAccessPolicyId);
+  const isEnterpriseGroupsEnabled = enterpriseFeatures.enterpriseGroupsV1
+    && !isEmpty(subsidyAccessPolicy?.groupAssociations);
+  const { openInviteModal } = useContext(BudgetDetailPageContext);
   const {
     isLoading: isBudgetActivityOverviewLoading,
     isFetching: isBudgetActivityOverviewFetching,

--- a/src/components/learner-credit-management/BudgetDetailPageOverviewAvailability.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPageOverviewAvailability.jsx
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import isEmpty from 'lodash/isEmpty';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { generatePath, useParams, Link } from 'react-router-dom';
@@ -95,7 +96,7 @@ const BudgetActions = ({
   }
 
   if (!isAssignable) {
-    if (enterpriseGroupsV1) {
+    if (enterpriseGroupsV1 && !isEmpty(subsidyAccessPolicy?.groupAssociations)) {
       if (isLmsBudget(enterpriseCustomer?.activeIntegrations.length, enterpriseGroup?.appliesToAllContexts)) {
         return (
           <div className="h-100 d-flex align-items-center pt-4 pt-lg-0">

--- a/src/components/learner-credit-management/data/tests/constants.js
+++ b/src/components/learner-credit-management/data/tests/constants.js
@@ -89,6 +89,23 @@ export const mockPerLearnerSpendLimitSubsidyAccessPolicy = {
   uuid: mockSubsidyAccessPolicyUUID,
   subsidyActiveDatetime: new Date(today).toISOString(),
   subsidyExpirationDatetime: new Date(today + 130 * 24 * 60 * 60 * 1000).toISOString(),
+  groupAssociations: ['test-group-uuid'],
+  policyType: 'PerLearnerSpendCreditAccessPolicy',
+  displayName: 'Per Learner Spend Limit',
+  spendLimit: 10000 * 100,
+  aggregates: {
+    spendAvailableUsd: 10000,
+    amountAllocatedUsd: 100,
+    amountRedeemedUsd: 350,
+  },
+  isAssignable: false,
+  subsidyUuid: 'mock-subsidy-uuid',
+};
+
+export const mockSpendLimitNoGroupsSubsidyAccessPolicy = {
+  uuid: mockSubsidyAccessPolicyUUID,
+  subsidyActiveDatetime: new Date(today).toISOString(),
+  subsidyExpirationDatetime: new Date(today + 130 * 24 * 60 * 60 * 1000).toISOString(),
   groupAssociations: [],
   policyType: 'PerLearnerSpendCreditAccessPolicy',
   displayName: 'Per Learner Spend Limit',

--- a/src/components/learner-credit-management/invite-modal/InviteMembersModalWrapper.jsx
+++ b/src/components/learner-credit-management/invite-modal/InviteMembersModalWrapper.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import {
   ActionRow, Button, FullscreenModal, Hyperlink, StatefulButton, useToggle,
 } from '@openedx/paragon';
-import { getConfig } from '@edx/frontend-platform/config';
 import { snakeCaseObject } from '@edx/frontend-platform/utils';
 
 import { useBudgetId, useSubsidyAccessPolicy } from '../data';
@@ -12,6 +11,7 @@ import SystemErrorAlertModal from '../cards/assignment-allocation-status-modals/
 import LmsApiService from '../../../data/services/LmsApiService';
 import { BudgetDetailPageContext } from '../BudgetDetailPageWrapper';
 import { BUDGET_DETAIL_MEMBERS_TAB } from '../data/constants';
+import { HELP_CENTER_GROUPS_INVITE_LINK } from '../../settings/data/constants';
 
 const InviteMembersModalWrapper = ({
   isOpen,
@@ -90,7 +90,7 @@ const InviteMembersModalWrapper = ({
             <Button
               variant="tertiary"
               as={Hyperlink}
-              destination={getConfig().ENTERPRISE_SUPPORT_URL}
+              destination={HELP_CENTER_GROUPS_INVITE_LINK}
               target="_blank"
             >
               Help Center: Invite Budget Members

--- a/src/components/learner-credit-management/members-tab/MemberStatusTableCell.jsx
+++ b/src/components/learner-credit-management/members-tab/MemberStatusTableCell.jsx
@@ -6,6 +6,7 @@ import {
 import {
   CheckCircle, RemoveCircle, Timelapse,
 } from '@openedx/paragon/icons';
+import { HELP_CENTER_GROUPS_INVITE_LINK } from '../../settings/data/constants';
 
 const MemberStatusTableCell = ({
   row,
@@ -56,7 +57,7 @@ const MemberStatusTableCell = ({
               <div>
                 <p className="mt-2 mb-0 small"><strong>{popoverExtra1}</strong></p>
                 <p className="mb-0 small">{popoverExtra2}
-                  <Hyperlink destination="https://www.edx.org">
+                  <Hyperlink target="_blank" destination={HELP_CENTER_GROUPS_INVITE_LINK}>
                     Help Center: Inviting Budget Members
                   </Hyperlink>
                 </p>

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -40,6 +40,7 @@ import {
   mockEnterpriseOfferId,
   mockEnterpriseOfferMetadata,
   mockPerLearnerSpendLimitSubsidyAccessPolicy,
+  mockSpendLimitNoGroupsSubsidyAccessPolicy,
   mockSubsidyAccessPolicyUUID,
   mockSubsidySummary,
 } from '../data/tests/constants';
@@ -507,6 +508,49 @@ describe('<BudgetDetailPage />', () => {
     useSubsidyAccessPolicy.mockReturnValue({
       isInitialLoading: false,
       data: mockPerLearnerSpendLimitSubsidyAccessPolicy,
+    });
+    useEnterpriseGroupLearners.mockReturnValue({
+      data: {
+        count: 0,
+        currentPage: 1,
+        next: null,
+        numPages: 1,
+        results: [],
+      },
+    });
+    useBudgetDetailActivityOverview.mockReturnValue({
+      isLoading: false,
+      data: mockEmptyStateBudgetDetailActivityOverview,
+    });
+    useBudgetRedemptions.mockReturnValue({
+      isLoading: false,
+      budgetRedemptions: mockEmptyBudgetRedemptions,
+      fetchBudgetRedemptions: jest.fn(),
+    });
+    renderWithRouter(<BudgetDetailPageWrapper initialState={initialState} />);
+
+    // Overview empty state (no content assignments, no spent transactions)
+    expect(screen.queryByText('No budget activity yet? Invite members to browse the catalog and enroll!')).not.toBeInTheDocument();
+  });
+
+  it('does not render bne zero state when the customer does not have any group associations', async () => {
+    const initialState = {
+      portalConfiguration: {
+        ...initialStoreState.portalConfiguration,
+        enterpriseFeatures: {
+          enterpriseGroupsV1: true,
+        },
+      },
+    };
+    useParams.mockReturnValue({
+      enterpriseSlug: 'test-enterprise-slug',
+      enterpriseAppPage: 'test-enterprise-page',
+      budgetId: 'a52e6548-649f-4576-b73f-c5c2bee25e9c',
+      activeTabKey: 'activity',
+    });
+    useSubsidyAccessPolicy.mockReturnValue({
+      isInitialLoading: false,
+      data: mockSpendLimitNoGroupsSubsidyAccessPolicy,
     });
     useEnterpriseGroupLearners.mockReturnValue({
       data: {

--- a/src/components/settings/data/constants.js
+++ b/src/components/settings/data/constants.js
@@ -25,6 +25,7 @@ export const HELP_CENTER_API_GUIDE = 'https://edx-enterprise-api.readthedocs.io/
 export const HELP_CENTER_SAML_LINK = 'https://business-support.edx.org/hc/en-us/articles/360005421073-5-Implementing-Single-Sign-on-SSO-with-edX';
 export const HELP_CENTER_SAP_IDP_LINK = 'https://business-support.edx.org/hc/en-us/articles/360005205314';
 export const HELP_CENTER_BRANDING_LINK = 'https://business-support.edx.org/hc/en-us/sections/8739219372183';
+export const HELP_CENTER_GROUPS_INVITE_LINK = 'https://business-support.edx.org/hc/en-us/sections/23077390950167-Inviting-Learner-Credit-Budget-Members';
 
 export const API_CLIENT_DOCUMENTATION = 'https://edx-enterprise-api.readthedocs.io/en/latest/index.html';
 export const API_TERMS_OF_SERVICE = 'https://courses.edx.org/api-admin/terms-of-service/';


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-9042

This ticket changes all the help center links from placeholders to the correct groups link and adds an additional check to make sure the org has a groups association before showing groups content. 

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
