### PR TITLE
feat: Add enroll-by date to the assignment table

### DIFF
--- a/src/components/BudgetExpiryAlertAndModal/data/expiryThresholds.js
+++ b/src/components/BudgetExpiryAlertAndModal/data/expiryThresholds.js
@@ -100,9 +100,9 @@ const expiryThresholds = {
       variant: 'danger',
       message: intl.formatMessage({
         id: 'adminPortal.learnerCredit.expiresInThirtyDaysNotification.message',
-        defaultMessage: 'When your plan expires you will lose access to administrative functions and the remaining balance of your plan{apostrophe}s budget(s) will be unusable. Contact support today to renew your plan.',
+        defaultMessage: "When your plan expires you will lose access to administrative functions and the remaining balance of your plan's budget(s) will be unusable. Contact support today to renew your plan.",
         description: 'Message for the notification that the Learner Credit plan is expiring in less than 30 days.',
-      }, { apostrophe: "'" }),
+      }),
     },
     modalTemplate: {
       title: intl.formatMessage({
@@ -161,10 +161,10 @@ const expiryThresholds = {
       message: parse(sanitizeHTML(
         intl.formatMessage({
           id: 'adminPortal.learnerCreditPlan.expiredModal.message',
-          defaultMessage: `Your Learner Credit plan expired on {date}. You no longer have access to administrative functions and the remaining balance of your plan{apostrophe}s budget(s) are no longer available to spend.
+          defaultMessage: `Your Learner Credit plan expired on {date}. You no longer have access to administrative functions and the remaining balance of your plan's budget(s) are no longer available to spend.
             Please contact your representative if you have any questions or concerns.`,
           description: 'Message for the modal that the Learner Credit plan has expired.',
-        }, { date, apostrophe: "'" }),
+        }, { date }),
       )),
     },
     variant: PLAN_EXPIRY_VARIANTS.expired,

--- a/src/components/BudgetExpiryAlertAndModal/data/expiryThresholds.js
+++ b/src/components/BudgetExpiryAlertAndModal/data/expiryThresholds.js
@@ -93,26 +93,26 @@ const expiryThresholds = {
   30: ({ intl, date }) => ({
     notificationTemplate: {
       title: intl.formatMessage({
-        id: 'adminPostal.learnerCredit.expiresInThirtyDaysNotification.title',
+        id: 'adminPortal.learnerCredit.expiresInThirtyDaysNotification.title',
         defaultMessage: 'Your Learner Credit plan expires in less than 30 days',
         description: 'Title for the notification that the Learner Credit plan is expiring in less than 30 days.',
       }),
       variant: 'danger',
       message: intl.formatMessage({
-        id: 'adminPostal.learnerCredit.expiresInThirtyDaysNotification.message',
+        id: 'adminPortal.learnerCredit.expiresInThirtyDaysNotification.message',
         defaultMessage: 'When your plan expires you will lose access to administrative functions and the remaining balance of your plan{apostrophe}s budget(s) will be unusable. Contact support today to renew your plan.',
         description: 'Message for the notification that the Learner Credit plan is expiring in less than 30 days.',
-      }, { aposrophe: "'" }),
+      }, { apostrophe: "'" }),
     },
     modalTemplate: {
       title: intl.formatMessage({
-        id: 'adminPostal.learnerCredit.expiresInThirtyDaysModal.title',
+        id: 'adminPortal.learnerCredit.expiresInThirtyDaysModal.title',
         defaultMessage: 'Your Learner Credit plan expires in less than 30 days',
         description: 'Title for the modal that the Learner Credit plan is expiring in less than 30 days.',
       }),
       message: parse(sanitizeHTML(
         intl.formatMessage({
-          id: 'adminPostal.learnerCredit.expiresInThirtyDaysModal.message',
+          id: 'adminPortal.learnerCredit.expiresInThirtyDaysModal.message',
           defaultMessage: 'Your Learner Credit plan expires {date}. Contact support today to renew your plan and keep people learning.',
           description: 'Message for the modal that the Learner Credit plan is expiring in less than 30 days.',
         }, { date }),

--- a/src/components/ContentHighlights/DeleteArchivedHighlightsDialogs.jsx
+++ b/src/components/ContentHighlights/DeleteArchivedHighlightsDialogs.jsx
@@ -95,11 +95,8 @@ const DeleteArchivedCoursesDialogs = ({
           <p>
             <FormattedMessage
               id="highlights.highlights.tab.archived.courses.modal.message"
-              defaultMessage="Deleting the archived courses in this highlight will remove it from your learners' {doubleQuote}Find a Course{doubleQuote}. This action is permanent and cannot be undone."
+              defaultMessage={"Deleting the archived courses in this highlight will remove it from your learners' \"Find a Course\". This action is permanent and cannot be undone."}
               description="Message shown in the modal to delete archived courses."
-              values={{
-                doubleQuote: '"',
-              }}
             />
           </p>
         </ModalDialog.Body>

--- a/src/components/ContentHighlights/DeleteArchivedHighlightsDialogs.jsx
+++ b/src/components/ContentHighlights/DeleteArchivedHighlightsDialogs.jsx
@@ -95,10 +95,9 @@ const DeleteArchivedCoursesDialogs = ({
           <p>
             <FormattedMessage
               id="highlights.highlights.tab.archived.courses.modal.message"
-              defaultMessage="Deleting the archived courses in this highlight will remove it from your learners{apostrophe} {doubleQuote}Find a Course{doubleQuote}. This action is permanent and cannot be undone."
+              defaultMessage="Deleting the archived courses in this highlight will remove it from your learners' {doubleQuote}Find a Course{doubleQuote}. This action is permanent and cannot be undone."
               description="Message shown in the modal to delete archived courses."
               values={{
-                apostrophe: "'",
                 doubleQuote: '"',
               }}
             />

--- a/src/components/ContentHighlights/DeleteArchivedHighlightsDialogs.jsx
+++ b/src/components/ContentHighlights/DeleteArchivedHighlightsDialogs.jsx
@@ -95,11 +95,11 @@ const DeleteArchivedCoursesDialogs = ({
           <p>
             <FormattedMessage
               id="highlights.highlights.tab.archived.courses.modal.message"
-              defaultMessage="Deleting the archived courses in this highlight will remove it from your learners{apostrophe} {doubleQoute}Find a Course{doubleQoute}. This action is permanent and cannot be undone."
+              defaultMessage="Deleting the archived courses in this highlight will remove it from your learners{apostrophe} {doubleQuote}Find a Course{doubleQuote}. This action is permanent and cannot be undone."
               description="Message shown in the modal to delete archived courses."
               values={{
                 apostrophe: "'",
-                doubleQoute: '"',
+                doubleQuote: '"',
               }}
             />
           </p>

--- a/src/components/ContentHighlights/DeleteHighlightSet.jsx
+++ b/src/components/ContentHighlights/DeleteHighlightSet.jsx
@@ -172,11 +172,8 @@ const DeleteHighlightSet = ({ enterpriseId, enterpriseSlug }) => {
         <p>
           <FormattedMessage
             id="highlights.modal.delete.highlight.confirmation.message"
-            defaultMessage="Deleting this highlight will remove it from your learners' {doubleQuote}Find a Course{doubleQuote}. This action is permanent and cannot be undone."
+            defaultMessage={"Deleting this highlight will remove it from your learners' \"Find a Course\". This action is permanent and cannot be undone."}
             description="Confirmation message shown when deleting a highlight."
-            values={{
-              doubleQuote: '"',
-            }}
           />
         </p>
       </AlertModal>

--- a/src/components/ContentHighlights/DeleteHighlightSet.jsx
+++ b/src/components/ContentHighlights/DeleteHighlightSet.jsx
@@ -172,11 +172,10 @@ const DeleteHighlightSet = ({ enterpriseId, enterpriseSlug }) => {
         <p>
           <FormattedMessage
             id="highlights.modal.delete.highlight.confirmation.message"
-            defaultMessage="Deleting this highlight will remove it from your learners{apostrophe} {doubleQoute}Find a Course{doubleQoute}. This action is permanent and cannot be undone."
+            defaultMessage="Deleting this highlight will remove it from your learners' {doubleQuote}Find a Course{doubleQuote}. This action is permanent and cannot be undone."
             description="Confirmation message shown when deleting a highlight."
             values={{
-              apostrophe: "'",
-              doubleQoute: '"',
+              doubleQuote: '"',
             }}
           />
         </p>

--- a/src/components/ContentHighlights/HighlightStepper/HighlightStepperTitle.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/HighlightStepperTitle.jsx
@@ -34,11 +34,11 @@ const HighlightStepperTitle = () => (
                 id="highlights.new.highlights.stepper.stepper.step.pro.tip.text.create.title"
                 defaultMessage="Pro tip: we recommend naming your highlight collection to reflect skills
                 it aims to develop, or to draw the attention of specific groups it targets.
-                For example, {doubleQoute}Recommended for Marketing{doubleQoute}
-                 or {doubleQoute}Develop Leadership Skills{doubleQoute}."
+                For example, {doubleQuote}Recommended for Marketing{doubleQuote}
+                 or {doubleQuote}Develop Leadership Skills{doubleQuote}."
                 description="Create title pro tip message shown to administrators during creation of new content highlights"
                 values={{
-                  doubleQoute: '"',
+                  doubleQuote: '"',
                 }}
               />
             </strong>

--- a/src/components/ContentHighlights/HighlightStepper/HighlightStepperTitle.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/HighlightStepperTitle.jsx
@@ -32,14 +32,8 @@ const HighlightStepperTitle = () => (
             <strong>
               <FormattedMessage
                 id="highlights.new.highlights.stepper.stepper.step.pro.tip.text.create.title"
-                defaultMessage="Pro tip: we recommend naming your highlight collection to reflect skills
-                it aims to develop, or to draw the attention of specific groups it targets.
-                For example, {doubleQuote}Recommended for Marketing{doubleQuote}
-                 or {doubleQuote}Develop Leadership Skills{doubleQuote}."
+                defaultMessage={'Pro tip: we recommend naming your highlight collection to reflect skills it aims to develop, or to draw the attention of specific groups it targets. For example, "Recommended for Marketing" or "Develop Leadership Skills".'}
                 description="Create title pro tip message shown to administrators during creation of new content highlights"
-                values={{
-                  doubleQuote: '"',
-                }}
               />
             </strong>
           </p>

--- a/src/components/NotFoundPage/index.jsx
+++ b/src/components/NotFoundPage/index.jsx
@@ -12,17 +12,15 @@ export const NotFound = () => (
       <p className="lead">
         <FormattedMessage
           id="admin.portal.not.found.page.message"
-          defaultMessage="Oops, sorry we can{apostrophe}t find that page!"
+          defaultMessage="Oops, sorry we can't find that page!"
           description="The message displayed on the 404 page"
-          values={{ apostrophe: "'" }}
         />
       </p>
       <p>
         <FormattedMessage
           id="admin.portal.not.found.page.message2"
-          defaultMessage="Either something went wrong or the page doesn{apostrophe}t exist anymore."
+          defaultMessage="Either something went wrong or the page doesn't exist anymore."
           description="The message displayed on the 404 page"
-          values={{ apostrophe: "'" }}
         />
       </p>
     </div>

--- a/src/components/learner-credit-management/AssignmentEnrollByDateCell.jsx
+++ b/src/components/learner-credit-management/AssignmentEnrollByDateCell.jsx
@@ -34,12 +34,10 @@ const AssignmentEnrollByDateCell = ({ row }) => {
   const { original: { earliestPossibleExpiration: { date } } } = row;
 
   const formattedEnrollByDate = formatDate(date);
-  const isAssignmentExpiringSoon = isTodayWithinDateThreshold(
-    {
-      days: ENROLL_BY_DATE_DAYS_THRESHOLD,
-      date,
-    },
-  );
+  const isAssignmentExpiringSoon = isTodayWithinDateThreshold({
+    days: ENROLL_BY_DATE_DAYS_THRESHOLD,
+    date,
+  });
 
   return (
     <Stack direction="horizontal" gap={1}>

--- a/src/components/learner-credit-management/AssignmentEnrollByDateCell.jsx
+++ b/src/components/learner-credit-management/AssignmentEnrollByDateCell.jsx
@@ -3,21 +3,24 @@ import {
   Icon, IconButtonWithTooltip, Stack,
 } from '@openedx/paragon';
 import { Warning } from '@openedx/paragon/icons';
-import { useIntl } from '@edx/frontend-platform/i18n';
+import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
 import { ENROLL_BY_DATE_DAYS_THRESHOLD, formatDate } from './data';
 import { isTodayWithinDateThreshold } from '../../utils';
 
-const ExpiringIconButtonWithToolTip = () => {
-  const intl = useIntl();
-  const internationalizedToolTipContent = intl.formatMessage({
-    id: 'lcm.budget.detail.page.assignments.table.columns.enroll.by.date.data.tool.tip.content',
+const messages = defineMessages({
+  tooltipContent: {
+    id: 'lcm.budget.detail.page.assignments.table.columns.enroll-by-date.data.tooltip-content',
     defaultMessage: 'Enrollment deadline approaching',
     description: 'On hover tool tip message for an upcoming enrollment date',
-  });
+  },
+});
+
+const ExpiringIconButtonWithTooltip = () => {
+  const intl = useIntl();
   return (
     <IconButtonWithTooltip
       variant="warning"
-      tooltipContent={internationalizedToolTipContent}
+      tooltipContent={intl.formatMessage(messages.tooltipContent)}
       tooltipPlacement="left"
       src={Warning}
       iconAs={Icon}
@@ -31,7 +34,7 @@ const AssignmentEnrollByDateCell = ({ row }) => {
   const { original: { earliestPossibleExpiration: { date } } } = row;
 
   const formattedEnrollByDate = formatDate(date);
-  const isDateWithinThreshold = isTodayWithinDateThreshold(
+  const isAssignmentExpiringSoon = isTodayWithinDateThreshold(
     {
       days: ENROLL_BY_DATE_DAYS_THRESHOLD,
       date,
@@ -40,8 +43,8 @@ const AssignmentEnrollByDateCell = ({ row }) => {
 
   return (
     <Stack direction="horizontal" gap={1}>
-      {isDateWithinThreshold && <ExpiringIconButtonWithToolTip />}
-      <div className="align-content-center">
+      {isAssignmentExpiringSoon && <ExpiringIconButtonWithTooltip />}
+      <div>
         {formattedEnrollByDate}
       </div>
     </Stack>

--- a/src/components/learner-credit-management/AssignmentEnrollByDateCell.jsx
+++ b/src/components/learner-credit-management/AssignmentEnrollByDateCell.jsx
@@ -2,24 +2,29 @@ import PropTypes from 'prop-types';
 import {
   Icon, IconButtonWithTooltip, Stack,
 } from '@openedx/paragon';
-import { WarningFilled } from '@openedx/paragon/icons';
-import classNames from 'classnames';
-import { formatDate } from './data';
+import { Warning } from '@openedx/paragon/icons';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { ENROLL_BY_DATE_DAYS_THRESHOLD, formatDate } from './data';
 import { isTodayWithinDateThreshold } from '../../utils';
 
-const ExpiringIconButtonWithToolTip = () => (
-  <IconButtonWithTooltip
-    variant="warning"
-    invertColors
-    isActive
-    tooltipContent="Enrollment deadline approaching"
-    tooltipPlacement="left"
-    src={WarningFilled}
-    iconAs={Icon}
-    size="sm"
-    className="bg-transparent"
-  />
-);
+const ExpiringIconButtonWithToolTip = () => {
+  const intl = useIntl();
+  const internationalizedToolTipContent = intl.formatMessage({
+    id: 'lcm.budget.detail.page.assignments.table.columns.enroll.by.date.data.tool.tip.content',
+    defaultMessage: 'Enrollment deadline approaching',
+    description: 'On hover tool tip message for an upcoming enrollment date',
+  });
+  return (
+    <IconButtonWithTooltip
+      variant="warning"
+      tooltipContent={internationalizedToolTipContent}
+      tooltipPlacement="left"
+      src={Warning}
+      iconAs={Icon}
+      size="inline"
+    />
+  );
+};
 
 const AssignmentEnrollByDateCell = ({ row }) => {
   const { original: { earliestPossibleExpiration: { date } } } = row;
@@ -27,22 +32,15 @@ const AssignmentEnrollByDateCell = ({ row }) => {
   const formattedEnrollByDate = formatDate(date);
   const isDateWithinThreshold = isTodayWithinDateThreshold(
     {
-      days: 15,
+      days: ENROLL_BY_DATE_DAYS_THRESHOLD,
       date,
-    },
-  );
-  const className = classNames(
-    'align-content-center',
-    {
-      'ml-4': !isDateWithinThreshold,
-      'pl-3.5': !isDateWithinThreshold,
     },
   );
 
   return (
     <Stack direction="horizontal" gap={1}>
       {isDateWithinThreshold && <ExpiringIconButtonWithToolTip />}
-      <div className={className}>
+      <div className="align-content-center">
         {formattedEnrollByDate}
       </div>
     </Stack>

--- a/src/components/learner-credit-management/AssignmentEnrollByDateCell.jsx
+++ b/src/components/learner-credit-management/AssignmentEnrollByDateCell.jsx
@@ -38,7 +38,7 @@ const AssignmentEnrollByDateCell = ({ row }) => {
   );
 
   return (
-    <Stack direction="horizontal" gap={1} className="justify-content-center">
+    <Stack direction="horizontal" gap={1}>
       {isDateWithinThreshold && <ExpiringIconButtonWithToolTip />}
       <div className="align-content-center">
         {formattedEnrollByDate}

--- a/src/components/learner-credit-management/AssignmentEnrollByDateCell.jsx
+++ b/src/components/learner-credit-management/AssignmentEnrollByDateCell.jsx
@@ -38,7 +38,7 @@ const AssignmentEnrollByDateCell = ({ row }) => {
   );
 
   return (
-    <Stack direction="horizontal" gap={1}>
+    <Stack direction="horizontal" gap={1} className="justify-content-center">
       {isDateWithinThreshold && <ExpiringIconButtonWithToolTip />}
       <div className="align-content-center">
         {formattedEnrollByDate}

--- a/src/components/learner-credit-management/AssignmentEnrollByDateCell.jsx
+++ b/src/components/learner-credit-management/AssignmentEnrollByDateCell.jsx
@@ -1,0 +1,62 @@
+import PropTypes from 'prop-types';
+import {
+  Icon, IconButtonWithTooltip, Stack,
+} from '@openedx/paragon';
+import { WarningFilled } from '@openedx/paragon/icons';
+import classNames from 'classnames';
+import { formatDate } from './data';
+import { isTodayWithinDateThreshold } from '../../utils';
+
+const ExpiringIconButtonWithToolTip = () => (
+  <IconButtonWithTooltip
+    variant="warning"
+    invertColors
+    isActive
+    tooltipContent="Enrollment deadline approaching"
+    tooltipPlacement="left"
+    src={WarningFilled}
+    iconAs={Icon}
+    size="sm"
+    className="bg-transparent"
+  />
+);
+
+const AssignmentEnrollByDateCell = ({ row }) => {
+  const { original: { earliestPossibleExpiration: { date } } } = row;
+
+  const formattedEnrollByDate = formatDate(date);
+  const isDateWithinThreshold = isTodayWithinDateThreshold(
+    {
+      days: 15,
+      date,
+    },
+  );
+  const className = classNames(
+    'align-content-center',
+    {
+      'ml-4': !isDateWithinThreshold,
+      'pl-3.5': !isDateWithinThreshold,
+    },
+  );
+
+  return (
+    <Stack direction="horizontal" gap={1}>
+      {isDateWithinThreshold && <ExpiringIconButtonWithToolTip />}
+      <div className={className}>
+        {formattedEnrollByDate}
+      </div>
+    </Stack>
+  );
+};
+
+AssignmentEnrollByDateCell.propTypes = {
+  row: PropTypes.shape({
+    original: PropTypes.shape({
+      earliestPossibleExpiration: PropTypes.shape({
+        date: PropTypes.string.isRequired,
+      }).isRequired,
+    }).isRequired,
+  }).isRequired,
+};
+
+export default AssignmentEnrollByDateCell;

--- a/src/components/learner-credit-management/AssignmentEnrollByDateCell.jsx
+++ b/src/components/learner-credit-management/AssignmentEnrollByDateCell.jsx
@@ -22,6 +22,7 @@ const ExpiringIconButtonWithToolTip = () => {
       src={Warning}
       iconAs={Icon}
       size="inline"
+      data-testid="upcoming-allocation-expiration-tooltip"
     />
   );
 };

--- a/src/components/learner-credit-management/AssignmentEnrollByDateHeader.jsx
+++ b/src/components/learner-credit-management/AssignmentEnrollByDateHeader.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import {
+  Stack,
+  Icon,
+  IconButtonWithTooltip,
+} from '@openedx/paragon';
+import { InfoOutline } from '@openedx/paragon/icons';
+
+const AssignmentEnrollByDateHeader = () => (
+  <Stack gap={0} direction="horizontal">
+    <span>
+      <p data-testid="assignments-table-enroll-by-column-header" className="mb-0 mr-1">Enroll-by date</p>
+    </span>
+    <IconButtonWithTooltip
+      invertColors
+      isActive
+      tooltipContent="Failure to enroll by midnight of enrollment deadline date will release funds back into the budget"
+      tooltipPlacement="right"
+      src={InfoOutline}
+      iconAs={Icon}
+      size="sm"
+      className="bg-transparent"
+    />
+  </Stack>
+);
+
+export default AssignmentEnrollByDateHeader;

--- a/src/components/learner-credit-management/AssignmentEnrollByDateHeader.jsx
+++ b/src/components/learner-credit-management/AssignmentEnrollByDateHeader.jsx
@@ -31,6 +31,7 @@ const AssignmentEnrollByDateHeader = () => {
         src={InfoOutline}
         iconAs={Icon}
         size="inline"
+        data-testid="enroll-by-date-tooltip"
       />
     </Stack>
   );

--- a/src/components/learner-credit-management/AssignmentEnrollByDateHeader.jsx
+++ b/src/components/learner-credit-management/AssignmentEnrollByDateHeader.jsx
@@ -5,23 +5,35 @@ import {
   IconButtonWithTooltip,
 } from '@openedx/paragon';
 import { InfoOutline } from '@openedx/paragon/icons';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
-const AssignmentEnrollByDateHeader = () => (
-  <Stack gap={0} direction="horizontal">
-    <span>
-      <p data-testid="assignments-table-enroll-by-column-header" className="mb-0 mr-1">Enroll-by date</p>
-    </span>
-    <IconButtonWithTooltip
-      invertColors
-      isActive
-      tooltipContent="Failure to enroll by midnight of enrollment deadline date will release funds back into the budget"
-      tooltipPlacement="right"
-      src={InfoOutline}
-      iconAs={Icon}
-      size="sm"
-      className="bg-transparent"
-    />
-  </Stack>
-);
+const AssignmentEnrollByDateHeader = () => {
+  const intl = useIntl();
+  const internationalizedToolTipContent = intl.formatMessage({
+    id: 'lcm.budget.detail.page.assignments.table.columns.enroll.by.date.tool.tip.content',
+    defaultMessage: 'Failure to enroll by midnight of enrollment deadline date will release funds back into the budget',
+    description: 'On hover tool tip message for the enroll-by date column',
+  });
+  return (
+    <Stack gap={0} direction="horizontal">
+      <span>
+        <p data-testid="assignments-table-enroll-by-column-header" className="mb-0 mr-1">
+          {intl.formatMessage({
+            id: 'lcm.budget.detail.page.assignments.table.columns.enroll.by.date',
+            defaultMessage: 'Enroll-by date',
+            description: 'Column header for the recent action column in the assignments table',
+          })}
+        </p>
+      </span>
+      <IconButtonWithTooltip
+        tooltipContent={internationalizedToolTipContent}
+        tooltipPlacement="right"
+        src={InfoOutline}
+        iconAs={Icon}
+        size="inline"
+      />
+    </Stack>
+  );
+};
 
 export default AssignmentEnrollByDateHeader;

--- a/src/components/learner-credit-management/AssignmentEnrollByDateHeader.jsx
+++ b/src/components/learner-credit-management/AssignmentEnrollByDateHeader.jsx
@@ -5,28 +5,30 @@ import {
   IconButtonWithTooltip,
 } from '@openedx/paragon';
 import { InfoOutline } from '@openedx/paragon/icons';
-import { useIntl } from '@edx/frontend-platform/i18n';
+import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  header: {
+    id: 'lcm.budget.detail.page.assignments.table.columns.enroll-by-date.header',
+    defaultMessage: 'Enroll-by date',
+    description: 'Column header for the enroll-by date column in the assignments table',
+  },
+  headerTooltipContent: {
+    id: 'lcm.budget.detail.page.assignments.table.columns.enroll-by-date.header.tooltip-content',
+    defaultMessage: 'Failure to enroll by midnight of enrollment deadline date will release funds back into the budget',
+    description: 'On hover tool tip message for the enroll-by date column',
+  },
+});
 
 const AssignmentEnrollByDateHeader = () => {
   const intl = useIntl();
-  const internationalizedToolTipContent = intl.formatMessage({
-    id: 'lcm.budget.detail.page.assignments.table.columns.enroll.by.date.tool.tip.content',
-    defaultMessage: 'Failure to enroll by midnight of enrollment deadline date will release funds back into the budget',
-    description: 'On hover tool tip message for the enroll-by date column',
-  });
   return (
-    <Stack gap={0} direction="horizontal">
-      <span>
-        <p data-testid="assignments-table-enroll-by-column-header" className="mb-0 mr-1">
-          {intl.formatMessage({
-            id: 'lcm.budget.detail.page.assignments.table.columns.enroll.by.date',
-            defaultMessage: 'Enroll-by date',
-            description: 'Column header for the recent action column in the assignments table',
-          })}
-        </p>
+    <Stack gap={1} direction="horizontal">
+      <span data-testid="assignments-table-enroll-by-column-header">
+        {intl.formatMessage(messages.header)}
       </span>
       <IconButtonWithTooltip
-        tooltipContent={internationalizedToolTipContent}
+        tooltipContent={intl.formatMessage(messages.headerTooltipContent)}
         tooltipPlacement="right"
         src={InfoOutline}
         iconAs={Icon}

--- a/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
+++ b/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
@@ -114,12 +114,6 @@ const BudgetAssignmentsTable = ({
           disableFilters: true,
         },
         {
-          // Header:
-          //     intl.formatMessage({
-          //       id: 'lcm.budget.detail.page.assignments.table.columns.enroll.by.date',
-          //       defaultMessage: 'Enroll-by date',
-          //       description: 'Column header for the recent action column in the assignments table',
-          //     }),
           Header: AssignmentEnrollByDateHeader,
           accessor: 'earliestPossibleExpiration',
           Cell: AssignmentEnrollByDateCell,

--- a/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
+++ b/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
@@ -115,7 +115,6 @@ const BudgetAssignmentsTable = ({
         },
         {
           Header: AssignmentEnrollByDateHeader,
-          headerClassName: 'justify-content-center',
           accessor: 'earliestPossibleExpiration',
           Cell: AssignmentEnrollByDateCell,
           disableFilters: true,

--- a/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
+++ b/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
@@ -115,6 +115,7 @@ const BudgetAssignmentsTable = ({
         },
         {
           Header: AssignmentEnrollByDateHeader,
+          headerClassName: 'justify-content-center',
           accessor: 'earliestPossibleExpiration',
           Cell: AssignmentEnrollByDateCell,
           disableFilters: true,

--- a/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
+++ b/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
@@ -12,6 +12,8 @@ import AssignmentTableCancelAction from './AssignmentTableCancel';
 import { DEFAULT_PAGE, PAGE_SIZE, formatPrice } from './data';
 import AssignmentRecentActionTableCell from './AssignmentRecentActionTableCell';
 import AssignmentsTableRefreshAction from './AssignmentsTableRefreshAction';
+import AssignmentEnrollByDateCell from './AssignmentEnrollByDateCell';
+import AssignmentEnrollByDateHeader from './AssignmentEnrollByDateHeader';
 
 const FilterStatus = (rest) => <DataTable.FilterStatus showFilteredFields={false} {...rest} />;
 
@@ -110,6 +112,19 @@ const BudgetAssignmentsTable = ({
           accessor: 'recentAction',
           Cell: AssignmentRecentActionTableCell,
           disableFilters: true,
+        },
+        {
+          // Header:
+          //     intl.formatMessage({
+          //       id: 'lcm.budget.detail.page.assignments.table.columns.enroll.by.date',
+          //       defaultMessage: 'Enroll-by date',
+          //       description: 'Column header for the recent action column in the assignments table',
+          //     }),
+          Header: AssignmentEnrollByDateHeader,
+          accessor: 'earliestPossibleExpiration',
+          Cell: AssignmentEnrollByDateCell,
+          disableFilters: true,
+          disableSortBy: true,
         },
       ]}
       additionalColumns={[

--- a/src/components/learner-credit-management/BudgetDetailPageOverviewAvailability.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPageOverviewAvailability.jsx
@@ -114,9 +114,8 @@ const BudgetActions = ({
               <p>
                 <FormattedMessage
                   id="lcm.budget.detail.page.overview.budget.actions.people.access.edx"
-                  defaultMessage="People who have received access to discover edX content in your integrated learning platform can spend from this budget{apostrophe}s available balance to enroll."
+                  defaultMessage="People who have received access to discover edX content in your integrated learning platform can spend from this budget's available balance to enroll."
                   description="Description which tells that people can spend from the budget's available balance to enroll"
-                  values={{ apostrophe: "'" }}
                 />
               </p>
               <Link to={`/${enterpriseSlug}/admin/settings/access`}>

--- a/src/components/learner-credit-management/BudgetDetailPageOverviewAvailability.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPageOverviewAvailability.jsx
@@ -13,12 +13,15 @@ import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import { configuration } from '../../config';
 import { BudgetDetailPageContext } from './BudgetDetailPageWrapper';
 import {
-  useBudgetId, useSubsidyAccessPolicy, useEnterpriseCustomer, useEnterpriseGroup,
+  useBudgetId,
+  useSubsidyAccessPolicy,
+  useEnterpriseCustomer,
+  useEnterpriseGroup,
+  isLmsBudget,
 } from './data';
 import EVENT_NAMES from '../../eventTracking';
 import { LEARNER_CREDIT_ROUTE } from './constants';
 import { BUDGET_STATUSES } from '../EnterpriseApp/data/constants';
-import isLmsBudget from './data/utils';
 import BudgetDetail from './BudgetDetail';
 
 const BudgetActions = ({

--- a/src/components/learner-credit-management/BudgetDetailPageOverviewAvailability.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPageOverviewAvailability.jsx
@@ -18,7 +18,7 @@ import {
 import EVENT_NAMES from '../../eventTracking';
 import { LEARNER_CREDIT_ROUTE } from './constants';
 import { BUDGET_STATUSES } from '../EnterpriseApp/data/constants';
-import isLmsBudget from './utils';
+import isLmsBudget from './data/utils';
 import BudgetDetail from './BudgetDetail';
 
 const BudgetActions = ({

--- a/src/components/learner-credit-management/BudgetStatusSubtitle.jsx
+++ b/src/components/learner-credit-management/BudgetStatusSubtitle.jsx
@@ -7,8 +7,12 @@ import {
 import { GroupAdd, Groups, ManageAccounts } from '@openedx/paragon/icons';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
-import { formatDate, useEnterpriseCustomer, useEnterpriseGroup } from './data';
-import isLmsBudget from './data/utils';
+import {
+  formatDate,
+  useEnterpriseCustomer,
+  useEnterpriseGroup,
+  isLmsBudget,
+} from './data';
 
 const BudgetStatusSubtitle = ({
   badgeVariant, status, isAssignable, term, date, policy, enterpriseUUID,

--- a/src/components/learner-credit-management/BudgetStatusSubtitle.jsx
+++ b/src/components/learner-credit-management/BudgetStatusSubtitle.jsx
@@ -8,7 +8,7 @@ import { GroupAdd, Groups, ManageAccounts } from '@openedx/paragon/icons';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { formatDate, useEnterpriseCustomer, useEnterpriseGroup } from './data';
-import isLmsBudget from './utils';
+import isLmsBudget from './data/utils';
 
 const BudgetStatusSubtitle = ({
   badgeVariant, status, isAssignable, term, date, policy, enterpriseUUID,

--- a/src/components/learner-credit-management/CancelAssignmentModal.jsx
+++ b/src/components/learner-credit-management/CancelAssignmentModal.jsx
@@ -53,9 +53,9 @@ const CancelAssignmentModal = ({
         <p>
           <FormattedMessage
             id="lcm.budget.detail.page.catalog.tab.cancel.assignment.modal.body2"
-            defaultMessage="The learner will be notified that you have canceled the assignment. The funds associated with this course assignment will move from {doubleQoute}assigned{doubleQoute} back to {doubleQoute}available{doubleQoute}."
+            defaultMessage="The learner will be notified that you have canceled the assignment. The funds associated with this course assignment will move from {doubleQuote}assigned{doubleQuote} back to {doubleQuote}available{doubleQuote}."
             description="Body text for the cancel assignment modal which informs the user that the learner will be notified that the assignment has been canceled."
-            values={{ doubleQoute: '"' }}
+            values={{ doubleQuote: '"' }}
           />
         </p>
       </ModalDialog.Body>

--- a/src/components/learner-credit-management/CancelAssignmentModal.jsx
+++ b/src/components/learner-credit-management/CancelAssignmentModal.jsx
@@ -53,9 +53,8 @@ const CancelAssignmentModal = ({
         <p>
           <FormattedMessage
             id="lcm.budget.detail.page.catalog.tab.cancel.assignment.modal.body2"
-            defaultMessage="The learner will be notified that you have canceled the assignment. The funds associated with this course assignment will move from {doubleQuote}assigned{doubleQuote} back to {doubleQuote}available{doubleQuote}."
+            defaultMessage={'The learner will be notified that you have canceled the assignment. The funds associated with this course assignment will move from "assigned" back to "available".'}
             description="Body text for the cancel assignment modal which informs the user that the learner will be notified that the assignment has been canceled."
-            values={{ doubleQuote: '"' }}
           />
         </p>
       </ModalDialog.Body>

--- a/src/components/learner-credit-management/RemindAssignmentModal.jsx
+++ b/src/components/learner-credit-management/RemindAssignmentModal.jsx
@@ -47,9 +47,9 @@ const RemindAssignmentModal = ({
         <p>
           <FormattedMessage
             id="lcm.budget.detail.page.catalog.tab.remind.assignment.modal.body2"
-            defaultMessage="When your learner completes enrollment, the associated {doubleQoute}assigned{doubleQoute} funds will be marked as {doubleQoute}spent{doubleQoute}."
+            defaultMessage="When your learner completes enrollment, the associated {doubleQuote}assigned{doubleQuote} funds will be marked as {doubleQuote}spent{doubleQuote}."
             description="Text2 for the body of the remind assignment modal"
-            values={{ doubleQoute: '"' }}
+            values={{ doubleQuote: '"' }}
           />
         </p>
       </ModalDialog.Body>

--- a/src/components/learner-credit-management/RemindAssignmentModal.jsx
+++ b/src/components/learner-credit-management/RemindAssignmentModal.jsx
@@ -47,9 +47,8 @@ const RemindAssignmentModal = ({
         <p>
           <FormattedMessage
             id="lcm.budget.detail.page.catalog.tab.remind.assignment.modal.body2"
-            defaultMessage="When your learner completes enrollment, the associated {doubleQuote}assigned{doubleQuote} funds will be marked as {doubleQuote}spent{doubleQuote}."
+            defaultMessage={'When your learner completes enrollment, the associated "assigned" funds will be marked as "spent".'}
             description="Text2 for the body of the remind assignment modal"
-            values={{ doubleQuote: '"' }}
           />
         </p>
       </ModalDialog.Body>

--- a/src/components/learner-credit-management/assignment-modal/AssignmentAllocationHelpCollapsibles.jsx
+++ b/src/components/learner-credit-management/assignment-modal/AssignmentAllocationHelpCollapsibles.jsx
@@ -78,23 +78,15 @@ const AssignmentAllocationHelpCollapsibles = ({ enterpriseId, course }) => (
           <li>
             <FormattedMessage
               id="lcm.budget.detailsPage.catalog.tab.course.card.total.assignment.cost"
-              defaultMessage="The total assignment cost will be earmarked as {doubleQuote}assigned{doubleQuote} funds in your
-               Learner Credit budget so you can't overspend."
+              defaultMessage={"The total assignment cost will be earmarked as \"assigned\" funds in your Learner Credit budget so you can't overspend."}
               description="A step which explains that the total assignment cost will be earmarked as 'assigned' funds in your Learner Credit budget"
-              values={{
-                doubleQuote: '"',
-              }}
             />
           </li>
           <li>
             <FormattedMessage
               id="lcm.budget.detail.page.catalog.tab.course.card.course.cost.will.convert"
-              defaultMessage="The course cost will automatically convert from {doubleQuote}assigned{doubleQuote} to {doubleQuote}spent{doubleQuote} funds
-                when your learners complete registration."
+              defaultMessage={'The course cost will automatically convert from "assigned" to "spent" funds when your learners complete registration.'}
               description="A step which explains that the course cost will automatically convert from 'assigned' to 'spent' funds when learners complete registration"
-              values={{
-                doubleQuote: '"',
-              }}
             />
           </li>
         </ul>

--- a/src/components/learner-credit-management/assignment-modal/AssignmentAllocationHelpCollapsibles.jsx
+++ b/src/components/learner-credit-management/assignment-modal/AssignmentAllocationHelpCollapsibles.jsx
@@ -78,23 +78,22 @@ const AssignmentAllocationHelpCollapsibles = ({ enterpriseId, course }) => (
           <li>
             <FormattedMessage
               id="lcm.budget.detailsPage.catalog.tab.course.card.total.assignment.cost"
-              defaultMessage="The total assignment cost will be earmarked as {doubleQoute}assigned{doubleQoute} funds in your
-               Learner Credit budget so you can{apostrophe}t overspend."
+              defaultMessage="The total assignment cost will be earmarked as {doubleQuote}assigned{doubleQuote} funds in your
+               Learner Credit budget so you can't overspend."
               description="A step which explains that the total assignment cost will be earmarked as 'assigned' funds in your Learner Credit budget"
               values={{
-                apostrophe: "'",
-                doubleQoute: '"',
+                doubleQuote: '"',
               }}
             />
           </li>
           <li>
             <FormattedMessage
               id="lcm.budget.detail.page.catalog.tab.course.card.course.cost.will.convert"
-              defaultMessage="The course cost will automatically convert from {doubleQoute}assigned{doubleQoute} to {doubleQoute}spent{doubleQoute} funds
+              defaultMessage="The course cost will automatically convert from {doubleQuote}assigned{doubleQuote} to {doubleQuote}spent{doubleQuote} funds
                 when your learners complete registration."
               description="A step which explains that the course cost will automatically convert from 'assigned' to 'spent' funds when learners complete registration"
               values={{
-                doubleQoute: '"',
+                doubleQuote: '"',
               }}
             />
           </li>

--- a/src/components/learner-credit-management/assignment-modal/AssignmentModalSummaryEmptyState.jsx
+++ b/src/components/learner-credit-management/assignment-modal/AssignmentModalSummaryEmptyState.jsx
@@ -6,9 +6,8 @@ const AssignmentModalSummaryEmptyState = () => (
     <div className="h4 mb-0">
       <FormattedMessage
         id="lcm.budget.detail.page.catalog.tab.course.card.entered.no.learners"
-        defaultMessage="You haven{apostrophe}t entered any learners yet."
+        defaultMessage="You haven't entered any learners yet."
         description="Error header when no learners have been entered in the assignment modal"
-        values={{ apostrophe: "'" }}
       />
     </div>
     <span className="small">

--- a/src/components/learner-credit-management/assignment-modal/AssignmentModalSummaryErrorState.jsx
+++ b/src/components/learner-credit-management/assignment-modal/AssignmentModalSummaryErrorState.jsx
@@ -10,9 +10,8 @@ const AssignmentModalSummaryErrorState = () => (
       <div className="h4 mb-0">
         <FormattedMessage
           id="lcm.budget.detail.page.catalog.tab.assign.course.section.error.header"
-          defaultMessage="Learners can{apostrophe}t be assigned as entered."
+          defaultMessage="Learners can't be assigned as entered."
           description="Error message header when course assignment fails due to invalid learner emails."
-          values={{ apostrophe: "'" }}
         />
       </div>
       <span className="small">

--- a/src/components/learner-credit-management/data/constants.js
+++ b/src/components/learner-credit-management/data/constants.js
@@ -68,6 +68,9 @@ export const ASSIGNMENT_STATUS_MODAL_MAX_WIDTH = 480;
 
 export const MEMBERS_TABLE_PAGE_SIZE = 10;
 
+// Enroll-by date warning message threshold by days
+export const ENROLL_BY_DATE_DAYS_THRESHOLD = 10;
+
 // Query Key factory for the learner credit management module, intended to be used with `@tanstack/react-query`.
 // Inspired by https://tkdodo.eu/blog/effective-react-query-keys#use-query-key-factories.
 export const learnerCreditManagementQueryKeys = {

--- a/src/components/learner-credit-management/data/utils.js
+++ b/src/components/learner-credit-management/data/utils.js
@@ -546,6 +546,7 @@ export const getTranslatedBudgetTerm = (intl, term) => {
   }
 };
 
-export default function isLmsBudget(activeIntegrationsLength, isUniversalGroup) {
-  return activeIntegrationsLength > 0 && isUniversalGroup;
-}
+export const isLmsBudget = (
+  activeIntegrationsLength,
+  isUniversalGroup,
+) => activeIntegrationsLength > 0 && isUniversalGroup;

--- a/src/components/learner-credit-management/data/utils.js
+++ b/src/components/learner-credit-management/data/utils.js
@@ -545,3 +545,7 @@ export const getTranslatedBudgetTerm = (intl, term) => {
       return '';
   }
 };
+
+export default function isLmsBudget(activeIntegrationsLength, isUniversalGroup) {
+  return activeIntegrationsLength > 0 && isUniversalGroup;
+}

--- a/src/components/learner-credit-management/members-tab/MemberEnrollmentsTableColumnHeader.jsx
+++ b/src/components/learner-credit-management/members-tab/MemberEnrollmentsTableColumnHeader.jsx
@@ -8,9 +8,9 @@ import {
 import { InfoOutline } from '@openedx/paragon/icons';
 
 const MemberEnrollmentsTableColumnHeader = () => (
-  <Stack gap={0} direction="horizontal">
+  <Stack gap={1} direction="horizontal">
     <span>
-      <p data-testid="members-table-enrollments-column-header" className="mb-0 mr-1">Enrollments</p>
+      Enrollments
     </span>
     <OverlayTrigger
       key="enrollments-column-tooltip"

--- a/src/components/learner-credit-management/members-tab/MemberEnrollmentsTableColumnHeader.jsx
+++ b/src/components/learner-credit-management/members-tab/MemberEnrollmentsTableColumnHeader.jsx
@@ -9,7 +9,7 @@ import { InfoOutline } from '@openedx/paragon/icons';
 
 const MemberEnrollmentsTableColumnHeader = () => (
   <Stack gap={1} direction="horizontal">
-    <span>
+    <span data-testid="members-table-enrollments-column-header">
       Enrollments
     </span>
     <OverlayTrigger

--- a/src/components/learner-credit-management/members-tab/MemberStatusTableColumnHeader.jsx
+++ b/src/components/learner-credit-management/members-tab/MemberStatusTableColumnHeader.jsx
@@ -8,9 +8,9 @@ import {
 import { InfoOutline } from '@openedx/paragon/icons';
 
 const MemberStatusTableColumnHeader = () => (
-  <Stack gap={0} direction="horizontal">
-    <span>
-      <p data-testid="members-table-status-column-header" className="mb-0 mr-1">Status</p>
+  <Stack gap={1} direction="horizontal">
+    <span data-testid="members-table-status-column-header">
+      Status
     </span>
     <OverlayTrigger
       key="status-column-tooltip"

--- a/src/components/learner-credit-management/members-tab/tests/MembersTab.test.jsx
+++ b/src/components/learner-credit-management/members-tab/tests/MembersTab.test.jsx
@@ -837,7 +837,6 @@ describe('<BudgetDetailPage />', () => {
     await waitFor(() => expect(screen.queryByText('dukesilver@test.com')).toBeInTheDocument());
     userEvent.click(screen.getByText('Waiting for member'));
     await waitFor(() => expect(screen.queryByText('Waiting for dukesilver@test.com')).toBeInTheDocument());
-    screen.debug(undefined, 10000000);
     screen.getByText('This member must accept their invitation to browse this budget\'s catalog and enroll using their '
       + 'member permissions by logging in or creating an account within 90 days.');
     // click again to close it out

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -12,6 +12,7 @@ import { renderWithRouter, sendEnterpriseTrackEvent } from '@edx/frontend-enterp
 import { act } from 'react-dom/test-utils';
 import { v4 as uuidv4 } from 'uuid';
 import { faker } from '@faker-js/faker';
+import dayjs from 'dayjs';
 import EnterpriseAccessApiService from '../../../data/services/EnterpriseAccessApiService';
 
 import BudgetDetailPage from '../BudgetDetailPage';
@@ -139,6 +140,7 @@ const mockLearnerContentAssignment = {
   actions: [mockSuccessfulLinkedLearnerAction, mockSuccessfulNotifiedAction],
   errorReason: null,
   assignmentConfiguration: expect.any(Object),
+  earliestPossibleExpiration: { date: dayjs().add(5, 'days').toISOString() },
 };
 const createMockLearnerContentAssignment = () => ({
   ...mockLearnerContentAssignment,
@@ -1958,6 +1960,7 @@ describe('<BudgetDetailPage />', () => {
             actions: [mockSuccessfulNotifiedAction],
             errorReason: null,
             state: 'allocated',
+            earliestPossibleExpiration: { date: dayjs().add(5, 'days').toISOString() },
           },
           {
             uuid: 'test-uuid2',
@@ -1968,6 +1971,7 @@ describe('<BudgetDetailPage />', () => {
             actions: [mockSuccessfulNotifiedAction],
             errorReason: null,
             state: 'allocated',
+            earliestPossibleExpiration: { date: dayjs().add(5, 'days').toISOString() },
           },
         ],
         learnerStateCounts: [
@@ -2049,6 +2053,7 @@ describe('<BudgetDetailPage />', () => {
             actions: [mockSuccessfulNotifiedAction],
             errorReason: null,
             state: 'allocated',
+            earliestPossibleExpiration: { date: dayjs().add(5, 'days').toISOString() },
           },
           {
             uuid: 'test-uuid2',
@@ -2059,6 +2064,7 @@ describe('<BudgetDetailPage />', () => {
             actions: [mockSuccessfulNotifiedAction],
             errorReason: null,
             state: 'allocated',
+            earliestPossibleExpiration: { date: dayjs().add(5, 'days').toISOString() },
           },
           {
             uuid: 'test-uuid3',
@@ -2069,6 +2075,7 @@ describe('<BudgetDetailPage />', () => {
             actions: [mockSuccessfulNotifiedAction],
             errorReason: null,
             state: 'allocated',
+            earliestPossibleExpiration: { date: dayjs().add(5, 'days').toISOString() },
           },
         ],
         learnerStateCounts: [
@@ -2149,6 +2156,7 @@ describe('<BudgetDetailPage />', () => {
             actions: [mockSuccessfulNotifiedAction],
             errorReason: null,
             state: 'allocated',
+            earliestPossibleExpiration: { date: dayjs().add(5, 'days').toISOString() },
           },
         ],
         learnerStateCounts: [{ learnerState: 'waiting', count: 1 }],
@@ -2218,6 +2226,7 @@ describe('<BudgetDetailPage />', () => {
             actions: [mockSuccessfulNotifiedAction],
             errorReason: null,
             state: 'allocated',
+            earliestPossibleExpiration: { date: dayjs().add(5, 'days').toISOString() },
           },
         ],
         learnerStateCounts: [{ learnerState: 'waiting', count: 1 }],

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -2314,7 +2314,7 @@ describe('<BudgetDetailPage />', () => {
     {
       modifiedDayOffset: 15,
     },
-  ])('displays upcoming expiring allocation', async ({ modifiedDayOffset }) => {
+  ])('displays upcoming expiring allocation (%s)', async ({ modifiedDayOffset }) => {
     useParams.mockReturnValue({
       enterpriseSlug: 'test-enterprise-slug',
       enterpriseAppPage: 'test-enterprise-page',

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -708,9 +708,6 @@ describe('<BudgetDetailPage />', () => {
     });
     renderWithRouter(<BudgetDetailPageWrapper />);
 
-    // Overview empty state (no content assignments, no spent transactions)
-    screen.debug(undefined, 1000000);
-
     expect(screen.queryByText('No budget activity yet? Invite members to browse the catalog and enroll!')).toBeInTheDocument();
 
     expect(screen.getByText('Invite more members', { selector: 'a' })).toBeInTheDocument();

--- a/src/components/learner-credit-management/utils.js
+++ b/src/components/learner-credit-management/utils.js
@@ -1,3 +1,0 @@
-export default function isLmsBudget(activeIntegrationsLength, isUniversalGroup) {
-  return activeIntegrationsLength > 0 && isUniversalGroup;
-}

--- a/src/components/settings/SettingsAppearanceTab/index.jsx
+++ b/src/components/settings/SettingsAppearanceTab/index.jsx
@@ -100,9 +100,8 @@ export const SettingsAppearanceTab = ({
       <p>
         <FormattedMessage
           id="adminPortal.settings.portalAppearanceTab.description"
-          defaultMessage="Customize the appearance of your learner and administrator edX experiences with your organization{apostrophe}s logo and color themes."
+          defaultMessage="Customize the appearance of your learner and administrator edX experiences with your organization's logo and color themes."
           description="Description for the portal appearance section."
-          values={{ apostrophe: "'" }}
         />
       </p>
       <Alert
@@ -116,9 +115,8 @@ export const SettingsAppearanceTab = ({
         <Alert.Heading>
           <FormattedMessage
             id="adminPortal.settings.portalAppearanceTab.errorHeading"
-            defaultMessage="We{apostrophe}re sorry"
+            defaultMessage="We're sorry"
             description="Heading for error alert."
-            values={{ apostrophe: "'" }}
           />
         </Alert.Heading>
         <p>

--- a/src/components/subscriptions/expiration/SubscriptionExpirationBanner.jsx
+++ b/src/components/subscriptions/expiration/SubscriptionExpirationBanner.jsx
@@ -36,9 +36,9 @@ const SubscriptionExpirationBanner = ({ isSubscriptionPlanDetails }) => {
       <Alert.Heading>
         {intl.formatMessage({
           id: 'admin.portal.subscription.expiration.banner.plan.expired.heading',
-          defaultMessage: 'This subscription plan{apostrophe}s end date has passed',
+          defaultMessage: "This subscription plan's end date has passed",
           description: 'Heading for expired plan message in subscription expiration banner.',
-        }, { apostrophe: "'" })}
+        })}
       </Alert.Heading>
       {intl.formatMessage({
         id: 'admin.portal.subscription.expiration.banner.plan.expired.message',
@@ -51,9 +51,9 @@ const SubscriptionExpirationBanner = ({ isSubscriptionPlanDetails }) => {
       <Alert.Heading>
         {intl.formatMessage({
           id: 'admin.portal.subscription.expiration.banner.plan.approaching.heading',
-          defaultMessage: 'This subscription plan{apostrophe}s end date is approaching',
+          defaultMessage: "This subscription plan's end date is approaching",
           description: 'Heading for approaching plan message in subscription expiration banner.',
-        }, { apostrophe: "'" })}
+        })}
       </Alert.Heading>
       {intl.formatMessage(
         {

--- a/src/components/subscriptions/expiration/SubscriptionExpiringModal.jsx
+++ b/src/components/subscriptions/expiration/SubscriptionExpiringModal.jsx
@@ -58,12 +58,10 @@ const SubscriptionExpiringModal = ({
           {
             intl.formatMessage({
               id: 'admin.portal.subscription.expiration.modal.body.p1',
-              defaultMessage: `It{apostrophe}s time to renew your subscription contract with edX!
+              defaultMessage: `It's time to renew your subscription contract with edX!
             The edX customer support team is here to help.
             Get in touch today to minimize access disruptions for your learners.`,
               description: 'Body paragraph 1 for the subscription expiring modal in the admin portal.',
-            }, {
-              apostrophe: "'",
             })
           }
         </p>

--- a/src/utils.js
+++ b/src/utils.js
@@ -561,6 +561,21 @@ function isArchivedContent(content) {
   return courseRunStatuses.every(status => ARCHIVABLE_STATUSES.includes(status));
 }
 
+/**
+ * Helper function utilizing dayjs's 'isBetween' function to determine
+ * if the date passed is between today and an offset amount of days
+ *
+ * @param date
+ * @param days
+ * @returns {boolean}
+ */
+function isTodayWithinDateThreshold({ date, days }) {
+  const dateToCheck = dayjs(date);
+  const today = dayjs();
+  const offsetDays = dateToCheck.subtract(days, 'days');
+  return today.isBetween(offsetDays, dateToCheck);
+}
+
 export {
   camelCaseDict,
   camelCaseDictArray,
@@ -604,4 +619,5 @@ export {
   i18nFormatTimestamp,
   i18nFormatPassedTimestamp,
   i18nFormatProgressStatus,
+  isTodayWithinDateThreshold,
 };


### PR DESCRIPTION
Adds a net new column to the learner credit management budget detail page on the assignments table called "Enroll-by date".
The column component determines if the date should render a "Warning" icon if the enroll by date is within 10 days of expiration.


https://github.com/openedx/frontend-app-admin-portal/assets/82611798/3dc10c33-7e69-4bc2-a2f7-70b31a02da79



# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
