### PR TITLE
fix: filter out video content types

### DIFF
--- a/src/components/ContentHighlights/HighlightStepper/HighlightStepperSelectContentSearch.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/HighlightStepperSelectContentSearch.jsx
@@ -148,9 +148,11 @@ const HighlightStepperSelectContent = ({ enterpriseId }) => {
     ContentHighlightsContext,
     v => v[0].searchClient,
   );
-    // TODO: replace testEnterpriseId with enterpriseId before push,
-    // uncomment out import and replace with testEnterpriseId to test
-  const searchFilters = `enterprise_customer_uuids:${ENABLE_TESTING(enterpriseId)}`;
+  // TODO: replace testEnterpriseId with enterpriseId before push,
+  // uncomment out import and replace with testEnterpriseId to test
+  // FIXME: Remove 'AND (NOT content_type:video)' when video content metadata updated to
+  // to identical data-structure as similar algolia search objects, ex. COURSES
+  const searchFilters = `enterprise_customer_uuids:${ENABLE_TESTING(enterpriseId)} AND (NOT content_type:video)`;
 
   return (
     <SearchData>


### PR DESCRIPTION
Filters out `content_type` of video in content highlights. This is due to inconsistent data formats between `content_types` in Algolia.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
