### PR TITLE
fix: zero state card and invite modal

### DIFF
--- a/src/components/learner-credit-management/BudgetDetailActivityTabContents.jsx
+++ b/src/components/learner-credit-management/BudgetDetailActivityTabContents.jsx
@@ -11,7 +11,7 @@ import { useBudgetDetailActivityOverview, useBudgetId, useSubsidyAccessPolicy } 
 import NoAssignableBudgetActivity from './empty-state/NoAssignableBudgetActivity';
 import NoBnEBudgetActivity from './empty-state/NoBnEBudgetActivity';
 
-const BudgetDetailActivityTabContents = ({ enterpriseUUID, enterpriseFeatures }) => {
+const BudgetDetailActivityTabContents = ({ enterpriseUUID, enterpriseFeatures, appliesToAllContexts }) => {
   const isTopDownAssignmentEnabled = enterpriseFeatures.topDownAssignmentRealTimeLcm;
   const { enterpriseOfferId, subsidyAccessPolicyId } = useBudgetId();
   const { data: subsidyAccessPolicy } = useSubsidyAccessPolicy(subsidyAccessPolicyId);
@@ -46,6 +46,12 @@ const BudgetDetailActivityTabContents = ({ enterpriseUUID, enterpriseFeatures })
 
   if (!isTopDownAssignmentEnabled || !subsidyAccessPolicy?.isAssignable) {
     if (isEnterpriseGroupsEnabled) {
+      if (appliesToAllContexts) {
+        return (
+          <BudgetDetailRedemptions />
+        );
+      }
+
       return (
         <>
           {renderBnEActivity
@@ -96,6 +102,7 @@ BudgetDetailActivityTabContents.propTypes = {
     topDownAssignmentRealTimeLcm: PropTypes.bool,
     enterpriseGroupsV1: PropTypes.bool,
   }).isRequired,
+  appliesToAllContexts: PropTypes.bool.isRequired,
 };
 
 export default connect(mapStateToProps)(BudgetDetailActivityTabContents);

--- a/src/components/learner-credit-management/data/hooks/useBudgetDetailTabs.jsx
+++ b/src/components/learner-credit-management/data/hooks/useBudgetDetailTabs.jsx
@@ -41,7 +41,7 @@ export const useBudgetDetailTabs = ({
         className={TAB_CLASS_NAME}
       >
         {activeTabKey === BUDGET_DETAIL_ACTIVITY_TAB && (
-          <ActivityTabElement />
+          <ActivityTabElement appliesToAllContexts={appliesToAllContexts} />
         )}
       </Tab>,
     );

--- a/src/components/learner-credit-management/invite-modal/InviteModalSummaryLearnerList.jsx
+++ b/src/components/learner-credit-management/invite-modal/InviteModalSummaryLearnerList.jsx
@@ -12,7 +12,7 @@ const InviteModalSummaryLearnerList = ({
   learnerEmails,
 }) => {
   const [isTruncated, setIsTruncated] = useState(hasLearnerEmailsSummaryListTruncation(learnerEmails));
-  const truncatedLearnerEmails = learnerEmails.slice(0, MAX_INITIAL_LEARNER_EMAILS_DISPLAYED_COUNT - 1);
+  const truncatedLearnerEmails = learnerEmails.slice(0, MAX_INITIAL_LEARNER_EMAILS_DISPLAYED_COUNT);
   const displayedLearnerEmails = isTruncated ? truncatedLearnerEmails : learnerEmails;
 
   useEffect(() => {

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -639,6 +639,11 @@ describe('<BudgetDetailPage />', () => {
         results: [],
       },
     });
+    useEnterpriseGroup.mockReturnValue({
+      data: {
+        appliesToAllContexts: false,
+      },
+    });
     useBudgetDetailActivityOverview.mockReturnValue({
       isLoading: false,
       data: mockEmptyStateBudgetDetailActivityOverview,
@@ -655,6 +660,58 @@ describe('<BudgetDetailPage />', () => {
     const illustrationTestIds = ['name-your-members-illustration', 'members-browse-illustration', 'enroll-and-spend-illustration'];
     illustrationTestIds.forEach(testId => expect(screen.getByTestId(testId)).toBeInTheDocument());
     expect(screen.getByText('Invite more members', { selector: 'a' })).toBeInTheDocument();
+  });
+
+  it('does not display bnr budget activity overview empty state and displays empty spent table', async () => {
+    useIsLargeOrGreater.mockReturnValue(true);
+    useParams.mockReturnValue({
+      enterpriseSlug: 'test-enterprise-slug',
+      enterpriseAppPage: 'test-enterprise-page',
+      budgetId: 'a52e6548-649f-4576-b73f-c5c2bee25e9c',
+      activeTabKey: 'activity',
+    });
+    useSubsidyAccessPolicy.mockReturnValue({
+      isInitialLoading: false,
+      data: mockPerLearnerSpendLimitSubsidyAccessPolicy,
+    });
+    useEnterpriseGroupLearners.mockReturnValue({
+      data: {
+        count: 0,
+        currentPage: 1,
+        next: null,
+        numPages: 1,
+        results: [],
+      },
+    });
+    useEnterpriseGroup.mockReturnValue({
+      data: {
+        appliesToAllContexts: true,
+      },
+    });
+    useBudgetDetailActivityOverview.mockReturnValue({
+      isLoading: false,
+      data: mockEmptyStateBudgetDetailActivityOverview,
+    });
+    useBudgetRedemptions.mockReturnValue({
+      isLoading: false,
+      budgetRedemptions: mockEmptyBudgetRedemptions,
+      fetchBudgetRedemptions: jest.fn(),
+    });
+    const storeState = {
+      ...initialStoreState,
+      portalConfiguration: {
+        ...initialStoreState.portalConfiguration,
+        enterpriseFeatures: {
+          ...initialStoreState.portalConfiguration.enterpriseFeatures,
+          topDownAssignmentRealTimeLcm: false,
+        },
+      },
+    };
+    renderWithRouter(<BudgetDetailPageWrapper initialState={storeState} />);
+
+    // Display spent table when there is no spent activity but appliesToAllContext is true
+    expect(screen.getByText('Search by enrollment details')).toBeInTheDocument();
+    expect(screen.queryByText('Invite more members', { selector: 'a' })).not.toBeInTheDocument();
   });
 
   it.each([

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -709,11 +709,14 @@ describe('<BudgetDetailPage />', () => {
       budgetRedemptions: mockEmptyBudgetRedemptions,
       fetchBudgetRedemptions: jest.fn(),
     });
+    useEnterpriseGroup.mockReturnValue({
+      data: {
+        appliesToAllContexts: false,
+      },
+    });
     renderWithRouter(<BudgetDetailPageWrapper />);
 
     // Overview empty state (no content assignments, no spent transactions)
-    screen.debug(undefined, 1000000);
-
     expect(screen.queryByText('No budget activity yet? Invite members to browse the catalog and enroll!')).toBeInTheDocument();
 
     expect(screen.getByText('Invite more members', { selector: 'a' })).toBeInTheDocument();


### PR DESCRIPTION
# Description
1. For groups that apply to all contexts, we will hide the zero state card with the "Get started" or "invite new members" button, we also shouldn't show this card to budgets that are expired.
2. For the invite modal email address overflow, set the limit to 15 instead of 14 email addresses. 
https://2u-internal.atlassian.net/browse/ENT-9022

# UI updates
|before|after|
|-------|----|
|![Screenshot 2024-06-05 at 1 36 44 PM](https://github.com/openedx/frontend-app-admin-portal/assets/71999631/e5a5280a-c22c-4403-b4e1-2207a9b60dce)|<img width="1469" alt="Screenshot 2024-05-29 at 10 20 10 AM" src="https://github.com/openedx/frontend-app-admin-portal/assets/71999631/32971b92-4781-4b32-848e-4dd462d63e31">|
|![Screenshot 2024-06-05 at 1 41 24 PM](https://github.com/openedx/frontend-app-admin-portal/assets/71999631/05727666-e92a-454c-8c01-c3f466c3e195)|![Screenshot 2024-06-05 at 1 40 12 PM](https://github.com/openedx/frontend-app-admin-portal/assets/71999631/9a856632-0f34-41ec-8385-62529c0f656c)|

# Test plan
Follow these steps to test/verify the changes to the invite modal:
 > 1. git fetch 
 > 2. git checkout knguyen2/ent-9022
 > 3. vist link https://localhost.stage.edx.org:1991/exec-ed-2u-integration-qa/admin/learner-credit/92fa52bc-6863-49ff-8a32-1cfefbfbb728
 > 4. click on button labeled New Members
 > 5. copy and paste the emails below into the email address box.
>     knguyen2+1@2u.com
>     knguyen2+2@2u.com
>     knguyen2+3@2u.com
>     knguyen2+4@2u.com
>     knguyen2+5@2u.com
>     knguyen2+6@2u.com
>     knguyen2+7@2u.com
>     knguyen2+8@2u.com
>     knguyen2+9@2u.com
>     knguyen2+10@2u.com
>     knguyen2+11@2u.com
>     knguyen2+12@2u.com
>     knguyen2+13@2u.com
>     knguyen2+14@2u.com
>     knguyen2+15@2u.com
>     knguyen2+16@2u.com
> 6. confirm in the summary tab that you are able to see the last email being knguyen2+15@2u.com and clicking Show more will display knguyen2+16@2u.com
> 7. repeat steps 4 - 5 on stage link https://portal.stage.edx.org/exec-ed-2u-integration-qa/admin/learner-credit/92fa52bc-6863-49ff-8a32-1cfefbfbb728 and confirm that only 14 emails are shown instead of 15 and clicking Show more renders 2 additional emails instead of 1. 

Follow the these steps to test/verify the changes to the Browse and Enroll zero state card for groups that apply to all contexts:
> 1. visit link with budget that is tied to a group that has apply to all contexts enabled: https://localhost.stage.edx.org:1991/pawnee-parks/admin/learner-credit/6acd1860-d0a5-4e35-a529-5b3dd589c1db 
> 2. confirm that the empty spent table is rendered in place of the zero state card as seen in the UI changes section.
> 3. to verify the changes between stage and dev, visit https://portal.stage.edx.org/pawnee-parks/admin/learner-credit/6acd1860-d0a5-4e35-a529-5b3dd589c1db and confirm that the zero state card is rendered instead of the empty spent table.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
