### PR TITLE
ENT-8186: Added a new data table to show user module performance data.

### DIFF
--- a/src/components/Admin/__snapshots__/Admin.test.jsx.snap
+++ b/src/components/Admin/__snapshots__/Admin.test.jsx.snap
@@ -156,14 +156,691 @@ exports[`<Admin /> renders correctly calls fetchDashboardAnalytics prop 1`] = `
       </div>
     </div>
     <div
-      className="row"
+      className="tabs-container"
     >
       <div
-        className="col"
-      >
+        className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
+      />
+      <div>
+        <nav
+          className="pgn__tabs nav nav-tabs"
+          onKeyDown={[Function]}
+          role="tablist"
+        >
+          <a
+            className="pgn__tab_more nav-item nav-link"
+            data-rb-event-key={null}
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            <div
+              className="pgn__dropdown pgn__dropdown-light dropdown"
+              data-testid="dropdown"
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="nav-link dropdown-toggle btn btn-link"
+                disabled={false}
+                id="pgn__tab-toggle"
+                onClick={[Function]}
+                type="button"
+              >
+                More...
+              </button>
+            </div>
+          </a>
+          <a
+            aria-selected={true}
+            className="pgn__tab_invisible nav-item nav-link active"
+            data-rb-event-key="learner-progress-report"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Learner Progress Report
+          </a>
+          <a
+            aria-selected={false}
+            className="pgn__tab_invisible nav-item nav-link"
+            data-rb-event-key="module-activity"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Module Activity (Executive Education)
+          </a>
+        </nav>
         <div
-          className="mt-3 mb-5"
-        />
+          className="tab-content"
+        >
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          />
+          <div
+            aria-hidden={false}
+            aria-labelledby={null}
+            className="fade tab-pane active show"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="row"
+            >
+              <div
+                className="col"
+              >
+                <div
+                  className="mt-3 mb-5"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="mt-3"
+            >
+              <div
+                className="pgn__searchfield d-flex mt-2 mb-2 w-25 "
+                onSearch={[Function]}
+              >
+                <form
+                  className="pgn__searchfield-form"
+                  onReset={[Function]}
+                  onSubmit={[Function]}
+                  role="search"
+                >
+                  <label
+                    className="m-0"
+                    htmlFor="pgn-searchfield-input-1"
+                  >
+                    <span
+                      className="sr-only"
+                    >
+                      search
+                    </span>
+                  </label>
+                  <input
+                    className="form-control"
+                    disabled={false}
+                    id="pgn-searchfield-input-1"
+                    name="searchfield-input"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder="Search email or course title"
+                    role="searchbox"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    className="btn"
+                    disabled={false}
+                    type="submit"
+                  >
+                    <span
+                      className="pgn__icon"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        fill="none"
+                        focusable={false}
+                        height={24}
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width={24}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="sr-only"
+                    >
+                      submit search
+                    </span>
+                  </button>
+                </form>
+              </div>
+              <div
+                className="pgn__data-table-layout-wrapper"
+              >
+                <div
+                  className="pgn__data-table-layout-main"
+                >
+                  <div
+                    className="pgn__data-table-wrapper"
+                  >
+                    <div
+                      className="pgn__data-table-status-bar"
+                      data-testid="table-control-bar"
+                    >
+                      <div
+                        className="pgn__data-table-status"
+                      >
+                        <div
+                          className="pgn__data-table-status-left"
+                        />
+                        <div
+                          className="pgn__data-table-actions-right"
+                        >
+                          <div
+                            className="pgn__data-table-toggle"
+                          />
+                          <div>
+                            <div
+                              className="pgn__table-actions"
+                              data-testid="table-actions"
+                            >
+                              <div
+                                className="pgn__datatable__visible-actions"
+                              >
+                                <button
+                                  aria-disabled={true}
+                                  aria-live="assertive"
+                                  className="pgn__stateful-btn pgn__stateful-btn-state-pageLoading download-button disabled btn btn-primary"
+                                  data-testid="module-activity-download"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="d-flex align-items-center justify-content-center"
+                                  >
+                                    <span
+                                      className="pgn__stateful-btn-icon"
+                                    >
+                                      <span
+                                        className="pgn__icon"
+                                        variant="light"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          fill="none"
+                                          focusable={false}
+                                          height={24}
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                          width={24}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M19 9h-4V3H9v6H5l7 7 7-7ZM5 18v2h14v-2H5Z"
+                                            fill="currentColor"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span>
+                                      Download module activity
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="pgn__data-table-container is-loading"
+                      data-testid="data-table-container"
+                    >
+                      <div
+                        className="pgn__data-table-spinner"
+                        data-testid="data-table-spinner"
+                      >
+                        <div
+                          className="pgn__spinner spinner-border"
+                          role="status"
+                        >
+                          <span
+                            className="sr-only"
+                          >
+                            loading
+                          </span>
+                        </div>
+                      </div>
+                      <table
+                        className="pgn__data-table is-striped"
+                        role="table"
+                      >
+                        <thead>
+                          <tr
+                            role="row"
+                          >
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Email
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Course Title
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Module
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Grade
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  % Activities Complete
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Learning Hours
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Log Views
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody
+                          role="rowgroup"
+                        />
+                      </table>
+                    </div>
+                    <div
+                      className="pgn__data-table-footer"
+                      data-testid="table-footer"
+                    >
+                      <nav
+                        aria-label="table pagination"
+                        className="pagination-minimal"
+                      >
+                        <div
+                          aria-atomic={true}
+                          aria-live="polite"
+                          aria-relevant="text"
+                          className="sr-only"
+                        >
+                          Page 1, Current Page, of -1
+                        </div>
+                        <ul
+                          className="pagination"
+                        >
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Previous"
+                              className="btn-icon btn-icon-primary btn-icon-md previous page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M17.51 3.87 15.73 2.1 5.84 12l9.9 9.9 1.77-1.77L9.38 12l8.13-8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Next, Page 2"
+                              className="btn-icon btn-icon-primary btn-icon-md next page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m6.49 20.13 1.77 1.77 9.9-9.9-9.9-9.9-1.77 1.77L14.62 12l-8.13 8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                        </ul>
+                      </nav>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -813,106 +1490,355 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # cou
       </div>
     </div>
     <div
-      className="row"
+      className="tabs-container"
     >
       <div
-        className="col"
+        className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
       >
-        <div
-          className="row pb-3"
+        Showing data as of 
+        July 31, 2018
+      </div>
+      <div>
+        <nav
+          className="pgn__tabs nav nav-tabs"
+          onKeyDown={[Function]}
+          role="tablist"
         >
-          <div
-            className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
-          >
-            Showing data as of 
-            July 31, 2018
-          </div>
-          <div
-            className="col-12 col-md-6 col-xl-8"
-          >
-            <button
-              className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
-              disabled={true}
-              onClick={[Function]}
-              type="button"
-            >
-              <svg
-                className="mr-2"
-                fill="none"
-                height={24}
-                viewBox="0 0 24 24"
-                width={24}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
-                  fill="currentColor"
-                />
-              </svg>
-              Download full report (CSV)
-            </button>
-          </div>
-        </div>
-        <div
-          className="row"
-        >
-          <div
-            className="col-12 pr-md-0 mb-0"
+          <a
+            className="pgn__tab_more nav-item nav-link"
+            data-rb-event-key={null}
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
           >
             <div
-              className="row w-100 m-0"
+              className="pgn__dropdown pgn__dropdown-light dropdown"
+              data-testid="dropdown"
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="nav-link dropdown-toggle btn btn-link"
+                disabled={false}
+                id="pgn__tab-toggle"
+                onClick={[Function]}
+                type="button"
+              >
+                More...
+              </button>
+            </div>
+          </a>
+          <a
+            aria-selected={true}
+            className="pgn__tab_invisible nav-item nav-link active"
+            data-rb-event-key="learner-progress-report"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Learner Progress Report
+          </a>
+          <a
+            aria-selected={false}
+            className="pgn__tab_invisible nav-item nav-link"
+            data-rb-event-key="module-activity"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Module Activity (Executive Education)
+          </a>
+        </nav>
+        <div
+          className="tab-content"
+        >
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          />
+          <div
+            aria-hidden={false}
+            aria-labelledby={null}
+            className="fade tab-pane active show"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="row"
             >
               <div
-                className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                className="col"
               >
                 <div
-                  className="pgn__form-group"
+                  className="row pb-3"
                 >
-                  <label
-                    className="pgn__form-label search-label mb-2"
-                    htmlFor="form-field11"
-                  >
-                    Filter by course
-                  </label>
                   <div
-                    className="pgn__form-control-decorator-group w-100"
+                    className="col-12 col-md-6 col-xl-8"
                   >
-                    <select
-                      className="form-control"
-                      id="form-field11"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <button
+                      className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
+                      disabled={true}
+                      onClick={[Function]}
+                      type="button"
                     >
-                      <option
-                        value=""
+                      <svg
+                        className="mr-2"
+                        fill="none"
+                        height={24}
+                        viewBox="0 0 24 24"
+                        width={24}
+                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        All Courses
-                      </option>
-                    </select>
+                        <path
+                          d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                      Download full report (CSV)
+                    </button>
                   </div>
                 </div>
-              </div>
-              <div
-                className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
-              >
                 <div
-                  className="pgn__form-group"
+                  className="row"
+                >
+                  <div
+                    className="col-12 pr-md-0 mb-0"
+                  >
+                    <div
+                      className="row w-100 m-0"
+                    >
+                      <div
+                        className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2"
+                            htmlFor="form-field17"
+                          >
+                            Filter by course
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              id="form-field17"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                All Courses
+                              </option>
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2 d-flex align-items-center"
+                            htmlFor="form-field18"
+                          >
+                            <span>
+                              Filter by start date
+                            </span>
+                            <span
+                              alt="More information"
+                              className="pgn__icon ml-1"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="none"
+                                focusable={false}
+                                height={24}
+                                role="img"
+                                viewBox="0 0 24 24"
+                                width={24}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                                  fill="currentColor"
+                                />
+                              </svg>
+                            </span>
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              disabled={true}
+                              id="form-field18"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                Choose a course
+                              </option>
+                              
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                      >
+                        <label
+                          className="pgn__form-label mb-2"
+                          id="search-email-label"
+                        >
+                          Filter by email
+                        </label>
+                        <div
+                          aria-labelledby="search-email-label"
+                          className="pgn__searchfield d-flex py-0"
+                          onSearch={[Function]}
+                        >
+                          <form
+                            className="pgn__searchfield-form"
+                            onReset={[Function]}
+                            onSubmit={[Function]}
+                            role="search"
+                          >
+                            <label
+                              className="m-0"
+                              htmlFor="pgn-searchfield-input-19"
+                            >
+                              <span
+                                className="sr-only"
+                              >
+                                search
+                              </span>
+                            </label>
+                            <input
+                              className="form-control"
+                              data-hj-suppress={true}
+                              disabled={false}
+                              id="pgn-searchfield-input-19"
+                              name="searchfield-input"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder="Search by email..."
+                              role="searchbox"
+                              type="text"
+                              value=""
+                            />
+                            <button
+                              className="btn"
+                              disabled={false}
+                              type="submit"
+                            >
+                              <span
+                                className="pgn__icon"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  fill="none"
+                                  focusable={false}
+                                  height={24}
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  width={24}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                              </span>
+                              <span
+                                className="sr-only"
+                              >
+                                submit search
+                              </span>
+                            </button>
+                          </form>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="mt-3 mb-5"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="mt-3"
+            >
+              <div
+                className="pgn__searchfield d-flex mt-2 mb-2 w-25 "
+                onSearch={[Function]}
+              >
+                <form
+                  className="pgn__searchfield-form"
+                  onReset={[Function]}
+                  onSubmit={[Function]}
+                  role="search"
                 >
                   <label
-                    className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                    htmlFor="form-field12"
+                    className="m-0"
+                    htmlFor="pgn-searchfield-input-20"
                   >
-                    <span>
-                      Filter by start date
-                    </span>
                     <span
-                      alt="More information"
-                      className="pgn__icon ml-1"
-                      onBlur={[Function]}
-                      onFocus={[Function]}
-                      onMouseOut={[Function]}
-                      onMouseOver={[Function]}
+                      className="sr-only"
+                    >
+                      search
+                    </span>
+                  </label>
+                  <input
+                    className="form-control"
+                    disabled={false}
+                    id="pgn-searchfield-input-20"
+                    name="searchfield-input"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder="Search email or course title"
+                    role="searchbox"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    className="btn"
+                    disabled={false}
+                    type="submit"
+                  >
+                    <span
+                      className="pgn__icon"
                     >
                       <svg
                         aria-hidden={true}
@@ -925,116 +1851,541 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # cou
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                          d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
                           fill="currentColor"
                         />
                       </svg>
                     </span>
-                  </label>
-                  <div
-                    className="pgn__form-control-decorator-group w-100"
-                  >
-                    <select
-                      className="form-control"
-                      disabled={true}
-                      id="form-field12"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <span
+                      className="sr-only"
                     >
-                      <option
-                        value=""
-                      >
-                        Choose a course
-                      </option>
-                      
-                    </select>
-                  </div>
-                </div>
+                      submit search
+                    </span>
+                  </button>
+                </form>
               </div>
               <div
-                className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                className="pgn__data-table-layout-wrapper"
               >
-                <label
-                  className="pgn__form-label mb-2"
-                  id="search-email-label"
-                >
-                  Filter by email
-                </label>
                 <div
-                  aria-labelledby="search-email-label"
-                  className="pgn__searchfield d-flex py-0"
-                  onSearch={[Function]}
+                  className="pgn__data-table-layout-main"
                 >
-                  <form
-                    className="pgn__searchfield-form"
-                    onReset={[Function]}
-                    onSubmit={[Function]}
-                    role="search"
+                  <div
+                    className="pgn__data-table-wrapper"
                   >
-                    <label
-                      className="m-0"
-                      htmlFor="pgn-searchfield-input-13"
+                    <div
+                      className="pgn__data-table-status-bar"
+                      data-testid="table-control-bar"
                     >
-                      <span
-                        className="sr-only"
+                      <div
+                        className="pgn__data-table-status"
                       >
-                        search
-                      </span>
-                    </label>
-                    <input
-                      className="form-control"
-                      data-hj-suppress={true}
-                      disabled={false}
-                      id="pgn-searchfield-input-13"
-                      name="searchfield-input"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Search by email..."
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      className="btn"
-                      disabled={false}
-                      type="submit"
-                    >
-                      <span
-                        className="pgn__icon"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="none"
-                          focusable={false}
-                          height={24}
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width={24}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          className="pgn__data-table-status-left"
+                        />
+                        <div
+                          className="pgn__data-table-actions-right"
                         >
-                          <path
-                            d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
-                            fill="currentColor"
+                          <div
+                            className="pgn__data-table-toggle"
                           />
-                        </svg>
-                      </span>
-                      <span
-                        className="sr-only"
+                          <div>
+                            <div
+                              className="pgn__table-actions"
+                              data-testid="table-actions"
+                            >
+                              <div
+                                className="pgn__datatable__visible-actions"
+                              >
+                                <button
+                                  aria-disabled={true}
+                                  aria-live="assertive"
+                                  className="pgn__stateful-btn pgn__stateful-btn-state-pageLoading download-button disabled btn btn-primary"
+                                  data-testid="module-activity-download"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="d-flex align-items-center justify-content-center"
+                                  >
+                                    <span
+                                      className="pgn__stateful-btn-icon"
+                                    >
+                                      <span
+                                        className="pgn__icon"
+                                        variant="light"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          fill="none"
+                                          focusable={false}
+                                          height={24}
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                          width={24}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M19 9h-4V3H9v6H5l7 7 7-7ZM5 18v2h14v-2H5Z"
+                                            fill="currentColor"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span>
+                                      Download module activity
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="pgn__data-table-container is-loading"
+                      data-testid="data-table-container"
+                    >
+                      <div
+                        className="pgn__data-table-spinner"
+                        data-testid="data-table-spinner"
                       >
-                        submit search
-                      </span>
-                    </button>
-                  </form>
+                        <div
+                          className="pgn__spinner spinner-border"
+                          role="status"
+                        >
+                          <span
+                            className="sr-only"
+                          >
+                            loading
+                          </span>
+                        </div>
+                      </div>
+                      <table
+                        className="pgn__data-table is-striped"
+                        role="table"
+                      >
+                        <thead>
+                          <tr
+                            role="row"
+                          >
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Email
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Course Title
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Module
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Grade
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  % Activities Complete
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Learning Hours
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Log Views
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody
+                          role="rowgroup"
+                        />
+                      </table>
+                    </div>
+                    <div
+                      className="pgn__data-table-footer"
+                      data-testid="table-footer"
+                    >
+                      <nav
+                        aria-label="table pagination"
+                        className="pagination-minimal"
+                      >
+                        <div
+                          aria-atomic={true}
+                          aria-live="polite"
+                          aria-relevant="text"
+                          className="sr-only"
+                        >
+                          Page 1, Current Page, of -1
+                        </div>
+                        <ul
+                          className="pagination"
+                        >
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Previous"
+                              className="btn-icon btn-icon-primary btn-icon-md previous page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M17.51 3.87 15.73 2.1 5.84 12l9.9 9.9 1.77-1.77L9.38 12l8.13-8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Next, Page 2"
+                              className="btn-icon btn-icon-primary btn-icon-md next page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m6.49 20.13 1.77 1.77 9.9-9.9-9.9-9.9-1.77 1.77L14.62 12l-8.13 8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                        </ul>
+                      </nav>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-        <div
-          className="mt-3 mb-5"
-        />
       </div>
     </div>
   </div>
@@ -1684,106 +3035,355 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
       </div>
     </div>
     <div
-      className="row"
+      className="tabs-container"
     >
       <div
-        className="col"
+        className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
       >
-        <div
-          className="row pb-3"
+        Showing data as of 
+        July 31, 2018
+      </div>
+      <div>
+        <nav
+          className="pgn__tabs nav nav-tabs"
+          onKeyDown={[Function]}
+          role="tablist"
         >
-          <div
-            className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
-          >
-            Showing data as of 
-            July 31, 2018
-          </div>
-          <div
-            className="col-12 col-md-6 col-xl-8"
-          >
-            <button
-              className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
-              disabled={true}
-              onClick={[Function]}
-              type="button"
-            >
-              <svg
-                className="mr-2"
-                fill="none"
-                height={24}
-                viewBox="0 0 24 24"
-                width={24}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
-                  fill="currentColor"
-                />
-              </svg>
-              Download full report (CSV)
-            </button>
-          </div>
-        </div>
-        <div
-          className="row"
-        >
-          <div
-            className="col-12 pr-md-0 mb-0"
+          <a
+            className="pgn__tab_more nav-item nav-link"
+            data-rb-event-key={null}
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
           >
             <div
-              className="row w-100 m-0"
+              className="pgn__dropdown pgn__dropdown-light dropdown"
+              data-testid="dropdown"
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="nav-link dropdown-toggle btn btn-link"
+                disabled={false}
+                id="pgn__tab-toggle"
+                onClick={[Function]}
+                type="button"
+              >
+                More...
+              </button>
+            </div>
+          </a>
+          <a
+            aria-selected={true}
+            className="pgn__tab_invisible nav-item nav-link active"
+            data-rb-event-key="learner-progress-report"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Learner Progress Report
+          </a>
+          <a
+            aria-selected={false}
+            className="pgn__tab_invisible nav-item nav-link"
+            data-rb-event-key="module-activity"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Module Activity (Executive Education)
+          </a>
+        </nav>
+        <div
+          className="tab-content"
+        >
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          />
+          <div
+            aria-hidden={false}
+            aria-labelledby={null}
+            className="fade tab-pane active show"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="row"
             >
               <div
-                className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                className="col"
               >
                 <div
-                  className="pgn__form-group"
+                  className="row pb-3"
                 >
-                  <label
-                    className="pgn__form-label search-label mb-2"
-                    htmlFor="form-field36"
-                  >
-                    Filter by course
-                  </label>
                   <div
-                    className="pgn__form-control-decorator-group w-100"
+                    className="col-12 col-md-6 col-xl-8"
                   >
-                    <select
-                      className="form-control"
-                      id="form-field36"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <button
+                      className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
+                      disabled={true}
+                      onClick={[Function]}
+                      type="button"
                     >
-                      <option
-                        value=""
+                      <svg
+                        className="mr-2"
+                        fill="none"
+                        height={24}
+                        viewBox="0 0 24 24"
+                        width={24}
+                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        All Courses
-                      </option>
-                    </select>
+                        <path
+                          d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                      Download full report (CSV)
+                    </button>
                   </div>
                 </div>
-              </div>
-              <div
-                className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
-              >
                 <div
-                  className="pgn__form-group"
+                  className="row"
+                >
+                  <div
+                    className="col-12 pr-md-0 mb-0"
+                  >
+                    <div
+                      className="row w-100 m-0"
+                    >
+                      <div
+                        className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2"
+                            htmlFor="form-field52"
+                          >
+                            Filter by course
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              id="form-field52"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                All Courses
+                              </option>
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2 d-flex align-items-center"
+                            htmlFor="form-field53"
+                          >
+                            <span>
+                              Filter by start date
+                            </span>
+                            <span
+                              alt="More information"
+                              className="pgn__icon ml-1"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="none"
+                                focusable={false}
+                                height={24}
+                                role="img"
+                                viewBox="0 0 24 24"
+                                width={24}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                                  fill="currentColor"
+                                />
+                              </svg>
+                            </span>
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              disabled={true}
+                              id="form-field53"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                Choose a course
+                              </option>
+                              
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                      >
+                        <label
+                          className="pgn__form-label mb-2"
+                          id="search-email-label"
+                        >
+                          Filter by email
+                        </label>
+                        <div
+                          aria-labelledby="search-email-label"
+                          className="pgn__searchfield d-flex py-0"
+                          onSearch={[Function]}
+                        >
+                          <form
+                            className="pgn__searchfield-form"
+                            onReset={[Function]}
+                            onSubmit={[Function]}
+                            role="search"
+                          >
+                            <label
+                              className="m-0"
+                              htmlFor="pgn-searchfield-input-54"
+                            >
+                              <span
+                                className="sr-only"
+                              >
+                                search
+                              </span>
+                            </label>
+                            <input
+                              className="form-control"
+                              data-hj-suppress={true}
+                              disabled={false}
+                              id="pgn-searchfield-input-54"
+                              name="searchfield-input"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder="Search by email..."
+                              role="searchbox"
+                              type="text"
+                              value=""
+                            />
+                            <button
+                              className="btn"
+                              disabled={false}
+                              type="submit"
+                            >
+                              <span
+                                className="pgn__icon"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  fill="none"
+                                  focusable={false}
+                                  height={24}
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  width={24}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                              </span>
+                              <span
+                                className="sr-only"
+                              >
+                                submit search
+                              </span>
+                            </button>
+                          </form>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="mt-3 mb-5"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="mt-3"
+            >
+              <div
+                className="pgn__searchfield d-flex mt-2 mb-2 w-25 "
+                onSearch={[Function]}
+              >
+                <form
+                  className="pgn__searchfield-form"
+                  onReset={[Function]}
+                  onSubmit={[Function]}
+                  role="search"
                 >
                   <label
-                    className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                    htmlFor="form-field37"
+                    className="m-0"
+                    htmlFor="pgn-searchfield-input-55"
                   >
-                    <span>
-                      Filter by start date
-                    </span>
                     <span
-                      alt="More information"
-                      className="pgn__icon ml-1"
-                      onBlur={[Function]}
-                      onFocus={[Function]}
-                      onMouseOut={[Function]}
-                      onMouseOver={[Function]}
+                      className="sr-only"
+                    >
+                      search
+                    </span>
+                  </label>
+                  <input
+                    className="form-control"
+                    disabled={false}
+                    id="pgn-searchfield-input-55"
+                    name="searchfield-input"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder="Search email or course title"
+                    role="searchbox"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    className="btn"
+                    disabled={false}
+                    type="submit"
+                  >
+                    <span
+                      className="pgn__icon"
                     >
                       <svg
                         aria-hidden={true}
@@ -1796,116 +3396,541 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                          d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
                           fill="currentColor"
                         />
                       </svg>
                     </span>
-                  </label>
-                  <div
-                    className="pgn__form-control-decorator-group w-100"
-                  >
-                    <select
-                      className="form-control"
-                      disabled={true}
-                      id="form-field37"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <span
+                      className="sr-only"
                     >
-                      <option
-                        value=""
-                      >
-                        Choose a course
-                      </option>
-                      
-                    </select>
-                  </div>
-                </div>
+                      submit search
+                    </span>
+                  </button>
+                </form>
               </div>
               <div
-                className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                className="pgn__data-table-layout-wrapper"
               >
-                <label
-                  className="pgn__form-label mb-2"
-                  id="search-email-label"
-                >
-                  Filter by email
-                </label>
                 <div
-                  aria-labelledby="search-email-label"
-                  className="pgn__searchfield d-flex py-0"
-                  onSearch={[Function]}
+                  className="pgn__data-table-layout-main"
                 >
-                  <form
-                    className="pgn__searchfield-form"
-                    onReset={[Function]}
-                    onSubmit={[Function]}
-                    role="search"
+                  <div
+                    className="pgn__data-table-wrapper"
                   >
-                    <label
-                      className="m-0"
-                      htmlFor="pgn-searchfield-input-38"
+                    <div
+                      className="pgn__data-table-status-bar"
+                      data-testid="table-control-bar"
                     >
-                      <span
-                        className="sr-only"
+                      <div
+                        className="pgn__data-table-status"
                       >
-                        search
-                      </span>
-                    </label>
-                    <input
-                      className="form-control"
-                      data-hj-suppress={true}
-                      disabled={false}
-                      id="pgn-searchfield-input-38"
-                      name="searchfield-input"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Search by email..."
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      className="btn"
-                      disabled={false}
-                      type="submit"
-                    >
-                      <span
-                        className="pgn__icon"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="none"
-                          focusable={false}
-                          height={24}
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width={24}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          className="pgn__data-table-status-left"
+                        />
+                        <div
+                          className="pgn__data-table-actions-right"
                         >
-                          <path
-                            d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
-                            fill="currentColor"
+                          <div
+                            className="pgn__data-table-toggle"
                           />
-                        </svg>
-                      </span>
-                      <span
-                        className="sr-only"
+                          <div>
+                            <div
+                              className="pgn__table-actions"
+                              data-testid="table-actions"
+                            >
+                              <div
+                                className="pgn__datatable__visible-actions"
+                              >
+                                <button
+                                  aria-disabled={true}
+                                  aria-live="assertive"
+                                  className="pgn__stateful-btn pgn__stateful-btn-state-pageLoading download-button disabled btn btn-primary"
+                                  data-testid="module-activity-download"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="d-flex align-items-center justify-content-center"
+                                  >
+                                    <span
+                                      className="pgn__stateful-btn-icon"
+                                    >
+                                      <span
+                                        className="pgn__icon"
+                                        variant="light"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          fill="none"
+                                          focusable={false}
+                                          height={24}
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                          width={24}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M19 9h-4V3H9v6H5l7 7 7-7ZM5 18v2h14v-2H5Z"
+                                            fill="currentColor"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span>
+                                      Download module activity
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="pgn__data-table-container is-loading"
+                      data-testid="data-table-container"
+                    >
+                      <div
+                        className="pgn__data-table-spinner"
+                        data-testid="data-table-spinner"
                       >
-                        submit search
-                      </span>
-                    </button>
-                  </form>
+                        <div
+                          className="pgn__spinner spinner-border"
+                          role="status"
+                        >
+                          <span
+                            className="sr-only"
+                          >
+                            loading
+                          </span>
+                        </div>
+                      </div>
+                      <table
+                        className="pgn__data-table is-striped"
+                        role="table"
+                      >
+                        <thead>
+                          <tr
+                            role="row"
+                          >
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Email
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Course Title
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Module
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Grade
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  % Activities Complete
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Learning Hours
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Log Views
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody
+                          role="rowgroup"
+                        />
+                      </table>
+                    </div>
+                    <div
+                      className="pgn__data-table-footer"
+                      data-testid="table-footer"
+                    >
+                      <nav
+                        aria-label="table pagination"
+                        className="pagination-minimal"
+                      >
+                        <div
+                          aria-atomic={true}
+                          aria-live="polite"
+                          aria-relevant="text"
+                          className="sr-only"
+                        >
+                          Page 1, Current Page, of -1
+                        </div>
+                        <ul
+                          className="pagination"
+                        >
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Previous"
+                              className="btn-icon btn-icon-primary btn-icon-md previous page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M17.51 3.87 15.73 2.1 5.84 12l9.9 9.9 1.77-1.77L9.38 12l8.13-8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Next, Page 2"
+                              className="btn-icon btn-icon-primary btn-icon-md next page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m6.49 20.13 1.77 1.77 9.9-9.9-9.9-9.9-1.77 1.77L14.62 12l-8.13 8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                        </ul>
+                      </nav>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-        <div
-          className="mt-3 mb-5"
-        />
       </div>
     </div>
   </div>
@@ -2555,106 +4580,355 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
       </div>
     </div>
     <div
-      className="row"
+      className="tabs-container"
     >
       <div
-        className="col"
+        className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
       >
-        <div
-          className="row pb-3"
+        Showing data as of 
+        July 31, 2018
+      </div>
+      <div>
+        <nav
+          className="pgn__tabs nav nav-tabs"
+          onKeyDown={[Function]}
+          role="tablist"
         >
-          <div
-            className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
-          >
-            Showing data as of 
-            July 31, 2018
-          </div>
-          <div
-            className="col-12 col-md-6 col-xl-8"
-          >
-            <button
-              className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
-              disabled={true}
-              onClick={[Function]}
-              type="button"
-            >
-              <svg
-                className="mr-2"
-                fill="none"
-                height={24}
-                viewBox="0 0 24 24"
-                width={24}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
-                  fill="currentColor"
-                />
-              </svg>
-              Download full report (CSV)
-            </button>
-          </div>
-        </div>
-        <div
-          className="row"
-        >
-          <div
-            className="col-12 pr-md-0 mb-0"
+          <a
+            className="pgn__tab_more nav-item nav-link"
+            data-rb-event-key={null}
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
           >
             <div
-              className="row w-100 m-0"
+              className="pgn__dropdown pgn__dropdown-light dropdown"
+              data-testid="dropdown"
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="nav-link dropdown-toggle btn btn-link"
+                disabled={false}
+                id="pgn__tab-toggle"
+                onClick={[Function]}
+                type="button"
+              >
+                More...
+              </button>
+            </div>
+          </a>
+          <a
+            aria-selected={true}
+            className="pgn__tab_invisible nav-item nav-link active"
+            data-rb-event-key="learner-progress-report"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Learner Progress Report
+          </a>
+          <a
+            aria-selected={false}
+            className="pgn__tab_invisible nav-item nav-link"
+            data-rb-event-key="module-activity"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Module Activity (Executive Education)
+          </a>
+        </nav>
+        <div
+          className="tab-content"
+        >
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          />
+          <div
+            aria-hidden={false}
+            aria-labelledby={null}
+            className="fade tab-pane active show"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="row"
             >
               <div
-                className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                className="col"
               >
                 <div
-                  className="pgn__form-group"
+                  className="row pb-3"
                 >
-                  <label
-                    className="pgn__form-label search-label mb-2"
-                    htmlFor="form-field41"
-                  >
-                    Filter by course
-                  </label>
                   <div
-                    className="pgn__form-control-decorator-group w-100"
+                    className="col-12 col-md-6 col-xl-8"
                   >
-                    <select
-                      className="form-control"
-                      id="form-field41"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <button
+                      className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
+                      disabled={true}
+                      onClick={[Function]}
+                      type="button"
                     >
-                      <option
-                        value=""
+                      <svg
+                        className="mr-2"
+                        fill="none"
+                        height={24}
+                        viewBox="0 0 24 24"
+                        width={24}
+                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        All Courses
-                      </option>
-                    </select>
+                        <path
+                          d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                      Download full report (CSV)
+                    </button>
                   </div>
                 </div>
-              </div>
-              <div
-                className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
-              >
                 <div
-                  className="pgn__form-group"
+                  className="row"
+                >
+                  <div
+                    className="col-12 pr-md-0 mb-0"
+                  >
+                    <div
+                      className="row w-100 m-0"
+                    >
+                      <div
+                        className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2"
+                            htmlFor="form-field59"
+                          >
+                            Filter by course
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              id="form-field59"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                All Courses
+                              </option>
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2 d-flex align-items-center"
+                            htmlFor="form-field60"
+                          >
+                            <span>
+                              Filter by start date
+                            </span>
+                            <span
+                              alt="More information"
+                              className="pgn__icon ml-1"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="none"
+                                focusable={false}
+                                height={24}
+                                role="img"
+                                viewBox="0 0 24 24"
+                                width={24}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                                  fill="currentColor"
+                                />
+                              </svg>
+                            </span>
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              disabled={true}
+                              id="form-field60"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                Choose a course
+                              </option>
+                              
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                      >
+                        <label
+                          className="pgn__form-label mb-2"
+                          id="search-email-label"
+                        >
+                          Filter by email
+                        </label>
+                        <div
+                          aria-labelledby="search-email-label"
+                          className="pgn__searchfield d-flex py-0"
+                          onSearch={[Function]}
+                        >
+                          <form
+                            className="pgn__searchfield-form"
+                            onReset={[Function]}
+                            onSubmit={[Function]}
+                            role="search"
+                          >
+                            <label
+                              className="m-0"
+                              htmlFor="pgn-searchfield-input-61"
+                            >
+                              <span
+                                className="sr-only"
+                              >
+                                search
+                              </span>
+                            </label>
+                            <input
+                              className="form-control"
+                              data-hj-suppress={true}
+                              disabled={false}
+                              id="pgn-searchfield-input-61"
+                              name="searchfield-input"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder="Search by email..."
+                              role="searchbox"
+                              type="text"
+                              value=""
+                            />
+                            <button
+                              className="btn"
+                              disabled={false}
+                              type="submit"
+                            >
+                              <span
+                                className="pgn__icon"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  fill="none"
+                                  focusable={false}
+                                  height={24}
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  width={24}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                              </span>
+                              <span
+                                className="sr-only"
+                              >
+                                submit search
+                              </span>
+                            </button>
+                          </form>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="mt-3 mb-5"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="mt-3"
+            >
+              <div
+                className="pgn__searchfield d-flex mt-2 mb-2 w-25 "
+                onSearch={[Function]}
+              >
+                <form
+                  className="pgn__searchfield-form"
+                  onReset={[Function]}
+                  onSubmit={[Function]}
+                  role="search"
                 >
                   <label
-                    className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                    htmlFor="form-field42"
+                    className="m-0"
+                    htmlFor="pgn-searchfield-input-62"
                   >
-                    <span>
-                      Filter by start date
-                    </span>
                     <span
-                      alt="More information"
-                      className="pgn__icon ml-1"
-                      onBlur={[Function]}
-                      onFocus={[Function]}
-                      onMouseOut={[Function]}
-                      onMouseOver={[Function]}
+                      className="sr-only"
+                    >
+                      search
+                    </span>
+                  </label>
+                  <input
+                    className="form-control"
+                    disabled={false}
+                    id="pgn-searchfield-input-62"
+                    name="searchfield-input"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder="Search email or course title"
+                    role="searchbox"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    className="btn"
+                    disabled={false}
+                    type="submit"
+                  >
+                    <span
+                      className="pgn__icon"
                     >
                       <svg
                         aria-hidden={true}
@@ -2667,116 +4941,541 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                          d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
                           fill="currentColor"
                         />
                       </svg>
                     </span>
-                  </label>
-                  <div
-                    className="pgn__form-control-decorator-group w-100"
-                  >
-                    <select
-                      className="form-control"
-                      disabled={true}
-                      id="form-field42"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <span
+                      className="sr-only"
                     >
-                      <option
-                        value=""
-                      >
-                        Choose a course
-                      </option>
-                      
-                    </select>
-                  </div>
-                </div>
+                      submit search
+                    </span>
+                  </button>
+                </form>
               </div>
               <div
-                className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                className="pgn__data-table-layout-wrapper"
               >
-                <label
-                  className="pgn__form-label mb-2"
-                  id="search-email-label"
-                >
-                  Filter by email
-                </label>
                 <div
-                  aria-labelledby="search-email-label"
-                  className="pgn__searchfield d-flex py-0"
-                  onSearch={[Function]}
+                  className="pgn__data-table-layout-main"
                 >
-                  <form
-                    className="pgn__searchfield-form"
-                    onReset={[Function]}
-                    onSubmit={[Function]}
-                    role="search"
+                  <div
+                    className="pgn__data-table-wrapper"
                   >
-                    <label
-                      className="m-0"
-                      htmlFor="pgn-searchfield-input-43"
+                    <div
+                      className="pgn__data-table-status-bar"
+                      data-testid="table-control-bar"
                     >
-                      <span
-                        className="sr-only"
+                      <div
+                        className="pgn__data-table-status"
                       >
-                        search
-                      </span>
-                    </label>
-                    <input
-                      className="form-control"
-                      data-hj-suppress={true}
-                      disabled={false}
-                      id="pgn-searchfield-input-43"
-                      name="searchfield-input"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Search by email..."
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      className="btn"
-                      disabled={false}
-                      type="submit"
-                    >
-                      <span
-                        className="pgn__icon"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="none"
-                          focusable={false}
-                          height={24}
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width={24}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          className="pgn__data-table-status-left"
+                        />
+                        <div
+                          className="pgn__data-table-actions-right"
                         >
-                          <path
-                            d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
-                            fill="currentColor"
+                          <div
+                            className="pgn__data-table-toggle"
                           />
-                        </svg>
-                      </span>
-                      <span
-                        className="sr-only"
+                          <div>
+                            <div
+                              className="pgn__table-actions"
+                              data-testid="table-actions"
+                            >
+                              <div
+                                className="pgn__datatable__visible-actions"
+                              >
+                                <button
+                                  aria-disabled={true}
+                                  aria-live="assertive"
+                                  className="pgn__stateful-btn pgn__stateful-btn-state-pageLoading download-button disabled btn btn-primary"
+                                  data-testid="module-activity-download"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="d-flex align-items-center justify-content-center"
+                                  >
+                                    <span
+                                      className="pgn__stateful-btn-icon"
+                                    >
+                                      <span
+                                        className="pgn__icon"
+                                        variant="light"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          fill="none"
+                                          focusable={false}
+                                          height={24}
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                          width={24}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M19 9h-4V3H9v6H5l7 7 7-7ZM5 18v2h14v-2H5Z"
+                                            fill="currentColor"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span>
+                                      Download module activity
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="pgn__data-table-container is-loading"
+                      data-testid="data-table-container"
+                    >
+                      <div
+                        className="pgn__data-table-spinner"
+                        data-testid="data-table-spinner"
                       >
-                        submit search
-                      </span>
-                    </button>
-                  </form>
+                        <div
+                          className="pgn__spinner spinner-border"
+                          role="status"
+                        >
+                          <span
+                            className="sr-only"
+                          >
+                            loading
+                          </span>
+                        </div>
+                      </div>
+                      <table
+                        className="pgn__data-table is-striped"
+                        role="table"
+                      >
+                        <thead>
+                          <tr
+                            role="row"
+                          >
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Email
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Course Title
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Module
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Grade
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  % Activities Complete
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Learning Hours
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Log Views
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody
+                          role="rowgroup"
+                        />
+                      </table>
+                    </div>
+                    <div
+                      className="pgn__data-table-footer"
+                      data-testid="table-footer"
+                    >
+                      <nav
+                        aria-label="table pagination"
+                        className="pagination-minimal"
+                      >
+                        <div
+                          aria-atomic={true}
+                          aria-live="polite"
+                          aria-relevant="text"
+                          className="sr-only"
+                        >
+                          Page 1, Current Page, of -1
+                        </div>
+                        <ul
+                          className="pagination"
+                        >
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Previous"
+                              className="btn-icon btn-icon-primary btn-icon-md previous page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M17.51 3.87 15.73 2.1 5.84 12l9.9 9.9 1.77-1.77L9.38 12l8.13-8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Next, Page 2"
+                              className="btn-icon btn-icon-primary btn-icon-md next page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m6.49 20.13 1.77 1.77 9.9-9.9-9.9-9.9-1.77 1.77L14.62 12l-8.13 8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                        </ul>
+                      </nav>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-        <div
-          className="mt-3 mb-5"
-        />
       </div>
     </div>
   </div>
@@ -3426,106 +6125,355 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
       </div>
     </div>
     <div
-      className="row"
+      className="tabs-container"
     >
       <div
-        className="col"
+        className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
       >
-        <div
-          className="row pb-3"
+        Showing data as of 
+        July 31, 2018
+      </div>
+      <div>
+        <nav
+          className="pgn__tabs nav nav-tabs"
+          onKeyDown={[Function]}
+          role="tablist"
         >
-          <div
-            className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
-          >
-            Showing data as of 
-            July 31, 2018
-          </div>
-          <div
-            className="col-12 col-md-6 col-xl-8"
-          >
-            <button
-              className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
-              disabled={true}
-              onClick={[Function]}
-              type="button"
-            >
-              <svg
-                className="mr-2"
-                fill="none"
-                height={24}
-                viewBox="0 0 24 24"
-                width={24}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
-                  fill="currentColor"
-                />
-              </svg>
-              Download full report (CSV)
-            </button>
-          </div>
-        </div>
-        <div
-          className="row"
-        >
-          <div
-            className="col-12 pr-md-0 mb-0"
+          <a
+            className="pgn__tab_more nav-item nav-link"
+            data-rb-event-key={null}
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
           >
             <div
-              className="row w-100 m-0"
+              className="pgn__dropdown pgn__dropdown-light dropdown"
+              data-testid="dropdown"
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="nav-link dropdown-toggle btn btn-link"
+                disabled={false}
+                id="pgn__tab-toggle"
+                onClick={[Function]}
+                type="button"
+              >
+                More...
+              </button>
+            </div>
+          </a>
+          <a
+            aria-selected={true}
+            className="pgn__tab_invisible nav-item nav-link active"
+            data-rb-event-key="learner-progress-report"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Learner Progress Report
+          </a>
+          <a
+            aria-selected={false}
+            className="pgn__tab_invisible nav-item nav-link"
+            data-rb-event-key="module-activity"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Module Activity (Executive Education)
+          </a>
+        </nav>
+        <div
+          className="tab-content"
+        >
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          />
+          <div
+            aria-hidden={false}
+            aria-labelledby={null}
+            className="fade tab-pane active show"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="row"
             >
               <div
-                className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                className="col"
               >
                 <div
-                  className="pgn__form-group"
+                  className="row pb-3"
                 >
-                  <label
-                    className="pgn__form-label search-label mb-2"
-                    htmlFor="form-field46"
-                  >
-                    Filter by course
-                  </label>
                   <div
-                    className="pgn__form-control-decorator-group w-100"
+                    className="col-12 col-md-6 col-xl-8"
                   >
-                    <select
-                      className="form-control"
-                      id="form-field46"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <button
+                      className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
+                      disabled={true}
+                      onClick={[Function]}
+                      type="button"
                     >
-                      <option
-                        value=""
+                      <svg
+                        className="mr-2"
+                        fill="none"
+                        height={24}
+                        viewBox="0 0 24 24"
+                        width={24}
+                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        All Courses
-                      </option>
-                    </select>
+                        <path
+                          d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                      Download full report (CSV)
+                    </button>
                   </div>
                 </div>
-              </div>
-              <div
-                className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
-              >
                 <div
-                  className="pgn__form-group"
+                  className="row"
+                >
+                  <div
+                    className="col-12 pr-md-0 mb-0"
+                  >
+                    <div
+                      className="row w-100 m-0"
+                    >
+                      <div
+                        className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2"
+                            htmlFor="form-field66"
+                          >
+                            Filter by course
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              id="form-field66"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                All Courses
+                              </option>
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2 d-flex align-items-center"
+                            htmlFor="form-field67"
+                          >
+                            <span>
+                              Filter by start date
+                            </span>
+                            <span
+                              alt="More information"
+                              className="pgn__icon ml-1"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="none"
+                                focusable={false}
+                                height={24}
+                                role="img"
+                                viewBox="0 0 24 24"
+                                width={24}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                                  fill="currentColor"
+                                />
+                              </svg>
+                            </span>
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              disabled={true}
+                              id="form-field67"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                Choose a course
+                              </option>
+                              
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                      >
+                        <label
+                          className="pgn__form-label mb-2"
+                          id="search-email-label"
+                        >
+                          Filter by email
+                        </label>
+                        <div
+                          aria-labelledby="search-email-label"
+                          className="pgn__searchfield d-flex py-0"
+                          onSearch={[Function]}
+                        >
+                          <form
+                            className="pgn__searchfield-form"
+                            onReset={[Function]}
+                            onSubmit={[Function]}
+                            role="search"
+                          >
+                            <label
+                              className="m-0"
+                              htmlFor="pgn-searchfield-input-68"
+                            >
+                              <span
+                                className="sr-only"
+                              >
+                                search
+                              </span>
+                            </label>
+                            <input
+                              className="form-control"
+                              data-hj-suppress={true}
+                              disabled={false}
+                              id="pgn-searchfield-input-68"
+                              name="searchfield-input"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder="Search by email..."
+                              role="searchbox"
+                              type="text"
+                              value=""
+                            />
+                            <button
+                              className="btn"
+                              disabled={false}
+                              type="submit"
+                            >
+                              <span
+                                className="pgn__icon"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  fill="none"
+                                  focusable={false}
+                                  height={24}
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  width={24}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                              </span>
+                              <span
+                                className="sr-only"
+                              >
+                                submit search
+                              </span>
+                            </button>
+                          </form>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="mt-3 mb-5"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="mt-3"
+            >
+              <div
+                className="pgn__searchfield d-flex mt-2 mb-2 w-25 "
+                onSearch={[Function]}
+              >
+                <form
+                  className="pgn__searchfield-form"
+                  onReset={[Function]}
+                  onSubmit={[Function]}
+                  role="search"
                 >
                   <label
-                    className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                    htmlFor="form-field47"
+                    className="m-0"
+                    htmlFor="pgn-searchfield-input-69"
                   >
-                    <span>
-                      Filter by start date
-                    </span>
                     <span
-                      alt="More information"
-                      className="pgn__icon ml-1"
-                      onBlur={[Function]}
-                      onFocus={[Function]}
-                      onMouseOut={[Function]}
-                      onMouseOver={[Function]}
+                      className="sr-only"
+                    >
+                      search
+                    </span>
+                  </label>
+                  <input
+                    className="form-control"
+                    disabled={false}
+                    id="pgn-searchfield-input-69"
+                    name="searchfield-input"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder="Search email or course title"
+                    role="searchbox"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    className="btn"
+                    disabled={false}
+                    type="submit"
+                  >
+                    <span
+                      className="pgn__icon"
                     >
                       <svg
                         aria-hidden={true}
@@ -3538,116 +6486,541 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                          d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
                           fill="currentColor"
                         />
                       </svg>
                     </span>
-                  </label>
-                  <div
-                    className="pgn__form-control-decorator-group w-100"
-                  >
-                    <select
-                      className="form-control"
-                      disabled={true}
-                      id="form-field47"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <span
+                      className="sr-only"
                     >
-                      <option
-                        value=""
-                      >
-                        Choose a course
-                      </option>
-                      
-                    </select>
-                  </div>
-                </div>
+                      submit search
+                    </span>
+                  </button>
+                </form>
               </div>
               <div
-                className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                className="pgn__data-table-layout-wrapper"
               >
-                <label
-                  className="pgn__form-label mb-2"
-                  id="search-email-label"
-                >
-                  Filter by email
-                </label>
                 <div
-                  aria-labelledby="search-email-label"
-                  className="pgn__searchfield d-flex py-0"
-                  onSearch={[Function]}
+                  className="pgn__data-table-layout-main"
                 >
-                  <form
-                    className="pgn__searchfield-form"
-                    onReset={[Function]}
-                    onSubmit={[Function]}
-                    role="search"
+                  <div
+                    className="pgn__data-table-wrapper"
                   >
-                    <label
-                      className="m-0"
-                      htmlFor="pgn-searchfield-input-48"
+                    <div
+                      className="pgn__data-table-status-bar"
+                      data-testid="table-control-bar"
                     >
-                      <span
-                        className="sr-only"
+                      <div
+                        className="pgn__data-table-status"
                       >
-                        search
-                      </span>
-                    </label>
-                    <input
-                      className="form-control"
-                      data-hj-suppress={true}
-                      disabled={false}
-                      id="pgn-searchfield-input-48"
-                      name="searchfield-input"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Search by email..."
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      className="btn"
-                      disabled={false}
-                      type="submit"
-                    >
-                      <span
-                        className="pgn__icon"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="none"
-                          focusable={false}
-                          height={24}
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width={24}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          className="pgn__data-table-status-left"
+                        />
+                        <div
+                          className="pgn__data-table-actions-right"
                         >
-                          <path
-                            d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
-                            fill="currentColor"
+                          <div
+                            className="pgn__data-table-toggle"
                           />
-                        </svg>
-                      </span>
-                      <span
-                        className="sr-only"
+                          <div>
+                            <div
+                              className="pgn__table-actions"
+                              data-testid="table-actions"
+                            >
+                              <div
+                                className="pgn__datatable__visible-actions"
+                              >
+                                <button
+                                  aria-disabled={true}
+                                  aria-live="assertive"
+                                  className="pgn__stateful-btn pgn__stateful-btn-state-pageLoading download-button disabled btn btn-primary"
+                                  data-testid="module-activity-download"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="d-flex align-items-center justify-content-center"
+                                  >
+                                    <span
+                                      className="pgn__stateful-btn-icon"
+                                    >
+                                      <span
+                                        className="pgn__icon"
+                                        variant="light"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          fill="none"
+                                          focusable={false}
+                                          height={24}
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                          width={24}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M19 9h-4V3H9v6H5l7 7 7-7ZM5 18v2h14v-2H5Z"
+                                            fill="currentColor"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span>
+                                      Download module activity
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="pgn__data-table-container is-loading"
+                      data-testid="data-table-container"
+                    >
+                      <div
+                        className="pgn__data-table-spinner"
+                        data-testid="data-table-spinner"
                       >
-                        submit search
-                      </span>
-                    </button>
-                  </form>
+                        <div
+                          className="pgn__spinner spinner-border"
+                          role="status"
+                        >
+                          <span
+                            className="sr-only"
+                          >
+                            loading
+                          </span>
+                        </div>
+                      </div>
+                      <table
+                        className="pgn__data-table is-striped"
+                        role="table"
+                      >
+                        <thead>
+                          <tr
+                            role="row"
+                          >
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Email
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Course Title
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Module
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Grade
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  % Activities Complete
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Learning Hours
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Log Views
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody
+                          role="rowgroup"
+                        />
+                      </table>
+                    </div>
+                    <div
+                      className="pgn__data-table-footer"
+                      data-testid="table-footer"
+                    >
+                      <nav
+                        aria-label="table pagination"
+                        className="pagination-minimal"
+                      >
+                        <div
+                          aria-atomic={true}
+                          aria-live="polite"
+                          aria-relevant="text"
+                          className="sr-only"
+                        >
+                          Page 1, Current Page, of -1
+                        </div>
+                        <ul
+                          className="pagination"
+                        >
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Previous"
+                              className="btn-icon btn-icon-primary btn-icon-md previous page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M17.51 3.87 15.73 2.1 5.84 12l9.9 9.9 1.77-1.77L9.38 12l8.13-8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Next, Page 2"
+                              className="btn-icon btn-icon-primary btn-icon-md next page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m6.49 20.13 1.77 1.77 9.9-9.9-9.9-9.9-1.77 1.77L14.62 12l-8.13 8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                        </ul>
+                      </nav>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-        <div
-          className="mt-3 mb-5"
-        />
       </div>
     </div>
   </div>
@@ -4297,106 +7670,355 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders full 
       </div>
     </div>
     <div
-      className="row"
+      className="tabs-container"
     >
       <div
-        className="col"
+        className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
       >
-        <div
-          className="row pb-3"
+        Showing data as of 
+        July 31, 2018
+      </div>
+      <div>
+        <nav
+          className="pgn__tabs nav nav-tabs"
+          onKeyDown={[Function]}
+          role="tablist"
         >
-          <div
-            className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
-          >
-            Showing data as of 
-            July 31, 2018
-          </div>
-          <div
-            className="col-12 col-md-6 col-xl-8"
-          >
-            <button
-              className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
-              disabled={true}
-              onClick={[Function]}
-              type="button"
-            >
-              <svg
-                className="mr-2"
-                fill="none"
-                height={24}
-                viewBox="0 0 24 24"
-                width={24}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
-                  fill="currentColor"
-                />
-              </svg>
-              Download full report (CSV)
-            </button>
-          </div>
-        </div>
-        <div
-          className="row"
-        >
-          <div
-            className="col-12 pr-md-0 mb-0"
+          <a
+            className="pgn__tab_more nav-item nav-link"
+            data-rb-event-key={null}
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
           >
             <div
-              className="row w-100 m-0"
+              className="pgn__dropdown pgn__dropdown-light dropdown"
+              data-testid="dropdown"
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="nav-link dropdown-toggle btn btn-link"
+                disabled={false}
+                id="pgn__tab-toggle"
+                onClick={[Function]}
+                type="button"
+              >
+                More...
+              </button>
+            </div>
+          </a>
+          <a
+            aria-selected={true}
+            className="pgn__tab_invisible nav-item nav-link active"
+            data-rb-event-key="learner-progress-report"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Learner Progress Report
+          </a>
+          <a
+            aria-selected={false}
+            className="pgn__tab_invisible nav-item nav-link"
+            data-rb-event-key="module-activity"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Module Activity (Executive Education)
+          </a>
+        </nav>
+        <div
+          className="tab-content"
+        >
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          />
+          <div
+            aria-hidden={false}
+            aria-labelledby={null}
+            className="fade tab-pane active show"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="row"
             >
               <div
-                className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                className="col"
               >
                 <div
-                  className="pgn__form-group"
+                  className="row pb-3"
                 >
-                  <label
-                    className="pgn__form-label search-label mb-2"
-                    htmlFor="form-field1"
-                  >
-                    Filter by course
-                  </label>
                   <div
-                    className="pgn__form-control-decorator-group w-100"
+                    className="col-12 col-md-6 col-xl-8"
                   >
-                    <select
-                      className="form-control"
-                      id="form-field1"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <button
+                      className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
+                      disabled={true}
+                      onClick={[Function]}
+                      type="button"
                     >
-                      <option
-                        value=""
+                      <svg
+                        className="mr-2"
+                        fill="none"
+                        height={24}
+                        viewBox="0 0 24 24"
+                        width={24}
+                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        All Courses
-                      </option>
-                    </select>
+                        <path
+                          d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                      Download full report (CSV)
+                    </button>
                   </div>
                 </div>
-              </div>
-              <div
-                className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
-              >
                 <div
-                  className="pgn__form-group"
+                  className="row"
+                >
+                  <div
+                    className="col-12 pr-md-0 mb-0"
+                  >
+                    <div
+                      className="row w-100 m-0"
+                    >
+                      <div
+                        className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2"
+                            htmlFor="form-field3"
+                          >
+                            Filter by course
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              id="form-field3"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                All Courses
+                              </option>
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2 d-flex align-items-center"
+                            htmlFor="form-field4"
+                          >
+                            <span>
+                              Filter by start date
+                            </span>
+                            <span
+                              alt="More information"
+                              className="pgn__icon ml-1"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="none"
+                                focusable={false}
+                                height={24}
+                                role="img"
+                                viewBox="0 0 24 24"
+                                width={24}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                                  fill="currentColor"
+                                />
+                              </svg>
+                            </span>
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              disabled={true}
+                              id="form-field4"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                Choose a course
+                              </option>
+                              
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                      >
+                        <label
+                          className="pgn__form-label mb-2"
+                          id="search-email-label"
+                        >
+                          Filter by email
+                        </label>
+                        <div
+                          aria-labelledby="search-email-label"
+                          className="pgn__searchfield d-flex py-0"
+                          onSearch={[Function]}
+                        >
+                          <form
+                            className="pgn__searchfield-form"
+                            onReset={[Function]}
+                            onSubmit={[Function]}
+                            role="search"
+                          >
+                            <label
+                              className="m-0"
+                              htmlFor="pgn-searchfield-input-5"
+                            >
+                              <span
+                                className="sr-only"
+                              >
+                                search
+                              </span>
+                            </label>
+                            <input
+                              className="form-control"
+                              data-hj-suppress={true}
+                              disabled={false}
+                              id="pgn-searchfield-input-5"
+                              name="searchfield-input"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder="Search by email..."
+                              role="searchbox"
+                              type="text"
+                              value=""
+                            />
+                            <button
+                              className="btn"
+                              disabled={false}
+                              type="submit"
+                            >
+                              <span
+                                className="pgn__icon"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  fill="none"
+                                  focusable={false}
+                                  height={24}
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  width={24}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                              </span>
+                              <span
+                                className="sr-only"
+                              >
+                                submit search
+                              </span>
+                            </button>
+                          </form>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="mt-3 mb-5"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="mt-3"
+            >
+              <div
+                className="pgn__searchfield d-flex mt-2 mb-2 w-25 "
+                onSearch={[Function]}
+              >
+                <form
+                  className="pgn__searchfield-form"
+                  onReset={[Function]}
+                  onSubmit={[Function]}
+                  role="search"
                 >
                   <label
-                    className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                    htmlFor="form-field2"
+                    className="m-0"
+                    htmlFor="pgn-searchfield-input-6"
                   >
-                    <span>
-                      Filter by start date
-                    </span>
                     <span
-                      alt="More information"
-                      className="pgn__icon ml-1"
-                      onBlur={[Function]}
-                      onFocus={[Function]}
-                      onMouseOut={[Function]}
-                      onMouseOver={[Function]}
+                      className="sr-only"
+                    >
+                      search
+                    </span>
+                  </label>
+                  <input
+                    className="form-control"
+                    disabled={false}
+                    id="pgn-searchfield-input-6"
+                    name="searchfield-input"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder="Search email or course title"
+                    role="searchbox"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    className="btn"
+                    disabled={false}
+                    type="submit"
+                  >
+                    <span
+                      className="pgn__icon"
                     >
                       <svg
                         aria-hidden={true}
@@ -4409,116 +8031,541 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders full 
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                          d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
                           fill="currentColor"
                         />
                       </svg>
                     </span>
-                  </label>
-                  <div
-                    className="pgn__form-control-decorator-group w-100"
-                  >
-                    <select
-                      className="form-control"
-                      disabled={true}
-                      id="form-field2"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <span
+                      className="sr-only"
                     >
-                      <option
-                        value=""
-                      >
-                        Choose a course
-                      </option>
-                      
-                    </select>
-                  </div>
-                </div>
+                      submit search
+                    </span>
+                  </button>
+                </form>
               </div>
               <div
-                className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                className="pgn__data-table-layout-wrapper"
               >
-                <label
-                  className="pgn__form-label mb-2"
-                  id="search-email-label"
-                >
-                  Filter by email
-                </label>
                 <div
-                  aria-labelledby="search-email-label"
-                  className="pgn__searchfield d-flex py-0"
-                  onSearch={[Function]}
+                  className="pgn__data-table-layout-main"
                 >
-                  <form
-                    className="pgn__searchfield-form"
-                    onReset={[Function]}
-                    onSubmit={[Function]}
-                    role="search"
+                  <div
+                    className="pgn__data-table-wrapper"
                   >
-                    <label
-                      className="m-0"
-                      htmlFor="pgn-searchfield-input-3"
+                    <div
+                      className="pgn__data-table-status-bar"
+                      data-testid="table-control-bar"
                     >
-                      <span
-                        className="sr-only"
+                      <div
+                        className="pgn__data-table-status"
                       >
-                        search
-                      </span>
-                    </label>
-                    <input
-                      className="form-control"
-                      data-hj-suppress={true}
-                      disabled={false}
-                      id="pgn-searchfield-input-3"
-                      name="searchfield-input"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Search by email..."
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      className="btn"
-                      disabled={false}
-                      type="submit"
-                    >
-                      <span
-                        className="pgn__icon"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="none"
-                          focusable={false}
-                          height={24}
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width={24}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          className="pgn__data-table-status-left"
+                        />
+                        <div
+                          className="pgn__data-table-actions-right"
                         >
-                          <path
-                            d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
-                            fill="currentColor"
+                          <div
+                            className="pgn__data-table-toggle"
                           />
-                        </svg>
-                      </span>
-                      <span
-                        className="sr-only"
+                          <div>
+                            <div
+                              className="pgn__table-actions"
+                              data-testid="table-actions"
+                            >
+                              <div
+                                className="pgn__datatable__visible-actions"
+                              >
+                                <button
+                                  aria-disabled={true}
+                                  aria-live="assertive"
+                                  className="pgn__stateful-btn pgn__stateful-btn-state-pageLoading download-button disabled btn btn-primary"
+                                  data-testid="module-activity-download"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="d-flex align-items-center justify-content-center"
+                                  >
+                                    <span
+                                      className="pgn__stateful-btn-icon"
+                                    >
+                                      <span
+                                        className="pgn__icon"
+                                        variant="light"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          fill="none"
+                                          focusable={false}
+                                          height={24}
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                          width={24}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M19 9h-4V3H9v6H5l7 7 7-7ZM5 18v2h14v-2H5Z"
+                                            fill="currentColor"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span>
+                                      Download module activity
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="pgn__data-table-container is-loading"
+                      data-testid="data-table-container"
+                    >
+                      <div
+                        className="pgn__data-table-spinner"
+                        data-testid="data-table-spinner"
                       >
-                        submit search
-                      </span>
-                    </button>
-                  </form>
+                        <div
+                          className="pgn__spinner spinner-border"
+                          role="status"
+                        >
+                          <span
+                            className="sr-only"
+                          >
+                            loading
+                          </span>
+                        </div>
+                      </div>
+                      <table
+                        className="pgn__data-table is-striped"
+                        role="table"
+                      >
+                        <thead>
+                          <tr
+                            role="row"
+                          >
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Email
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Course Title
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Module
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Grade
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  % Activities Complete
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Learning Hours
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Log Views
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody
+                          role="rowgroup"
+                        />
+                      </table>
+                    </div>
+                    <div
+                      className="pgn__data-table-footer"
+                      data-testid="table-footer"
+                    >
+                      <nav
+                        aria-label="table pagination"
+                        className="pagination-minimal"
+                      >
+                        <div
+                          aria-atomic={true}
+                          aria-live="polite"
+                          aria-relevant="text"
+                          className="sr-only"
+                        >
+                          Page 1, Current Page, of -1
+                        </div>
+                        <ul
+                          className="pagination"
+                        >
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Previous"
+                              className="btn-icon btn-icon-primary btn-icon-md previous page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M17.51 3.87 15.73 2.1 5.84 12l9.9 9.9 1.77-1.77L9.38 12l8.13-8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Next, Page 2"
+                              className="btn-icon btn-icon-primary btn-icon-md next page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m6.49 20.13 1.77 1.77 9.9-9.9-9.9-9.9-1.77 1.77L14.62 12l-8.13 8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                        </ul>
+                      </nav>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-        <div
-          className="mt-3 mb-5"
-        />
       </div>
     </div>
   </div>
@@ -5168,106 +9215,355 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
       </div>
     </div>
     <div
-      className="row"
+      className="tabs-container"
     >
       <div
-        className="col"
+        className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
       >
-        <div
-          className="row pb-3"
+        Showing data as of 
+        July 31, 2018
+      </div>
+      <div>
+        <nav
+          className="pgn__tabs nav nav-tabs"
+          onKeyDown={[Function]}
+          role="tablist"
         >
-          <div
-            className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
-          >
-            Showing data as of 
-            July 31, 2018
-          </div>
-          <div
-            className="col-12 col-md-6 col-xl-8"
-          >
-            <button
-              className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
-              disabled={true}
-              onClick={[Function]}
-              type="button"
-            >
-              <svg
-                className="mr-2"
-                fill="none"
-                height={24}
-                viewBox="0 0 24 24"
-                width={24}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
-                  fill="currentColor"
-                />
-              </svg>
-              Download full report (CSV)
-            </button>
-          </div>
-        </div>
-        <div
-          className="row"
-        >
-          <div
-            className="col-12 pr-md-0 mb-0"
+          <a
+            className="pgn__tab_more nav-item nav-link"
+            data-rb-event-key={null}
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
           >
             <div
-              className="row w-100 m-0"
+              className="pgn__dropdown pgn__dropdown-light dropdown"
+              data-testid="dropdown"
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="nav-link dropdown-toggle btn btn-link"
+                disabled={false}
+                id="pgn__tab-toggle"
+                onClick={[Function]}
+                type="button"
+              >
+                More...
+              </button>
+            </div>
+          </a>
+          <a
+            aria-selected={true}
+            className="pgn__tab_invisible nav-item nav-link active"
+            data-rb-event-key="learner-progress-report"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Learner Progress Report
+          </a>
+          <a
+            aria-selected={false}
+            className="pgn__tab_invisible nav-item nav-link"
+            data-rb-event-key="module-activity"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Module Activity (Executive Education)
+          </a>
+        </nav>
+        <div
+          className="tab-content"
+        >
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          />
+          <div
+            aria-hidden={false}
+            aria-labelledby={null}
+            className="fade tab-pane active show"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="row"
             >
               <div
-                className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                className="col"
               >
                 <div
-                  className="pgn__form-group"
+                  className="row pb-3"
                 >
-                  <label
-                    className="pgn__form-label search-label mb-2"
-                    htmlFor="form-field31"
-                  >
-                    Filter by course
-                  </label>
                   <div
-                    className="pgn__form-control-decorator-group w-100"
+                    className="col-12 col-md-6 col-xl-8"
                   >
-                    <select
-                      className="form-control"
-                      id="form-field31"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <button
+                      className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
+                      disabled={true}
+                      onClick={[Function]}
+                      type="button"
                     >
-                      <option
-                        value=""
+                      <svg
+                        className="mr-2"
+                        fill="none"
+                        height={24}
+                        viewBox="0 0 24 24"
+                        width={24}
+                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        All Courses
-                      </option>
-                    </select>
+                        <path
+                          d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                      Download full report (CSV)
+                    </button>
                   </div>
                 </div>
-              </div>
-              <div
-                className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
-              >
                 <div
-                  className="pgn__form-group"
+                  className="row"
+                >
+                  <div
+                    className="col-12 pr-md-0 mb-0"
+                  >
+                    <div
+                      className="row w-100 m-0"
+                    >
+                      <div
+                        className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2"
+                            htmlFor="form-field45"
+                          >
+                            Filter by course
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              id="form-field45"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                All Courses
+                              </option>
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2 d-flex align-items-center"
+                            htmlFor="form-field46"
+                          >
+                            <span>
+                              Filter by start date
+                            </span>
+                            <span
+                              alt="More information"
+                              className="pgn__icon ml-1"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="none"
+                                focusable={false}
+                                height={24}
+                                role="img"
+                                viewBox="0 0 24 24"
+                                width={24}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                                  fill="currentColor"
+                                />
+                              </svg>
+                            </span>
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              disabled={true}
+                              id="form-field46"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                Choose a course
+                              </option>
+                              
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                      >
+                        <label
+                          className="pgn__form-label mb-2"
+                          id="search-email-label"
+                        >
+                          Filter by email
+                        </label>
+                        <div
+                          aria-labelledby="search-email-label"
+                          className="pgn__searchfield d-flex py-0"
+                          onSearch={[Function]}
+                        >
+                          <form
+                            className="pgn__searchfield-form"
+                            onReset={[Function]}
+                            onSubmit={[Function]}
+                            role="search"
+                          >
+                            <label
+                              className="m-0"
+                              htmlFor="pgn-searchfield-input-47"
+                            >
+                              <span
+                                className="sr-only"
+                              >
+                                search
+                              </span>
+                            </label>
+                            <input
+                              className="form-control"
+                              data-hj-suppress={true}
+                              disabled={false}
+                              id="pgn-searchfield-input-47"
+                              name="searchfield-input"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder="Search by email..."
+                              role="searchbox"
+                              type="text"
+                              value=""
+                            />
+                            <button
+                              className="btn"
+                              disabled={false}
+                              type="submit"
+                            >
+                              <span
+                                className="pgn__icon"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  fill="none"
+                                  focusable={false}
+                                  height={24}
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  width={24}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                              </span>
+                              <span
+                                className="sr-only"
+                              >
+                                submit search
+                              </span>
+                            </button>
+                          </form>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="mt-3 mb-5"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="mt-3"
+            >
+              <div
+                className="pgn__searchfield d-flex mt-2 mb-2 w-25 "
+                onSearch={[Function]}
+              >
+                <form
+                  className="pgn__searchfield-form"
+                  onReset={[Function]}
+                  onSubmit={[Function]}
+                  role="search"
                 >
                   <label
-                    className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                    htmlFor="form-field32"
+                    className="m-0"
+                    htmlFor="pgn-searchfield-input-48"
                   >
-                    <span>
-                      Filter by start date
-                    </span>
                     <span
-                      alt="More information"
-                      className="pgn__icon ml-1"
-                      onBlur={[Function]}
-                      onFocus={[Function]}
-                      onMouseOut={[Function]}
-                      onMouseOver={[Function]}
+                      className="sr-only"
+                    >
+                      search
+                    </span>
+                  </label>
+                  <input
+                    className="form-control"
+                    disabled={false}
+                    id="pgn-searchfield-input-48"
+                    name="searchfield-input"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder="Search email or course title"
+                    role="searchbox"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    className="btn"
+                    disabled={false}
+                    type="submit"
+                  >
+                    <span
+                      className="pgn__icon"
                     >
                       <svg
                         aria-hidden={true}
@@ -5280,116 +9576,541 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                          d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
                           fill="currentColor"
                         />
                       </svg>
                     </span>
-                  </label>
-                  <div
-                    className="pgn__form-control-decorator-group w-100"
-                  >
-                    <select
-                      className="form-control"
-                      disabled={true}
-                      id="form-field32"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <span
+                      className="sr-only"
                     >
-                      <option
-                        value=""
-                      >
-                        Choose a course
-                      </option>
-                      
-                    </select>
-                  </div>
-                </div>
+                      submit search
+                    </span>
+                  </button>
+                </form>
               </div>
               <div
-                className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                className="pgn__data-table-layout-wrapper"
               >
-                <label
-                  className="pgn__form-label mb-2"
-                  id="search-email-label"
-                >
-                  Filter by email
-                </label>
                 <div
-                  aria-labelledby="search-email-label"
-                  className="pgn__searchfield d-flex py-0"
-                  onSearch={[Function]}
+                  className="pgn__data-table-layout-main"
                 >
-                  <form
-                    className="pgn__searchfield-form"
-                    onReset={[Function]}
-                    onSubmit={[Function]}
-                    role="search"
+                  <div
+                    className="pgn__data-table-wrapper"
                   >
-                    <label
-                      className="m-0"
-                      htmlFor="pgn-searchfield-input-33"
+                    <div
+                      className="pgn__data-table-status-bar"
+                      data-testid="table-control-bar"
                     >
-                      <span
-                        className="sr-only"
+                      <div
+                        className="pgn__data-table-status"
                       >
-                        search
-                      </span>
-                    </label>
-                    <input
-                      className="form-control"
-                      data-hj-suppress={true}
-                      disabled={false}
-                      id="pgn-searchfield-input-33"
-                      name="searchfield-input"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Search by email..."
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      className="btn"
-                      disabled={false}
-                      type="submit"
-                    >
-                      <span
-                        className="pgn__icon"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="none"
-                          focusable={false}
-                          height={24}
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width={24}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          className="pgn__data-table-status-left"
+                        />
+                        <div
+                          className="pgn__data-table-actions-right"
                         >
-                          <path
-                            d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
-                            fill="currentColor"
+                          <div
+                            className="pgn__data-table-toggle"
                           />
-                        </svg>
-                      </span>
-                      <span
-                        className="sr-only"
+                          <div>
+                            <div
+                              className="pgn__table-actions"
+                              data-testid="table-actions"
+                            >
+                              <div
+                                className="pgn__datatable__visible-actions"
+                              >
+                                <button
+                                  aria-disabled={true}
+                                  aria-live="assertive"
+                                  className="pgn__stateful-btn pgn__stateful-btn-state-pageLoading download-button disabled btn btn-primary"
+                                  data-testid="module-activity-download"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="d-flex align-items-center justify-content-center"
+                                  >
+                                    <span
+                                      className="pgn__stateful-btn-icon"
+                                    >
+                                      <span
+                                        className="pgn__icon"
+                                        variant="light"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          fill="none"
+                                          focusable={false}
+                                          height={24}
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                          width={24}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M19 9h-4V3H9v6H5l7 7 7-7ZM5 18v2h14v-2H5Z"
+                                            fill="currentColor"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span>
+                                      Download module activity
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="pgn__data-table-container is-loading"
+                      data-testid="data-table-container"
+                    >
+                      <div
+                        className="pgn__data-table-spinner"
+                        data-testid="data-table-spinner"
                       >
-                        submit search
-                      </span>
-                    </button>
-                  </form>
+                        <div
+                          className="pgn__spinner spinner-border"
+                          role="status"
+                        >
+                          <span
+                            className="sr-only"
+                          >
+                            loading
+                          </span>
+                        </div>
+                      </div>
+                      <table
+                        className="pgn__data-table is-striped"
+                        role="table"
+                      >
+                        <thead>
+                          <tr
+                            role="row"
+                          >
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Email
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Course Title
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Module
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Grade
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  % Activities Complete
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Learning Hours
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Log Views
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody
+                          role="rowgroup"
+                        />
+                      </table>
+                    </div>
+                    <div
+                      className="pgn__data-table-footer"
+                      data-testid="table-footer"
+                    >
+                      <nav
+                        aria-label="table pagination"
+                        className="pagination-minimal"
+                      >
+                        <div
+                          aria-atomic={true}
+                          aria-live="polite"
+                          aria-relevant="text"
+                          className="sr-only"
+                        >
+                          Page 1, Current Page, of -1
+                        </div>
+                        <ul
+                          className="pagination"
+                        >
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Previous"
+                              className="btn-icon btn-icon-primary btn-icon-md previous page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M17.51 3.87 15.73 2.1 5.84 12l9.9 9.9 1.77-1.77L9.38 12l8.13-8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Next, Page 2"
+                              className="btn-icon btn-icon-primary btn-icon-md next page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m6.49 20.13 1.77 1.77 9.9-9.9-9.9-9.9-1.77 1.77L14.62 12l-8.13 8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                        </ul>
+                      </nav>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-        <div
-          className="mt-3 mb-5"
-        />
       </div>
     </div>
   </div>
@@ -6039,106 +10760,355 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
       </div>
     </div>
     <div
-      className="row"
+      className="tabs-container"
     >
       <div
-        className="col"
+        className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
       >
-        <div
-          className="row pb-3"
+        Showing data as of 
+        July 31, 2018
+      </div>
+      <div>
+        <nav
+          className="pgn__tabs nav nav-tabs"
+          onKeyDown={[Function]}
+          role="tablist"
         >
-          <div
-            className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
-          >
-            Showing data as of 
-            July 31, 2018
-          </div>
-          <div
-            className="col-12 col-md-6 col-xl-8"
-          >
-            <button
-              className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
-              disabled={true}
-              onClick={[Function]}
-              type="button"
-            >
-              <svg
-                className="mr-2"
-                fill="none"
-                height={24}
-                viewBox="0 0 24 24"
-                width={24}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
-                  fill="currentColor"
-                />
-              </svg>
-              Download full report (CSV)
-            </button>
-          </div>
-        </div>
-        <div
-          className="row"
-        >
-          <div
-            className="col-12 pr-md-0 mb-0"
+          <a
+            className="pgn__tab_more nav-item nav-link"
+            data-rb-event-key={null}
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
           >
             <div
-              className="row w-100 m-0"
+              className="pgn__dropdown pgn__dropdown-light dropdown"
+              data-testid="dropdown"
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="nav-link dropdown-toggle btn btn-link"
+                disabled={false}
+                id="pgn__tab-toggle"
+                onClick={[Function]}
+                type="button"
+              >
+                More...
+              </button>
+            </div>
+          </a>
+          <a
+            aria-selected={true}
+            className="pgn__tab_invisible nav-item nav-link active"
+            data-rb-event-key="learner-progress-report"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Learner Progress Report
+          </a>
+          <a
+            aria-selected={false}
+            className="pgn__tab_invisible nav-item nav-link"
+            data-rb-event-key="module-activity"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Module Activity (Executive Education)
+          </a>
+        </nav>
+        <div
+          className="tab-content"
+        >
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          />
+          <div
+            aria-hidden={false}
+            aria-labelledby={null}
+            className="fade tab-pane active show"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="row"
             >
               <div
-                className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                className="col"
               >
                 <div
-                  className="pgn__form-group"
+                  className="row pb-3"
                 >
-                  <label
-                    className="pgn__form-label search-label mb-2"
-                    htmlFor="form-field26"
-                  >
-                    Filter by course
-                  </label>
                   <div
-                    className="pgn__form-control-decorator-group w-100"
+                    className="col-12 col-md-6 col-xl-8"
                   >
-                    <select
-                      className="form-control"
-                      id="form-field26"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <button
+                      className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
+                      disabled={true}
+                      onClick={[Function]}
+                      type="button"
                     >
-                      <option
-                        value=""
+                      <svg
+                        className="mr-2"
+                        fill="none"
+                        height={24}
+                        viewBox="0 0 24 24"
+                        width={24}
+                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        All Courses
-                      </option>
-                    </select>
+                        <path
+                          d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                      Download full report (CSV)
+                    </button>
                   </div>
                 </div>
-              </div>
-              <div
-                className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
-              >
                 <div
-                  className="pgn__form-group"
+                  className="row"
+                >
+                  <div
+                    className="col-12 pr-md-0 mb-0"
+                  >
+                    <div
+                      className="row w-100 m-0"
+                    >
+                      <div
+                        className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2"
+                            htmlFor="form-field38"
+                          >
+                            Filter by course
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              id="form-field38"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                All Courses
+                              </option>
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2 d-flex align-items-center"
+                            htmlFor="form-field39"
+                          >
+                            <span>
+                              Filter by start date
+                            </span>
+                            <span
+                              alt="More information"
+                              className="pgn__icon ml-1"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="none"
+                                focusable={false}
+                                height={24}
+                                role="img"
+                                viewBox="0 0 24 24"
+                                width={24}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                                  fill="currentColor"
+                                />
+                              </svg>
+                            </span>
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              disabled={true}
+                              id="form-field39"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                Choose a course
+                              </option>
+                              
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                      >
+                        <label
+                          className="pgn__form-label mb-2"
+                          id="search-email-label"
+                        >
+                          Filter by email
+                        </label>
+                        <div
+                          aria-labelledby="search-email-label"
+                          className="pgn__searchfield d-flex py-0"
+                          onSearch={[Function]}
+                        >
+                          <form
+                            className="pgn__searchfield-form"
+                            onReset={[Function]}
+                            onSubmit={[Function]}
+                            role="search"
+                          >
+                            <label
+                              className="m-0"
+                              htmlFor="pgn-searchfield-input-40"
+                            >
+                              <span
+                                className="sr-only"
+                              >
+                                search
+                              </span>
+                            </label>
+                            <input
+                              className="form-control"
+                              data-hj-suppress={true}
+                              disabled={false}
+                              id="pgn-searchfield-input-40"
+                              name="searchfield-input"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder="Search by email..."
+                              role="searchbox"
+                              type="text"
+                              value=""
+                            />
+                            <button
+                              className="btn"
+                              disabled={false}
+                              type="submit"
+                            >
+                              <span
+                                className="pgn__icon"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  fill="none"
+                                  focusable={false}
+                                  height={24}
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  width={24}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                              </span>
+                              <span
+                                className="sr-only"
+                              >
+                                submit search
+                              </span>
+                            </button>
+                          </form>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="mt-3 mb-5"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="mt-3"
+            >
+              <div
+                className="pgn__searchfield d-flex mt-2 mb-2 w-25 "
+                onSearch={[Function]}
+              >
+                <form
+                  className="pgn__searchfield-form"
+                  onReset={[Function]}
+                  onSubmit={[Function]}
+                  role="search"
                 >
                   <label
-                    className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                    htmlFor="form-field27"
+                    className="m-0"
+                    htmlFor="pgn-searchfield-input-41"
                   >
-                    <span>
-                      Filter by start date
-                    </span>
                     <span
-                      alt="More information"
-                      className="pgn__icon ml-1"
-                      onBlur={[Function]}
-                      onFocus={[Function]}
-                      onMouseOut={[Function]}
-                      onMouseOver={[Function]}
+                      className="sr-only"
+                    >
+                      search
+                    </span>
+                  </label>
+                  <input
+                    className="form-control"
+                    disabled={false}
+                    id="pgn-searchfield-input-41"
+                    name="searchfield-input"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder="Search email or course title"
+                    role="searchbox"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    className="btn"
+                    disabled={false}
+                    type="submit"
+                  >
+                    <span
+                      className="pgn__icon"
                     >
                       <svg
                         aria-hidden={true}
@@ -6151,116 +11121,541 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                          d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
                           fill="currentColor"
                         />
                       </svg>
                     </span>
-                  </label>
-                  <div
-                    className="pgn__form-control-decorator-group w-100"
-                  >
-                    <select
-                      className="form-control"
-                      disabled={true}
-                      id="form-field27"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <span
+                      className="sr-only"
                     >
-                      <option
-                        value=""
-                      >
-                        Choose a course
-                      </option>
-                      
-                    </select>
-                  </div>
-                </div>
+                      submit search
+                    </span>
+                  </button>
+                </form>
               </div>
               <div
-                className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                className="pgn__data-table-layout-wrapper"
               >
-                <label
-                  className="pgn__form-label mb-2"
-                  id="search-email-label"
-                >
-                  Filter by email
-                </label>
                 <div
-                  aria-labelledby="search-email-label"
-                  className="pgn__searchfield d-flex py-0"
-                  onSearch={[Function]}
+                  className="pgn__data-table-layout-main"
                 >
-                  <form
-                    className="pgn__searchfield-form"
-                    onReset={[Function]}
-                    onSubmit={[Function]}
-                    role="search"
+                  <div
+                    className="pgn__data-table-wrapper"
                   >
-                    <label
-                      className="m-0"
-                      htmlFor="pgn-searchfield-input-28"
+                    <div
+                      className="pgn__data-table-status-bar"
+                      data-testid="table-control-bar"
                     >
-                      <span
-                        className="sr-only"
+                      <div
+                        className="pgn__data-table-status"
                       >
-                        search
-                      </span>
-                    </label>
-                    <input
-                      className="form-control"
-                      data-hj-suppress={true}
-                      disabled={false}
-                      id="pgn-searchfield-input-28"
-                      name="searchfield-input"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Search by email..."
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      className="btn"
-                      disabled={false}
-                      type="submit"
-                    >
-                      <span
-                        className="pgn__icon"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="none"
-                          focusable={false}
-                          height={24}
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width={24}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          className="pgn__data-table-status-left"
+                        />
+                        <div
+                          className="pgn__data-table-actions-right"
                         >
-                          <path
-                            d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
-                            fill="currentColor"
+                          <div
+                            className="pgn__data-table-toggle"
                           />
-                        </svg>
-                      </span>
-                      <span
-                        className="sr-only"
+                          <div>
+                            <div
+                              className="pgn__table-actions"
+                              data-testid="table-actions"
+                            >
+                              <div
+                                className="pgn__datatable__visible-actions"
+                              >
+                                <button
+                                  aria-disabled={true}
+                                  aria-live="assertive"
+                                  className="pgn__stateful-btn pgn__stateful-btn-state-pageLoading download-button disabled btn btn-primary"
+                                  data-testid="module-activity-download"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="d-flex align-items-center justify-content-center"
+                                  >
+                                    <span
+                                      className="pgn__stateful-btn-icon"
+                                    >
+                                      <span
+                                        className="pgn__icon"
+                                        variant="light"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          fill="none"
+                                          focusable={false}
+                                          height={24}
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                          width={24}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M19 9h-4V3H9v6H5l7 7 7-7ZM5 18v2h14v-2H5Z"
+                                            fill="currentColor"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span>
+                                      Download module activity
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="pgn__data-table-container is-loading"
+                      data-testid="data-table-container"
+                    >
+                      <div
+                        className="pgn__data-table-spinner"
+                        data-testid="data-table-spinner"
                       >
-                        submit search
-                      </span>
-                    </button>
-                  </form>
+                        <div
+                          className="pgn__spinner spinner-border"
+                          role="status"
+                        >
+                          <span
+                            className="sr-only"
+                          >
+                            loading
+                          </span>
+                        </div>
+                      </div>
+                      <table
+                        className="pgn__data-table is-striped"
+                        role="table"
+                      >
+                        <thead>
+                          <tr
+                            role="row"
+                          >
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Email
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Course Title
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Module
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Grade
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  % Activities Complete
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Learning Hours
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Log Views
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody
+                          role="rowgroup"
+                        />
+                      </table>
+                    </div>
+                    <div
+                      className="pgn__data-table-footer"
+                      data-testid="table-footer"
+                    >
+                      <nav
+                        aria-label="table pagination"
+                        className="pagination-minimal"
+                      >
+                        <div
+                          aria-atomic={true}
+                          aria-live="polite"
+                          aria-relevant="text"
+                          className="sr-only"
+                        >
+                          Page 1, Current Page, of -1
+                        </div>
+                        <ul
+                          className="pagination"
+                        >
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Previous"
+                              className="btn-icon btn-icon-primary btn-icon-md previous page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M17.51 3.87 15.73 2.1 5.84 12l9.9 9.9 1.77-1.77L9.38 12l8.13-8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Next, Page 2"
+                              className="btn-icon btn-icon-primary btn-icon-md next page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m6.49 20.13 1.77 1.77 9.9-9.9-9.9-9.9-1.77 1.77L14.62 12l-8.13 8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                        </ul>
+                      </nav>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-        <div
-          className="mt-3 mb-5"
-        />
       </div>
     </div>
   </div>
@@ -6910,106 +12305,355 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders learn
       </div>
     </div>
     <div
-      className="row"
+      className="tabs-container"
     >
       <div
-        className="col"
+        className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
       >
-        <div
-          className="row pb-3"
+        Showing data as of 
+        July 31, 2018
+      </div>
+      <div>
+        <nav
+          className="pgn__tabs nav nav-tabs"
+          onKeyDown={[Function]}
+          role="tablist"
         >
-          <div
-            className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
-          >
-            Showing data as of 
-            July 31, 2018
-          </div>
-          <div
-            className="col-12 col-md-6 col-xl-8"
-          >
-            <button
-              className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
-              disabled={true}
-              onClick={[Function]}
-              type="button"
-            >
-              <svg
-                className="mr-2"
-                fill="none"
-                height={24}
-                viewBox="0 0 24 24"
-                width={24}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
-                  fill="currentColor"
-                />
-              </svg>
-              Download full report (CSV)
-            </button>
-          </div>
-        </div>
-        <div
-          className="row"
-        >
-          <div
-            className="col-12 pr-md-0 mb-0"
+          <a
+            className="pgn__tab_more nav-item nav-link"
+            data-rb-event-key={null}
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
           >
             <div
-              className="row w-100 m-0"
+              className="pgn__dropdown pgn__dropdown-light dropdown"
+              data-testid="dropdown"
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="nav-link dropdown-toggle btn btn-link"
+                disabled={false}
+                id="pgn__tab-toggle"
+                onClick={[Function]}
+                type="button"
+              >
+                More...
+              </button>
+            </div>
+          </a>
+          <a
+            aria-selected={true}
+            className="pgn__tab_invisible nav-item nav-link active"
+            data-rb-event-key="learner-progress-report"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Learner Progress Report
+          </a>
+          <a
+            aria-selected={false}
+            className="pgn__tab_invisible nav-item nav-link"
+            data-rb-event-key="module-activity"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Module Activity (Executive Education)
+          </a>
+        </nav>
+        <div
+          className="tab-content"
+        >
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          />
+          <div
+            aria-hidden={false}
+            aria-labelledby={null}
+            className="fade tab-pane active show"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="row"
             >
               <div
-                className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                className="col"
               >
                 <div
-                  className="pgn__form-group"
+                  className="row pb-3"
                 >
-                  <label
-                    className="pgn__form-label search-label mb-2"
-                    htmlFor="form-field16"
-                  >
-                    Filter by course
-                  </label>
                   <div
-                    className="pgn__form-control-decorator-group w-100"
+                    className="col-12 col-md-6 col-xl-8"
                   >
-                    <select
-                      className="form-control"
-                      id="form-field16"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <button
+                      className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
+                      disabled={true}
+                      onClick={[Function]}
+                      type="button"
                     >
-                      <option
-                        value=""
+                      <svg
+                        className="mr-2"
+                        fill="none"
+                        height={24}
+                        viewBox="0 0 24 24"
+                        width={24}
+                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        All Courses
-                      </option>
-                    </select>
+                        <path
+                          d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                      Download full report (CSV)
+                    </button>
                   </div>
                 </div>
-              </div>
-              <div
-                className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
-              >
                 <div
-                  className="pgn__form-group"
+                  className="row"
+                >
+                  <div
+                    className="col-12 pr-md-0 mb-0"
+                  >
+                    <div
+                      className="row w-100 m-0"
+                    >
+                      <div
+                        className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2"
+                            htmlFor="form-field24"
+                          >
+                            Filter by course
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              id="form-field24"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                All Courses
+                              </option>
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2 d-flex align-items-center"
+                            htmlFor="form-field25"
+                          >
+                            <span>
+                              Filter by start date
+                            </span>
+                            <span
+                              alt="More information"
+                              className="pgn__icon ml-1"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="none"
+                                focusable={false}
+                                height={24}
+                                role="img"
+                                viewBox="0 0 24 24"
+                                width={24}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                                  fill="currentColor"
+                                />
+                              </svg>
+                            </span>
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              disabled={true}
+                              id="form-field25"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                Choose a course
+                              </option>
+                              
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                      >
+                        <label
+                          className="pgn__form-label mb-2"
+                          id="search-email-label"
+                        >
+                          Filter by email
+                        </label>
+                        <div
+                          aria-labelledby="search-email-label"
+                          className="pgn__searchfield d-flex py-0"
+                          onSearch={[Function]}
+                        >
+                          <form
+                            className="pgn__searchfield-form"
+                            onReset={[Function]}
+                            onSubmit={[Function]}
+                            role="search"
+                          >
+                            <label
+                              className="m-0"
+                              htmlFor="pgn-searchfield-input-26"
+                            >
+                              <span
+                                className="sr-only"
+                              >
+                                search
+                              </span>
+                            </label>
+                            <input
+                              className="form-control"
+                              data-hj-suppress={true}
+                              disabled={false}
+                              id="pgn-searchfield-input-26"
+                              name="searchfield-input"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder="Search by email..."
+                              role="searchbox"
+                              type="text"
+                              value=""
+                            />
+                            <button
+                              className="btn"
+                              disabled={false}
+                              type="submit"
+                            >
+                              <span
+                                className="pgn__icon"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  fill="none"
+                                  focusable={false}
+                                  height={24}
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  width={24}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                              </span>
+                              <span
+                                className="sr-only"
+                              >
+                                submit search
+                              </span>
+                            </button>
+                          </form>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="mt-3 mb-5"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="mt-3"
+            >
+              <div
+                className="pgn__searchfield d-flex mt-2 mb-2 w-25 "
+                onSearch={[Function]}
+              >
+                <form
+                  className="pgn__searchfield-form"
+                  onReset={[Function]}
+                  onSubmit={[Function]}
+                  role="search"
                 >
                   <label
-                    className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                    htmlFor="form-field17"
+                    className="m-0"
+                    htmlFor="pgn-searchfield-input-27"
                   >
-                    <span>
-                      Filter by start date
-                    </span>
                     <span
-                      alt="More information"
-                      className="pgn__icon ml-1"
-                      onBlur={[Function]}
-                      onFocus={[Function]}
-                      onMouseOut={[Function]}
-                      onMouseOver={[Function]}
+                      className="sr-only"
+                    >
+                      search
+                    </span>
+                  </label>
+                  <input
+                    className="form-control"
+                    disabled={false}
+                    id="pgn-searchfield-input-27"
+                    name="searchfield-input"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder="Search email or course title"
+                    role="searchbox"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    className="btn"
+                    disabled={false}
+                    type="submit"
+                  >
+                    <span
+                      className="pgn__icon"
                     >
                       <svg
                         aria-hidden={true}
@@ -7022,116 +12666,541 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders learn
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                          d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
                           fill="currentColor"
                         />
                       </svg>
                     </span>
-                  </label>
-                  <div
-                    className="pgn__form-control-decorator-group w-100"
-                  >
-                    <select
-                      className="form-control"
-                      disabled={true}
-                      id="form-field17"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <span
+                      className="sr-only"
                     >
-                      <option
-                        value=""
-                      >
-                        Choose a course
-                      </option>
-                      
-                    </select>
-                  </div>
-                </div>
+                      submit search
+                    </span>
+                  </button>
+                </form>
               </div>
               <div
-                className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                className="pgn__data-table-layout-wrapper"
               >
-                <label
-                  className="pgn__form-label mb-2"
-                  id="search-email-label"
-                >
-                  Filter by email
-                </label>
                 <div
-                  aria-labelledby="search-email-label"
-                  className="pgn__searchfield d-flex py-0"
-                  onSearch={[Function]}
+                  className="pgn__data-table-layout-main"
                 >
-                  <form
-                    className="pgn__searchfield-form"
-                    onReset={[Function]}
-                    onSubmit={[Function]}
-                    role="search"
+                  <div
+                    className="pgn__data-table-wrapper"
                   >
-                    <label
-                      className="m-0"
-                      htmlFor="pgn-searchfield-input-18"
+                    <div
+                      className="pgn__data-table-status-bar"
+                      data-testid="table-control-bar"
                     >
-                      <span
-                        className="sr-only"
+                      <div
+                        className="pgn__data-table-status"
                       >
-                        search
-                      </span>
-                    </label>
-                    <input
-                      className="form-control"
-                      data-hj-suppress={true}
-                      disabled={false}
-                      id="pgn-searchfield-input-18"
-                      name="searchfield-input"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Search by email..."
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      className="btn"
-                      disabled={false}
-                      type="submit"
-                    >
-                      <span
-                        className="pgn__icon"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="none"
-                          focusable={false}
-                          height={24}
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width={24}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          className="pgn__data-table-status-left"
+                        />
+                        <div
+                          className="pgn__data-table-actions-right"
                         >
-                          <path
-                            d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
-                            fill="currentColor"
+                          <div
+                            className="pgn__data-table-toggle"
                           />
-                        </svg>
-                      </span>
-                      <span
-                        className="sr-only"
+                          <div>
+                            <div
+                              className="pgn__table-actions"
+                              data-testid="table-actions"
+                            >
+                              <div
+                                className="pgn__datatable__visible-actions"
+                              >
+                                <button
+                                  aria-disabled={true}
+                                  aria-live="assertive"
+                                  className="pgn__stateful-btn pgn__stateful-btn-state-pageLoading download-button disabled btn btn-primary"
+                                  data-testid="module-activity-download"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="d-flex align-items-center justify-content-center"
+                                  >
+                                    <span
+                                      className="pgn__stateful-btn-icon"
+                                    >
+                                      <span
+                                        className="pgn__icon"
+                                        variant="light"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          fill="none"
+                                          focusable={false}
+                                          height={24}
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                          width={24}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M19 9h-4V3H9v6H5l7 7 7-7ZM5 18v2h14v-2H5Z"
+                                            fill="currentColor"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span>
+                                      Download module activity
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="pgn__data-table-container is-loading"
+                      data-testid="data-table-container"
+                    >
+                      <div
+                        className="pgn__data-table-spinner"
+                        data-testid="data-table-spinner"
                       >
-                        submit search
-                      </span>
-                    </button>
-                  </form>
+                        <div
+                          className="pgn__spinner spinner-border"
+                          role="status"
+                        >
+                          <span
+                            className="sr-only"
+                          >
+                            loading
+                          </span>
+                        </div>
+                      </div>
+                      <table
+                        className="pgn__data-table is-striped"
+                        role="table"
+                      >
+                        <thead>
+                          <tr
+                            role="row"
+                          >
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Email
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Course Title
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Module
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Grade
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  % Activities Complete
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Learning Hours
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Log Views
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody
+                          role="rowgroup"
+                        />
+                      </table>
+                    </div>
+                    <div
+                      className="pgn__data-table-footer"
+                      data-testid="table-footer"
+                    >
+                      <nav
+                        aria-label="table pagination"
+                        className="pagination-minimal"
+                      >
+                        <div
+                          aria-atomic={true}
+                          aria-live="polite"
+                          aria-relevant="text"
+                          className="sr-only"
+                        >
+                          Page 1, Current Page, of -1
+                        </div>
+                        <ul
+                          className="pagination"
+                        >
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Previous"
+                              className="btn-icon btn-icon-primary btn-icon-md previous page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M17.51 3.87 15.73 2.1 5.84 12l9.9 9.9 1.77-1.77L9.38 12l8.13-8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Next, Page 2"
+                              className="btn-icon btn-icon-primary btn-icon-md next page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m6.49 20.13 1.77 1.77 9.9-9.9-9.9-9.9-1.77 1.77L14.62 12l-8.13 8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                        </ul>
+                      </nav>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-        <div
-          className="mt-3 mb-5"
-        />
       </div>
     </div>
   </div>
@@ -7781,106 +13850,355 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders regis
       </div>
     </div>
     <div
-      className="row"
+      className="tabs-container"
     >
       <div
-        className="col"
+        className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
       >
-        <div
-          className="row pb-3"
+        Showing data as of 
+        July 31, 2018
+      </div>
+      <div>
+        <nav
+          className="pgn__tabs nav nav-tabs"
+          onKeyDown={[Function]}
+          role="tablist"
         >
-          <div
-            className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
-          >
-            Showing data as of 
-            July 31, 2018
-          </div>
-          <div
-            className="col-12 col-md-6 col-xl-8"
-          >
-            <button
-              className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
-              disabled={true}
-              onClick={[Function]}
-              type="button"
-            >
-              <svg
-                className="mr-2"
-                fill="none"
-                height={24}
-                viewBox="0 0 24 24"
-                width={24}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
-                  fill="currentColor"
-                />
-              </svg>
-              Download full report (CSV)
-            </button>
-          </div>
-        </div>
-        <div
-          className="row"
-        >
-          <div
-            className="col-12 pr-md-0 mb-0"
+          <a
+            className="pgn__tab_more nav-item nav-link"
+            data-rb-event-key={null}
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
           >
             <div
-              className="row w-100 m-0"
+              className="pgn__dropdown pgn__dropdown-light dropdown"
+              data-testid="dropdown"
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="nav-link dropdown-toggle btn btn-link"
+                disabled={false}
+                id="pgn__tab-toggle"
+                onClick={[Function]}
+                type="button"
+              >
+                More...
+              </button>
+            </div>
+          </a>
+          <a
+            aria-selected={true}
+            className="pgn__tab_invisible nav-item nav-link active"
+            data-rb-event-key="learner-progress-report"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Learner Progress Report
+          </a>
+          <a
+            aria-selected={false}
+            className="pgn__tab_invisible nav-item nav-link"
+            data-rb-event-key="module-activity"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Module Activity (Executive Education)
+          </a>
+        </nav>
+        <div
+          className="tab-content"
+        >
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          />
+          <div
+            aria-hidden={false}
+            aria-labelledby={null}
+            className="fade tab-pane active show"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="row"
             >
               <div
-                className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                className="col"
               >
                 <div
-                  className="pgn__form-group"
+                  className="row pb-3"
                 >
-                  <label
-                    className="pgn__form-label search-label mb-2"
-                    htmlFor="form-field6"
-                  >
-                    Filter by course
-                  </label>
                   <div
-                    className="pgn__form-control-decorator-group w-100"
+                    className="col-12 col-md-6 col-xl-8"
                   >
-                    <select
-                      className="form-control"
-                      id="form-field6"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <button
+                      className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
+                      disabled={true}
+                      onClick={[Function]}
+                      type="button"
                     >
-                      <option
-                        value=""
+                      <svg
+                        className="mr-2"
+                        fill="none"
+                        height={24}
+                        viewBox="0 0 24 24"
+                        width={24}
+                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        All Courses
-                      </option>
-                    </select>
+                        <path
+                          d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                      Download full report (CSV)
+                    </button>
                   </div>
                 </div>
-              </div>
-              <div
-                className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
-              >
                 <div
-                  className="pgn__form-group"
+                  className="row"
+                >
+                  <div
+                    className="col-12 pr-md-0 mb-0"
+                  >
+                    <div
+                      className="row w-100 m-0"
+                    >
+                      <div
+                        className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2"
+                            htmlFor="form-field10"
+                          >
+                            Filter by course
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              id="form-field10"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                All Courses
+                              </option>
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2 d-flex align-items-center"
+                            htmlFor="form-field11"
+                          >
+                            <span>
+                              Filter by start date
+                            </span>
+                            <span
+                              alt="More information"
+                              className="pgn__icon ml-1"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="none"
+                                focusable={false}
+                                height={24}
+                                role="img"
+                                viewBox="0 0 24 24"
+                                width={24}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                                  fill="currentColor"
+                                />
+                              </svg>
+                            </span>
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              disabled={true}
+                              id="form-field11"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                Choose a course
+                              </option>
+                              
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                      >
+                        <label
+                          className="pgn__form-label mb-2"
+                          id="search-email-label"
+                        >
+                          Filter by email
+                        </label>
+                        <div
+                          aria-labelledby="search-email-label"
+                          className="pgn__searchfield d-flex py-0"
+                          onSearch={[Function]}
+                        >
+                          <form
+                            className="pgn__searchfield-form"
+                            onReset={[Function]}
+                            onSubmit={[Function]}
+                            role="search"
+                          >
+                            <label
+                              className="m-0"
+                              htmlFor="pgn-searchfield-input-12"
+                            >
+                              <span
+                                className="sr-only"
+                              >
+                                search
+                              </span>
+                            </label>
+                            <input
+                              className="form-control"
+                              data-hj-suppress={true}
+                              disabled={false}
+                              id="pgn-searchfield-input-12"
+                              name="searchfield-input"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder="Search by email..."
+                              role="searchbox"
+                              type="text"
+                              value=""
+                            />
+                            <button
+                              className="btn"
+                              disabled={false}
+                              type="submit"
+                            >
+                              <span
+                                className="pgn__icon"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  fill="none"
+                                  focusable={false}
+                                  height={24}
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  width={24}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                              </span>
+                              <span
+                                className="sr-only"
+                              >
+                                submit search
+                              </span>
+                            </button>
+                          </form>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="mt-3 mb-5"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="mt-3"
+            >
+              <div
+                className="pgn__searchfield d-flex mt-2 mb-2 w-25 "
+                onSearch={[Function]}
+              >
+                <form
+                  className="pgn__searchfield-form"
+                  onReset={[Function]}
+                  onSubmit={[Function]}
+                  role="search"
                 >
                   <label
-                    className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                    htmlFor="form-field7"
+                    className="m-0"
+                    htmlFor="pgn-searchfield-input-13"
                   >
-                    <span>
-                      Filter by start date
-                    </span>
                     <span
-                      alt="More information"
-                      className="pgn__icon ml-1"
-                      onBlur={[Function]}
-                      onFocus={[Function]}
-                      onMouseOut={[Function]}
-                      onMouseOver={[Function]}
+                      className="sr-only"
+                    >
+                      search
+                    </span>
+                  </label>
+                  <input
+                    className="form-control"
+                    disabled={false}
+                    id="pgn-searchfield-input-13"
+                    name="searchfield-input"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder="Search email or course title"
+                    role="searchbox"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    className="btn"
+                    disabled={false}
+                    type="submit"
+                  >
+                    <span
+                      className="pgn__icon"
                     >
                       <svg
                         aria-hidden={true}
@@ -7893,116 +14211,541 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders regis
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                          d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
                           fill="currentColor"
                         />
                       </svg>
                     </span>
-                  </label>
-                  <div
-                    className="pgn__form-control-decorator-group w-100"
-                  >
-                    <select
-                      className="form-control"
-                      disabled={true}
-                      id="form-field7"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <span
+                      className="sr-only"
                     >
-                      <option
-                        value=""
-                      >
-                        Choose a course
-                      </option>
-                      
-                    </select>
-                  </div>
-                </div>
+                      submit search
+                    </span>
+                  </button>
+                </form>
               </div>
               <div
-                className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                className="pgn__data-table-layout-wrapper"
               >
-                <label
-                  className="pgn__form-label mb-2"
-                  id="search-email-label"
-                >
-                  Filter by email
-                </label>
                 <div
-                  aria-labelledby="search-email-label"
-                  className="pgn__searchfield d-flex py-0"
-                  onSearch={[Function]}
+                  className="pgn__data-table-layout-main"
                 >
-                  <form
-                    className="pgn__searchfield-form"
-                    onReset={[Function]}
-                    onSubmit={[Function]}
-                    role="search"
+                  <div
+                    className="pgn__data-table-wrapper"
                   >
-                    <label
-                      className="m-0"
-                      htmlFor="pgn-searchfield-input-8"
+                    <div
+                      className="pgn__data-table-status-bar"
+                      data-testid="table-control-bar"
                     >
-                      <span
-                        className="sr-only"
+                      <div
+                        className="pgn__data-table-status"
                       >
-                        search
-                      </span>
-                    </label>
-                    <input
-                      className="form-control"
-                      data-hj-suppress={true}
-                      disabled={false}
-                      id="pgn-searchfield-input-8"
-                      name="searchfield-input"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Search by email..."
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      className="btn"
-                      disabled={false}
-                      type="submit"
-                    >
-                      <span
-                        className="pgn__icon"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="none"
-                          focusable={false}
-                          height={24}
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width={24}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          className="pgn__data-table-status-left"
+                        />
+                        <div
+                          className="pgn__data-table-actions-right"
                         >
-                          <path
-                            d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
-                            fill="currentColor"
+                          <div
+                            className="pgn__data-table-toggle"
                           />
-                        </svg>
-                      </span>
-                      <span
-                        className="sr-only"
+                          <div>
+                            <div
+                              className="pgn__table-actions"
+                              data-testid="table-actions"
+                            >
+                              <div
+                                className="pgn__datatable__visible-actions"
+                              >
+                                <button
+                                  aria-disabled={true}
+                                  aria-live="assertive"
+                                  className="pgn__stateful-btn pgn__stateful-btn-state-pageLoading download-button disabled btn btn-primary"
+                                  data-testid="module-activity-download"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="d-flex align-items-center justify-content-center"
+                                  >
+                                    <span
+                                      className="pgn__stateful-btn-icon"
+                                    >
+                                      <span
+                                        className="pgn__icon"
+                                        variant="light"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          fill="none"
+                                          focusable={false}
+                                          height={24}
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                          width={24}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M19 9h-4V3H9v6H5l7 7 7-7ZM5 18v2h14v-2H5Z"
+                                            fill="currentColor"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span>
+                                      Download module activity
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="pgn__data-table-container is-loading"
+                      data-testid="data-table-container"
+                    >
+                      <div
+                        className="pgn__data-table-spinner"
+                        data-testid="data-table-spinner"
                       >
-                        submit search
-                      </span>
-                    </button>
-                  </form>
+                        <div
+                          className="pgn__spinner spinner-border"
+                          role="status"
+                        >
+                          <span
+                            className="sr-only"
+                          >
+                            loading
+                          </span>
+                        </div>
+                      </div>
+                      <table
+                        className="pgn__data-table is-striped"
+                        role="table"
+                      >
+                        <thead>
+                          <tr
+                            role="row"
+                          >
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Email
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Course Title
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Module
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Grade
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  % Activities Complete
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Learning Hours
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Log Views
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody
+                          role="rowgroup"
+                        />
+                      </table>
+                    </div>
+                    <div
+                      className="pgn__data-table-footer"
+                      data-testid="table-footer"
+                    >
+                      <nav
+                        aria-label="table pagination"
+                        className="pagination-minimal"
+                      >
+                        <div
+                          aria-atomic={true}
+                          aria-live="polite"
+                          aria-relevant="text"
+                          className="sr-only"
+                        >
+                          Page 1, Current Page, of -1
+                        </div>
+                        <ul
+                          className="pagination"
+                        >
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Previous"
+                              className="btn-icon btn-icon-primary btn-icon-md previous page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M17.51 3.87 15.73 2.1 5.84 12l9.9 9.9 1.77-1.77L9.38 12l8.13-8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Next, Page 2"
+                              className="btn-icon btn-icon-primary btn-icon-md next page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m6.49 20.13 1.77 1.77 9.9-9.9-9.9-9.9-1.77 1.77L14.62 12l-8.13 8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                        </ul>
+                      </nav>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-        <div
-          className="mt-3 mb-5"
-        />
       </div>
     </div>
   </div>
@@ -8652,106 +15395,355 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders top a
       </div>
     </div>
     <div
-      className="row"
+      className="tabs-container"
     >
       <div
-        className="col"
+        className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
       >
-        <div
-          className="row pb-3"
+        Showing data as of 
+        July 31, 2018
+      </div>
+      <div>
+        <nav
+          className="pgn__tabs nav nav-tabs"
+          onKeyDown={[Function]}
+          role="tablist"
         >
-          <div
-            className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
-          >
-            Showing data as of 
-            July 31, 2018
-          </div>
-          <div
-            className="col-12 col-md-6 col-xl-8"
-          >
-            <button
-              className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
-              disabled={true}
-              onClick={[Function]}
-              type="button"
-            >
-              <svg
-                className="mr-2"
-                fill="none"
-                height={24}
-                viewBox="0 0 24 24"
-                width={24}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
-                  fill="currentColor"
-                />
-              </svg>
-              Download full report (CSV)
-            </button>
-          </div>
-        </div>
-        <div
-          className="row"
-        >
-          <div
-            className="col-12 pr-md-0 mb-0"
+          <a
+            className="pgn__tab_more nav-item nav-link"
+            data-rb-event-key={null}
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
           >
             <div
-              className="row w-100 m-0"
+              className="pgn__dropdown pgn__dropdown-light dropdown"
+              data-testid="dropdown"
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="nav-link dropdown-toggle btn btn-link"
+                disabled={false}
+                id="pgn__tab-toggle"
+                onClick={[Function]}
+                type="button"
+              >
+                More...
+              </button>
+            </div>
+          </a>
+          <a
+            aria-selected={true}
+            className="pgn__tab_invisible nav-item nav-link active"
+            data-rb-event-key="learner-progress-report"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Learner Progress Report
+          </a>
+          <a
+            aria-selected={false}
+            className="pgn__tab_invisible nav-item nav-link"
+            data-rb-event-key="module-activity"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Module Activity (Executive Education)
+          </a>
+        </nav>
+        <div
+          className="tab-content"
+        >
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          />
+          <div
+            aria-hidden={false}
+            aria-labelledby={null}
+            className="fade tab-pane active show"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="row"
             >
               <div
-                className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                className="col"
               >
                 <div
-                  className="pgn__form-group"
+                  className="row pb-3"
                 >
-                  <label
-                    className="pgn__form-label search-label mb-2"
-                    htmlFor="form-field21"
-                  >
-                    Filter by course
-                  </label>
                   <div
-                    className="pgn__form-control-decorator-group w-100"
+                    className="col-12 col-md-6 col-xl-8"
                   >
-                    <select
-                      className="form-control"
-                      id="form-field21"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <button
+                      className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
+                      disabled={true}
+                      onClick={[Function]}
+                      type="button"
                     >
-                      <option
-                        value=""
+                      <svg
+                        className="mr-2"
+                        fill="none"
+                        height={24}
+                        viewBox="0 0 24 24"
+                        width={24}
+                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        All Courses
-                      </option>
-                    </select>
+                        <path
+                          d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                      Download full report (CSV)
+                    </button>
                   </div>
                 </div>
-              </div>
-              <div
-                className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
-              >
                 <div
-                  className="pgn__form-group"
+                  className="row"
+                >
+                  <div
+                    className="col-12 pr-md-0 mb-0"
+                  >
+                    <div
+                      className="row w-100 m-0"
+                    >
+                      <div
+                        className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2"
+                            htmlFor="form-field31"
+                          >
+                            Filter by course
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              id="form-field31"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                All Courses
+                              </option>
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2 d-flex align-items-center"
+                            htmlFor="form-field32"
+                          >
+                            <span>
+                              Filter by start date
+                            </span>
+                            <span
+                              alt="More information"
+                              className="pgn__icon ml-1"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="none"
+                                focusable={false}
+                                height={24}
+                                role="img"
+                                viewBox="0 0 24 24"
+                                width={24}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                                  fill="currentColor"
+                                />
+                              </svg>
+                            </span>
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              disabled={true}
+                              id="form-field32"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                Choose a course
+                              </option>
+                              
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                      >
+                        <label
+                          className="pgn__form-label mb-2"
+                          id="search-email-label"
+                        >
+                          Filter by email
+                        </label>
+                        <div
+                          aria-labelledby="search-email-label"
+                          className="pgn__searchfield d-flex py-0"
+                          onSearch={[Function]}
+                        >
+                          <form
+                            className="pgn__searchfield-form"
+                            onReset={[Function]}
+                            onSubmit={[Function]}
+                            role="search"
+                          >
+                            <label
+                              className="m-0"
+                              htmlFor="pgn-searchfield-input-33"
+                            >
+                              <span
+                                className="sr-only"
+                              >
+                                search
+                              </span>
+                            </label>
+                            <input
+                              className="form-control"
+                              data-hj-suppress={true}
+                              disabled={false}
+                              id="pgn-searchfield-input-33"
+                              name="searchfield-input"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder="Search by email..."
+                              role="searchbox"
+                              type="text"
+                              value=""
+                            />
+                            <button
+                              className="btn"
+                              disabled={false}
+                              type="submit"
+                            >
+                              <span
+                                className="pgn__icon"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  fill="none"
+                                  focusable={false}
+                                  height={24}
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  width={24}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                              </span>
+                              <span
+                                className="sr-only"
+                              >
+                                submit search
+                              </span>
+                            </button>
+                          </form>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="mt-3 mb-5"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="mt-3"
+            >
+              <div
+                className="pgn__searchfield d-flex mt-2 mb-2 w-25 "
+                onSearch={[Function]}
+              >
+                <form
+                  className="pgn__searchfield-form"
+                  onReset={[Function]}
+                  onSubmit={[Function]}
+                  role="search"
                 >
                   <label
-                    className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                    htmlFor="form-field22"
+                    className="m-0"
+                    htmlFor="pgn-searchfield-input-34"
                   >
-                    <span>
-                      Filter by start date
-                    </span>
                     <span
-                      alt="More information"
-                      className="pgn__icon ml-1"
-                      onBlur={[Function]}
-                      onFocus={[Function]}
-                      onMouseOut={[Function]}
-                      onMouseOver={[Function]}
+                      className="sr-only"
+                    >
+                      search
+                    </span>
+                  </label>
+                  <input
+                    className="form-control"
+                    disabled={false}
+                    id="pgn-searchfield-input-34"
+                    name="searchfield-input"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder="Search email or course title"
+                    role="searchbox"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    className="btn"
+                    disabled={false}
+                    type="submit"
+                  >
+                    <span
+                      className="pgn__icon"
                     >
                       <svg
                         aria-hidden={true}
@@ -8764,116 +15756,541 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders top a
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                          d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
                           fill="currentColor"
                         />
                       </svg>
                     </span>
-                  </label>
-                  <div
-                    className="pgn__form-control-decorator-group w-100"
-                  >
-                    <select
-                      className="form-control"
-                      disabled={true}
-                      id="form-field22"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <span
+                      className="sr-only"
                     >
-                      <option
-                        value=""
-                      >
-                        Choose a course
-                      </option>
-                      
-                    </select>
-                  </div>
-                </div>
+                      submit search
+                    </span>
+                  </button>
+                </form>
               </div>
               <div
-                className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                className="pgn__data-table-layout-wrapper"
               >
-                <label
-                  className="pgn__form-label mb-2"
-                  id="search-email-label"
-                >
-                  Filter by email
-                </label>
                 <div
-                  aria-labelledby="search-email-label"
-                  className="pgn__searchfield d-flex py-0"
-                  onSearch={[Function]}
+                  className="pgn__data-table-layout-main"
                 >
-                  <form
-                    className="pgn__searchfield-form"
-                    onReset={[Function]}
-                    onSubmit={[Function]}
-                    role="search"
+                  <div
+                    className="pgn__data-table-wrapper"
                   >
-                    <label
-                      className="m-0"
-                      htmlFor="pgn-searchfield-input-23"
+                    <div
+                      className="pgn__data-table-status-bar"
+                      data-testid="table-control-bar"
                     >
-                      <span
-                        className="sr-only"
+                      <div
+                        className="pgn__data-table-status"
                       >
-                        search
-                      </span>
-                    </label>
-                    <input
-                      className="form-control"
-                      data-hj-suppress={true}
-                      disabled={false}
-                      id="pgn-searchfield-input-23"
-                      name="searchfield-input"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Search by email..."
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      className="btn"
-                      disabled={false}
-                      type="submit"
-                    >
-                      <span
-                        className="pgn__icon"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="none"
-                          focusable={false}
-                          height={24}
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width={24}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          className="pgn__data-table-status-left"
+                        />
+                        <div
+                          className="pgn__data-table-actions-right"
                         >
-                          <path
-                            d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
-                            fill="currentColor"
+                          <div
+                            className="pgn__data-table-toggle"
                           />
-                        </svg>
-                      </span>
-                      <span
-                        className="sr-only"
+                          <div>
+                            <div
+                              className="pgn__table-actions"
+                              data-testid="table-actions"
+                            >
+                              <div
+                                className="pgn__datatable__visible-actions"
+                              >
+                                <button
+                                  aria-disabled={true}
+                                  aria-live="assertive"
+                                  className="pgn__stateful-btn pgn__stateful-btn-state-pageLoading download-button disabled btn btn-primary"
+                                  data-testid="module-activity-download"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="d-flex align-items-center justify-content-center"
+                                  >
+                                    <span
+                                      className="pgn__stateful-btn-icon"
+                                    >
+                                      <span
+                                        className="pgn__icon"
+                                        variant="light"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          fill="none"
+                                          focusable={false}
+                                          height={24}
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                          width={24}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M19 9h-4V3H9v6H5l7 7 7-7ZM5 18v2h14v-2H5Z"
+                                            fill="currentColor"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span>
+                                      Download module activity
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="pgn__data-table-container is-loading"
+                      data-testid="data-table-container"
+                    >
+                      <div
+                        className="pgn__data-table-spinner"
+                        data-testid="data-table-spinner"
                       >
-                        submit search
-                      </span>
-                    </button>
-                  </form>
+                        <div
+                          className="pgn__spinner spinner-border"
+                          role="status"
+                        >
+                          <span
+                            className="sr-only"
+                          >
+                            loading
+                          </span>
+                        </div>
+                      </div>
+                      <table
+                        className="pgn__data-table is-striped"
+                        role="table"
+                      >
+                        <thead>
+                          <tr
+                            role="row"
+                          >
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Email
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Course Title
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Module
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Grade
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  % Activities Complete
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Learning Hours
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Log Views
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody
+                          role="rowgroup"
+                        />
+                      </table>
+                    </div>
+                    <div
+                      className="pgn__data-table-footer"
+                      data-testid="table-footer"
+                    >
+                      <nav
+                        aria-label="table pagination"
+                        className="pagination-minimal"
+                      >
+                        <div
+                          aria-atomic={true}
+                          aria-live="polite"
+                          aria-relevant="text"
+                          className="sr-only"
+                        >
+                          Page 1, Current Page, of -1
+                        </div>
+                        <ul
+                          className="pagination"
+                        >
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Previous"
+                              className="btn-icon btn-icon-primary btn-icon-md previous page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M17.51 3.87 15.73 2.1 5.84 12l9.9 9.9 1.77-1.77L9.38 12l8.13-8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Next, Page 2"
+                              className="btn-icon btn-icon-primary btn-icon-md next page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m6.49 20.13 1.77 1.77 9.9-9.9-9.9-9.9-1.77 1.77L14.62 12l-8.13 8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                        </ul>
+                      </nav>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-        <div
-          className="mt-3 mb-5"
-        />
       </div>
     </div>
   </div>
@@ -9572,106 +16989,355 @@ exports[`<Admin /> renders correctly with dashboard insights data renders dashbo
       </div>
     </div>
     <div
-      className="row"
+      className="tabs-container"
     >
       <div
-        className="col"
+        className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
       >
-        <div
-          className="row pb-3"
+        Showing data as of 
+        July 31, 2018
+      </div>
+      <div>
+        <nav
+          className="pgn__tabs nav nav-tabs"
+          onKeyDown={[Function]}
+          role="tablist"
         >
-          <div
-            className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
-          >
-            Showing data as of 
-            July 31, 2018
-          </div>
-          <div
-            className="col-12 col-md-6 col-xl-8"
-          >
-            <button
-              className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
-              disabled={true}
-              onClick={[Function]}
-              type="button"
-            >
-              <svg
-                className="mr-2"
-                fill="none"
-                height={24}
-                viewBox="0 0 24 24"
-                width={24}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
-                  fill="currentColor"
-                />
-              </svg>
-              Download full report (CSV)
-            </button>
-          </div>
-        </div>
-        <div
-          className="row"
-        >
-          <div
-            className="col-12 pr-md-0 mb-0"
+          <a
+            className="pgn__tab_more nav-item nav-link"
+            data-rb-event-key={null}
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
           >
             <div
-              className="row w-100 m-0"
+              className="pgn__dropdown pgn__dropdown-light dropdown"
+              data-testid="dropdown"
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="nav-link dropdown-toggle btn btn-link"
+                disabled={false}
+                id="pgn__tab-toggle"
+                onClick={[Function]}
+                type="button"
+              >
+                More...
+              </button>
+            </div>
+          </a>
+          <a
+            aria-selected={true}
+            className="pgn__tab_invisible nav-item nav-link active"
+            data-rb-event-key="learner-progress-report"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Learner Progress Report
+          </a>
+          <a
+            aria-selected={false}
+            className="pgn__tab_invisible nav-item nav-link"
+            data-rb-event-key="module-activity"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Module Activity (Executive Education)
+          </a>
+        </nav>
+        <div
+          className="tab-content"
+        >
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          />
+          <div
+            aria-hidden={false}
+            aria-labelledby={null}
+            className="fade tab-pane active show"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="row"
             >
               <div
-                className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                className="col"
               >
                 <div
-                  className="pgn__form-group"
+                  className="row pb-3"
                 >
-                  <label
-                    className="pgn__form-label search-label mb-2"
-                    htmlFor="form-field56"
-                  >
-                    Filter by course
-                  </label>
                   <div
-                    className="pgn__form-control-decorator-group w-100"
+                    className="col-12 col-md-6 col-xl-8"
                   >
-                    <select
-                      className="form-control"
-                      id="form-field56"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <button
+                      className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
+                      disabled={true}
+                      onClick={[Function]}
+                      type="button"
                     >
-                      <option
-                        value=""
+                      <svg
+                        className="mr-2"
+                        fill="none"
+                        height={24}
+                        viewBox="0 0 24 24"
+                        width={24}
+                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        All Courses
-                      </option>
-                    </select>
+                        <path
+                          d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                      Download full report (CSV)
+                    </button>
                   </div>
                 </div>
-              </div>
-              <div
-                className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
-              >
                 <div
-                  className="pgn__form-group"
+                  className="row"
+                >
+                  <div
+                    className="col-12 pr-md-0 mb-0"
+                  >
+                    <div
+                      className="row w-100 m-0"
+                    >
+                      <div
+                        className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2"
+                            htmlFor="form-field84"
+                          >
+                            Filter by course
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              id="form-field84"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                All Courses
+                              </option>
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2 d-flex align-items-center"
+                            htmlFor="form-field85"
+                          >
+                            <span>
+                              Filter by start date
+                            </span>
+                            <span
+                              alt="More information"
+                              className="pgn__icon ml-1"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="none"
+                                focusable={false}
+                                height={24}
+                                role="img"
+                                viewBox="0 0 24 24"
+                                width={24}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                                  fill="currentColor"
+                                />
+                              </svg>
+                            </span>
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              disabled={true}
+                              id="form-field85"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                Choose a course
+                              </option>
+                              
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                      >
+                        <label
+                          className="pgn__form-label mb-2"
+                          id="search-email-label"
+                        >
+                          Filter by email
+                        </label>
+                        <div
+                          aria-labelledby="search-email-label"
+                          className="pgn__searchfield d-flex py-0"
+                          onSearch={[Function]}
+                        >
+                          <form
+                            className="pgn__searchfield-form"
+                            onReset={[Function]}
+                            onSubmit={[Function]}
+                            role="search"
+                          >
+                            <label
+                              className="m-0"
+                              htmlFor="pgn-searchfield-input-86"
+                            >
+                              <span
+                                className="sr-only"
+                              >
+                                search
+                              </span>
+                            </label>
+                            <input
+                              className="form-control"
+                              data-hj-suppress={true}
+                              disabled={false}
+                              id="pgn-searchfield-input-86"
+                              name="searchfield-input"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder="Search by email..."
+                              role="searchbox"
+                              type="text"
+                              value=""
+                            />
+                            <button
+                              className="btn"
+                              disabled={false}
+                              type="submit"
+                            >
+                              <span
+                                className="pgn__icon"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  fill="none"
+                                  focusable={false}
+                                  height={24}
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  width={24}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                              </span>
+                              <span
+                                className="sr-only"
+                              >
+                                submit search
+                              </span>
+                            </button>
+                          </form>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="mt-3 mb-5"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="mt-3"
+            >
+              <div
+                className="pgn__searchfield d-flex mt-2 mb-2 w-25 "
+                onSearch={[Function]}
+              >
+                <form
+                  className="pgn__searchfield-form"
+                  onReset={[Function]}
+                  onSubmit={[Function]}
+                  role="search"
                 >
                   <label
-                    className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                    htmlFor="form-field57"
+                    className="m-0"
+                    htmlFor="pgn-searchfield-input-87"
                   >
-                    <span>
-                      Filter by start date
-                    </span>
                     <span
-                      alt="More information"
-                      className="pgn__icon ml-1"
-                      onBlur={[Function]}
-                      onFocus={[Function]}
-                      onMouseOut={[Function]}
-                      onMouseOver={[Function]}
+                      className="sr-only"
+                    >
+                      search
+                    </span>
+                  </label>
+                  <input
+                    className="form-control"
+                    disabled={false}
+                    id="pgn-searchfield-input-87"
+                    name="searchfield-input"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder="Search email or course title"
+                    role="searchbox"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    className="btn"
+                    disabled={false}
+                    type="submit"
+                  >
+                    <span
+                      className="pgn__icon"
                     >
                       <svg
                         aria-hidden={true}
@@ -9684,116 +17350,541 @@ exports[`<Admin /> renders correctly with dashboard insights data renders dashbo
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                          d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
                           fill="currentColor"
                         />
                       </svg>
                     </span>
-                  </label>
-                  <div
-                    className="pgn__form-control-decorator-group w-100"
-                  >
-                    <select
-                      className="form-control"
-                      disabled={true}
-                      id="form-field57"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <span
+                      className="sr-only"
                     >
-                      <option
-                        value=""
-                      >
-                        Choose a course
-                      </option>
-                      
-                    </select>
-                  </div>
-                </div>
+                      submit search
+                    </span>
+                  </button>
+                </form>
               </div>
               <div
-                className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                className="pgn__data-table-layout-wrapper"
               >
-                <label
-                  className="pgn__form-label mb-2"
-                  id="search-email-label"
-                >
-                  Filter by email
-                </label>
                 <div
-                  aria-labelledby="search-email-label"
-                  className="pgn__searchfield d-flex py-0"
-                  onSearch={[Function]}
+                  className="pgn__data-table-layout-main"
                 >
-                  <form
-                    className="pgn__searchfield-form"
-                    onReset={[Function]}
-                    onSubmit={[Function]}
-                    role="search"
+                  <div
+                    className="pgn__data-table-wrapper"
                   >
-                    <label
-                      className="m-0"
-                      htmlFor="pgn-searchfield-input-58"
+                    <div
+                      className="pgn__data-table-status-bar"
+                      data-testid="table-control-bar"
                     >
-                      <span
-                        className="sr-only"
+                      <div
+                        className="pgn__data-table-status"
                       >
-                        search
-                      </span>
-                    </label>
-                    <input
-                      className="form-control"
-                      data-hj-suppress={true}
-                      disabled={false}
-                      id="pgn-searchfield-input-58"
-                      name="searchfield-input"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Search by email..."
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      className="btn"
-                      disabled={false}
-                      type="submit"
-                    >
-                      <span
-                        className="pgn__icon"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="none"
-                          focusable={false}
-                          height={24}
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width={24}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          className="pgn__data-table-status-left"
+                        />
+                        <div
+                          className="pgn__data-table-actions-right"
                         >
-                          <path
-                            d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
-                            fill="currentColor"
+                          <div
+                            className="pgn__data-table-toggle"
                           />
-                        </svg>
-                      </span>
-                      <span
-                        className="sr-only"
+                          <div>
+                            <div
+                              className="pgn__table-actions"
+                              data-testid="table-actions"
+                            >
+                              <div
+                                className="pgn__datatable__visible-actions"
+                              >
+                                <button
+                                  aria-disabled={true}
+                                  aria-live="assertive"
+                                  className="pgn__stateful-btn pgn__stateful-btn-state-pageLoading download-button disabled btn btn-primary"
+                                  data-testid="module-activity-download"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="d-flex align-items-center justify-content-center"
+                                  >
+                                    <span
+                                      className="pgn__stateful-btn-icon"
+                                    >
+                                      <span
+                                        className="pgn__icon"
+                                        variant="light"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          fill="none"
+                                          focusable={false}
+                                          height={24}
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                          width={24}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M19 9h-4V3H9v6H5l7 7 7-7ZM5 18v2h14v-2H5Z"
+                                            fill="currentColor"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span>
+                                      Download module activity
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="pgn__data-table-container is-loading"
+                      data-testid="data-table-container"
+                    >
+                      <div
+                        className="pgn__data-table-spinner"
+                        data-testid="data-table-spinner"
                       >
-                        submit search
-                      </span>
-                    </button>
-                  </form>
+                        <div
+                          className="pgn__spinner spinner-border"
+                          role="status"
+                        >
+                          <span
+                            className="sr-only"
+                          >
+                            loading
+                          </span>
+                        </div>
+                      </div>
+                      <table
+                        className="pgn__data-table is-striped"
+                        role="table"
+                      >
+                        <thead>
+                          <tr
+                            role="row"
+                          >
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Email
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Course Title
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Module
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Grade
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  % Activities Complete
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Learning Hours
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Log Views
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody
+                          role="rowgroup"
+                        />
+                      </table>
+                    </div>
+                    <div
+                      className="pgn__data-table-footer"
+                      data-testid="table-footer"
+                    >
+                      <nav
+                        aria-label="table pagination"
+                        className="pagination-minimal"
+                      >
+                        <div
+                          aria-atomic={true}
+                          aria-live="polite"
+                          aria-relevant="text"
+                          className="sr-only"
+                        >
+                          Page 1, Current Page, of -1
+                        </div>
+                        <ul
+                          className="pagination"
+                        >
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Previous"
+                              className="btn-icon btn-icon-primary btn-icon-md previous page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M17.51 3.87 15.73 2.1 5.84 12l9.9 9.9 1.77-1.77L9.38 12l8.13-8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Next, Page 2"
+                              className="btn-icon btn-icon-primary btn-icon-md next page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m6.49 20.13 1.77 1.77 9.9-9.9-9.9-9.9-1.77 1.77L14.62 12l-8.13 8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                        </ul>
+                      </nav>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-        <div
-          className="mt-3 mb-5"
-        />
       </div>
     </div>
   </div>
@@ -9939,14 +18030,691 @@ exports[`<Admin /> renders correctly with error state 1`] = `
       </div>
     </div>
     <div
-      className="row"
+      className="tabs-container"
     >
       <div
-        className="col"
-      >
+        className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
+      />
+      <div>
+        <nav
+          className="pgn__tabs nav nav-tabs"
+          onKeyDown={[Function]}
+          role="tablist"
+        >
+          <a
+            className="pgn__tab_more nav-item nav-link"
+            data-rb-event-key={null}
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            <div
+              className="pgn__dropdown pgn__dropdown-light dropdown"
+              data-testid="dropdown"
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="nav-link dropdown-toggle btn btn-link"
+                disabled={false}
+                id="pgn__tab-toggle"
+                onClick={[Function]}
+                type="button"
+              >
+                More...
+              </button>
+            </div>
+          </a>
+          <a
+            aria-selected={true}
+            className="pgn__tab_invisible nav-item nav-link active"
+            data-rb-event-key="learner-progress-report"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Learner Progress Report
+          </a>
+          <a
+            aria-selected={false}
+            className="pgn__tab_invisible nav-item nav-link"
+            data-rb-event-key="module-activity"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Module Activity (Executive Education)
+          </a>
+        </nav>
         <div
-          className="mt-3 mb-5"
-        />
+          className="tab-content"
+        >
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          />
+          <div
+            aria-hidden={false}
+            aria-labelledby={null}
+            className="fade tab-pane active show"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="row"
+            >
+              <div
+                className="col"
+              >
+                <div
+                  className="mt-3 mb-5"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="mt-3"
+            >
+              <div
+                className="pgn__searchfield d-flex mt-2 mb-2 w-25 "
+                onSearch={[Function]}
+              >
+                <form
+                  className="pgn__searchfield-form"
+                  onReset={[Function]}
+                  onSubmit={[Function]}
+                  role="search"
+                >
+                  <label
+                    className="m-0"
+                    htmlFor="pgn-searchfield-input-73"
+                  >
+                    <span
+                      className="sr-only"
+                    >
+                      search
+                    </span>
+                  </label>
+                  <input
+                    className="form-control"
+                    disabled={false}
+                    id="pgn-searchfield-input-73"
+                    name="searchfield-input"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder="Search email or course title"
+                    role="searchbox"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    className="btn"
+                    disabled={false}
+                    type="submit"
+                  >
+                    <span
+                      className="pgn__icon"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        fill="none"
+                        focusable={false}
+                        height={24}
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width={24}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="sr-only"
+                    >
+                      submit search
+                    </span>
+                  </button>
+                </form>
+              </div>
+              <div
+                className="pgn__data-table-layout-wrapper"
+              >
+                <div
+                  className="pgn__data-table-layout-main"
+                >
+                  <div
+                    className="pgn__data-table-wrapper"
+                  >
+                    <div
+                      className="pgn__data-table-status-bar"
+                      data-testid="table-control-bar"
+                    >
+                      <div
+                        className="pgn__data-table-status"
+                      >
+                        <div
+                          className="pgn__data-table-status-left"
+                        />
+                        <div
+                          className="pgn__data-table-actions-right"
+                        >
+                          <div
+                            className="pgn__data-table-toggle"
+                          />
+                          <div>
+                            <div
+                              className="pgn__table-actions"
+                              data-testid="table-actions"
+                            >
+                              <div
+                                className="pgn__datatable__visible-actions"
+                              >
+                                <button
+                                  aria-disabled={true}
+                                  aria-live="assertive"
+                                  className="pgn__stateful-btn pgn__stateful-btn-state-pageLoading download-button disabled btn btn-primary"
+                                  data-testid="module-activity-download"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="d-flex align-items-center justify-content-center"
+                                  >
+                                    <span
+                                      className="pgn__stateful-btn-icon"
+                                    >
+                                      <span
+                                        className="pgn__icon"
+                                        variant="light"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          fill="none"
+                                          focusable={false}
+                                          height={24}
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                          width={24}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M19 9h-4V3H9v6H5l7 7 7-7ZM5 18v2h14v-2H5Z"
+                                            fill="currentColor"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span>
+                                      Download module activity
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="pgn__data-table-container is-loading"
+                      data-testid="data-table-container"
+                    >
+                      <div
+                        className="pgn__data-table-spinner"
+                        data-testid="data-table-spinner"
+                      >
+                        <div
+                          className="pgn__spinner spinner-border"
+                          role="status"
+                        >
+                          <span
+                            className="sr-only"
+                          >
+                            loading
+                          </span>
+                        </div>
+                      </div>
+                      <table
+                        className="pgn__data-table is-striped"
+                        role="table"
+                      >
+                        <thead>
+                          <tr
+                            role="row"
+                          >
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Email
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Course Title
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Module
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Grade
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  % Activities Complete
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Learning Hours
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Log Views
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody
+                          role="rowgroup"
+                        />
+                      </table>
+                    </div>
+                    <div
+                      className="pgn__data-table-footer"
+                      data-testid="table-footer"
+                    >
+                      <nav
+                        aria-label="table pagination"
+                        className="pagination-minimal"
+                      >
+                        <div
+                          aria-atomic={true}
+                          aria-live="polite"
+                          aria-relevant="text"
+                          className="sr-only"
+                        >
+                          Page 1, Current Page, of -1
+                        </div>
+                        <ul
+                          className="pagination"
+                        >
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Previous"
+                              className="btn-icon btn-icon-primary btn-icon-md previous page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M17.51 3.87 15.73 2.1 5.84 12l9.9 9.9 1.77-1.77L9.38 12l8.13-8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Next, Page 2"
+                              className="btn-icon btn-icon-primary btn-icon-md next page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m6.49 20.13 1.77 1.77 9.9-9.9-9.9-9.9-1.77 1.77L14.62 12l-8.13 8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                        </ul>
+                      </nav>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -10109,14 +18877,691 @@ exports[`<Admin /> renders correctly with loading state 1`] = `
       </div>
     </div>
     <div
-      className="row"
+      className="tabs-container"
     >
       <div
-        className="col"
-      >
+        className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
+      />
+      <div>
+        <nav
+          className="pgn__tabs nav nav-tabs"
+          onKeyDown={[Function]}
+          role="tablist"
+        >
+          <a
+            className="pgn__tab_more nav-item nav-link"
+            data-rb-event-key={null}
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            <div
+              className="pgn__dropdown pgn__dropdown-light dropdown"
+              data-testid="dropdown"
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="nav-link dropdown-toggle btn btn-link"
+                disabled={false}
+                id="pgn__tab-toggle"
+                onClick={[Function]}
+                type="button"
+              >
+                More...
+              </button>
+            </div>
+          </a>
+          <a
+            aria-selected={true}
+            className="pgn__tab_invisible nav-item nav-link active"
+            data-rb-event-key="learner-progress-report"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Learner Progress Report
+          </a>
+          <a
+            aria-selected={false}
+            className="pgn__tab_invisible nav-item nav-link"
+            data-rb-event-key="module-activity"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Module Activity (Executive Education)
+          </a>
+        </nav>
         <div
-          className="mt-3 mb-5"
-        />
+          className="tab-content"
+        >
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          />
+          <div
+            aria-hidden={false}
+            aria-labelledby={null}
+            className="fade tab-pane active show"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="row"
+            >
+              <div
+                className="col"
+              >
+                <div
+                  className="mt-3 mb-5"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="mt-3"
+            >
+              <div
+                className="pgn__searchfield d-flex mt-2 mb-2 w-25 "
+                onSearch={[Function]}
+              >
+                <form
+                  className="pgn__searchfield-form"
+                  onReset={[Function]}
+                  onSubmit={[Function]}
+                  role="search"
+                >
+                  <label
+                    className="m-0"
+                    htmlFor="pgn-searchfield-input-75"
+                  >
+                    <span
+                      className="sr-only"
+                    >
+                      search
+                    </span>
+                  </label>
+                  <input
+                    className="form-control"
+                    disabled={false}
+                    id="pgn-searchfield-input-75"
+                    name="searchfield-input"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder="Search email or course title"
+                    role="searchbox"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    className="btn"
+                    disabled={false}
+                    type="submit"
+                  >
+                    <span
+                      className="pgn__icon"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        fill="none"
+                        focusable={false}
+                        height={24}
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width={24}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="sr-only"
+                    >
+                      submit search
+                    </span>
+                  </button>
+                </form>
+              </div>
+              <div
+                className="pgn__data-table-layout-wrapper"
+              >
+                <div
+                  className="pgn__data-table-layout-main"
+                >
+                  <div
+                    className="pgn__data-table-wrapper"
+                  >
+                    <div
+                      className="pgn__data-table-status-bar"
+                      data-testid="table-control-bar"
+                    >
+                      <div
+                        className="pgn__data-table-status"
+                      >
+                        <div
+                          className="pgn__data-table-status-left"
+                        />
+                        <div
+                          className="pgn__data-table-actions-right"
+                        >
+                          <div
+                            className="pgn__data-table-toggle"
+                          />
+                          <div>
+                            <div
+                              className="pgn__table-actions"
+                              data-testid="table-actions"
+                            >
+                              <div
+                                className="pgn__datatable__visible-actions"
+                              >
+                                <button
+                                  aria-disabled={true}
+                                  aria-live="assertive"
+                                  className="pgn__stateful-btn pgn__stateful-btn-state-pageLoading download-button disabled btn btn-primary"
+                                  data-testid="module-activity-download"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="d-flex align-items-center justify-content-center"
+                                  >
+                                    <span
+                                      className="pgn__stateful-btn-icon"
+                                    >
+                                      <span
+                                        className="pgn__icon"
+                                        variant="light"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          fill="none"
+                                          focusable={false}
+                                          height={24}
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                          width={24}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M19 9h-4V3H9v6H5l7 7 7-7ZM5 18v2h14v-2H5Z"
+                                            fill="currentColor"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span>
+                                      Download module activity
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="pgn__data-table-container is-loading"
+                      data-testid="data-table-container"
+                    >
+                      <div
+                        className="pgn__data-table-spinner"
+                        data-testid="data-table-spinner"
+                      >
+                        <div
+                          className="pgn__spinner spinner-border"
+                          role="status"
+                        >
+                          <span
+                            className="sr-only"
+                          >
+                            loading
+                          </span>
+                        </div>
+                      </div>
+                      <table
+                        className="pgn__data-table is-striped"
+                        role="table"
+                      >
+                        <thead>
+                          <tr
+                            role="row"
+                          >
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Email
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Course Title
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Module
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Grade
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  % Activities Complete
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Learning Hours
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Log Views
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody
+                          role="rowgroup"
+                        />
+                      </table>
+                    </div>
+                    <div
+                      className="pgn__data-table-footer"
+                      data-testid="table-footer"
+                    >
+                      <nav
+                        aria-label="table pagination"
+                        className="pagination-minimal"
+                      >
+                        <div
+                          aria-atomic={true}
+                          aria-live="polite"
+                          aria-relevant="text"
+                          className="sr-only"
+                        >
+                          Page 1, Current Page, of -1
+                        </div>
+                        <ul
+                          className="pagination"
+                        >
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Previous"
+                              className="btn-icon btn-icon-primary btn-icon-md previous page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M17.51 3.87 15.73 2.1 5.84 12l9.9 9.9 1.77-1.77L9.38 12l8.13-8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Next, Page 2"
+                              className="btn-icon btn-icon-primary btn-icon-md next page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m6.49 20.13 1.77 1.77 9.9-9.9-9.9-9.9-1.77 1.77L14.62 12l-8.13 8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                        </ul>
+                      </nav>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -10811,106 +20256,355 @@ exports[`<Admin /> renders correctly with no dashboard insights data 1`] = `
       </div>
     </div>
     <div
-      className="row"
+      className="tabs-container"
     >
       <div
-        className="col"
+        className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
       >
-        <div
-          className="row pb-3"
+        Showing data as of 
+        July 31, 2018
+      </div>
+      <div>
+        <nav
+          className="pgn__tabs nav nav-tabs"
+          onKeyDown={[Function]}
+          role="tablist"
         >
-          <div
-            className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
-          >
-            Showing data as of 
-            July 31, 2018
-          </div>
-          <div
-            className="col-12 col-md-6 col-xl-8"
-          >
-            <button
-              className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
-              disabled={true}
-              onClick={[Function]}
-              type="button"
-            >
-              <svg
-                className="mr-2"
-                fill="none"
-                height={24}
-                viewBox="0 0 24 24"
-                width={24}
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
-                  fill="currentColor"
-                />
-              </svg>
-              Download full report (CSV)
-            </button>
-          </div>
-        </div>
-        <div
-          className="row"
-        >
-          <div
-            className="col-12 pr-md-0 mb-0"
+          <a
+            className="pgn__tab_more nav-item nav-link"
+            data-rb-event-key={null}
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
           >
             <div
-              className="row w-100 m-0"
+              className="pgn__dropdown pgn__dropdown-light dropdown"
+              data-testid="dropdown"
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="nav-link dropdown-toggle btn btn-link"
+                disabled={false}
+                id="pgn__tab-toggle"
+                onClick={[Function]}
+                type="button"
+              >
+                More...
+              </button>
+            </div>
+          </a>
+          <a
+            aria-selected={true}
+            className="pgn__tab_invisible nav-item nav-link active"
+            data-rb-event-key="learner-progress-report"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Learner Progress Report
+          </a>
+          <a
+            aria-selected={false}
+            className="pgn__tab_invisible nav-item nav-link"
+            data-rb-event-key="module-activity"
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Module Activity (Executive Education)
+          </a>
+        </nav>
+        <div
+          className="tab-content"
+        >
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          />
+          <div
+            aria-hidden={false}
+            aria-labelledby={null}
+            className="fade tab-pane active show"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="row"
             >
               <div
-                className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                className="col"
               >
                 <div
-                  className="pgn__form-group"
+                  className="row pb-3"
                 >
-                  <label
-                    className="pgn__form-label search-label mb-2"
-                    htmlFor="form-field51"
-                  >
-                    Filter by course
-                  </label>
                   <div
-                    className="pgn__form-control-decorator-group w-100"
+                    className="col-12 col-md-6 col-xl-8"
                   >
-                    <select
-                      className="form-control"
-                      id="form-field51"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <button
+                      className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
+                      disabled={true}
+                      onClick={[Function]}
+                      type="button"
                     >
-                      <option
-                        value=""
+                      <svg
+                        className="mr-2"
+                        fill="none"
+                        height={24}
+                        viewBox="0 0 24 24"
+                        width={24}
+                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        All Courses
-                      </option>
-                    </select>
+                        <path
+                          d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                      Download full report (CSV)
+                    </button>
                   </div>
                 </div>
-              </div>
-              <div
-                className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
-              >
                 <div
-                  className="pgn__form-group"
+                  className="row"
+                >
+                  <div
+                    className="col-12 pr-md-0 mb-0"
+                  >
+                    <div
+                      className="row w-100 m-0"
+                    >
+                      <div
+                        className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2"
+                            htmlFor="form-field77"
+                          >
+                            Filter by course
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              id="form-field77"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                All Courses
+                              </option>
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
+                      >
+                        <div
+                          className="pgn__form-group"
+                        >
+                          <label
+                            className="pgn__form-label search-label mb-2 d-flex align-items-center"
+                            htmlFor="form-field78"
+                          >
+                            <span>
+                              Filter by start date
+                            </span>
+                            <span
+                              alt="More information"
+                              className="pgn__icon ml-1"
+                              onBlur={[Function]}
+                              onFocus={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
+                            >
+                              <svg
+                                aria-hidden={true}
+                                fill="none"
+                                focusable={false}
+                                height={24}
+                                role="img"
+                                viewBox="0 0 24 24"
+                                width={24}
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                                  fill="currentColor"
+                                />
+                              </svg>
+                            </span>
+                          </label>
+                          <div
+                            className="pgn__form-control-decorator-group w-100"
+                          >
+                            <select
+                              className="form-control"
+                              disabled={true}
+                              id="form-field78"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              value=""
+                            >
+                              <option
+                                value=""
+                              >
+                                Choose a course
+                              </option>
+                              
+                            </select>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                      >
+                        <label
+                          className="pgn__form-label mb-2"
+                          id="search-email-label"
+                        >
+                          Filter by email
+                        </label>
+                        <div
+                          aria-labelledby="search-email-label"
+                          className="pgn__searchfield d-flex py-0"
+                          onSearch={[Function]}
+                        >
+                          <form
+                            className="pgn__searchfield-form"
+                            onReset={[Function]}
+                            onSubmit={[Function]}
+                            role="search"
+                          >
+                            <label
+                              className="m-0"
+                              htmlFor="pgn-searchfield-input-79"
+                            >
+                              <span
+                                className="sr-only"
+                              >
+                                search
+                              </span>
+                            </label>
+                            <input
+                              className="form-control"
+                              data-hj-suppress={true}
+                              disabled={false}
+                              id="pgn-searchfield-input-79"
+                              name="searchfield-input"
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder="Search by email..."
+                              role="searchbox"
+                              type="text"
+                              value=""
+                            />
+                            <button
+                              className="btn"
+                              disabled={false}
+                              type="submit"
+                            >
+                              <span
+                                className="pgn__icon"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  fill="none"
+                                  focusable={false}
+                                  height={24}
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  width={24}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                              </span>
+                              <span
+                                className="sr-only"
+                              >
+                                submit search
+                              </span>
+                            </button>
+                          </form>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="mt-3 mb-5"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="mt-3"
+            >
+              <div
+                className="pgn__searchfield d-flex mt-2 mb-2 w-25 "
+                onSearch={[Function]}
+              >
+                <form
+                  className="pgn__searchfield-form"
+                  onReset={[Function]}
+                  onSubmit={[Function]}
+                  role="search"
                 >
                   <label
-                    className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                    htmlFor="form-field52"
+                    className="m-0"
+                    htmlFor="pgn-searchfield-input-80"
                   >
-                    <span>
-                      Filter by start date
-                    </span>
                     <span
-                      alt="More information"
-                      className="pgn__icon ml-1"
-                      onBlur={[Function]}
-                      onFocus={[Function]}
-                      onMouseOut={[Function]}
-                      onMouseOver={[Function]}
+                      className="sr-only"
+                    >
+                      search
+                    </span>
+                  </label>
+                  <input
+                    className="form-control"
+                    disabled={false}
+                    id="pgn-searchfield-input-80"
+                    name="searchfield-input"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder="Search email or course title"
+                    role="searchbox"
+                    type="text"
+                    value=""
+                  />
+                  <button
+                    className="btn"
+                    disabled={false}
+                    type="submit"
+                  >
+                    <span
+                      className="pgn__icon"
                     >
                       <svg
                         aria-hidden={true}
@@ -10923,116 +20617,541 @@ exports[`<Admin /> renders correctly with no dashboard insights data 1`] = `
                         xmlns="http://www.w3.org/2000/svg"
                       >
                         <path
-                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                          d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
                           fill="currentColor"
                         />
                       </svg>
                     </span>
-                  </label>
-                  <div
-                    className="pgn__form-control-decorator-group w-100"
-                  >
-                    <select
-                      className="form-control"
-                      disabled={true}
-                      id="form-field52"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      value=""
+                    <span
+                      className="sr-only"
                     >
-                      <option
-                        value=""
-                      >
-                        Choose a course
-                      </option>
-                      
-                    </select>
-                  </div>
-                </div>
+                      submit search
+                    </span>
+                  </button>
+                </form>
               </div>
               <div
-                className="col-12 col-md-6 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                className="pgn__data-table-layout-wrapper"
               >
-                <label
-                  className="pgn__form-label mb-2"
-                  id="search-email-label"
-                >
-                  Filter by email
-                </label>
                 <div
-                  aria-labelledby="search-email-label"
-                  className="pgn__searchfield d-flex py-0"
-                  onSearch={[Function]}
+                  className="pgn__data-table-layout-main"
                 >
-                  <form
-                    className="pgn__searchfield-form"
-                    onReset={[Function]}
-                    onSubmit={[Function]}
-                    role="search"
+                  <div
+                    className="pgn__data-table-wrapper"
                   >
-                    <label
-                      className="m-0"
-                      htmlFor="pgn-searchfield-input-53"
+                    <div
+                      className="pgn__data-table-status-bar"
+                      data-testid="table-control-bar"
                     >
-                      <span
-                        className="sr-only"
+                      <div
+                        className="pgn__data-table-status"
                       >
-                        search
-                      </span>
-                    </label>
-                    <input
-                      className="form-control"
-                      data-hj-suppress={true}
-                      disabled={false}
-                      id="pgn-searchfield-input-53"
-                      name="searchfield-input"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder="Search by email..."
-                      role="searchbox"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      className="btn"
-                      disabled={false}
-                      type="submit"
-                    >
-                      <span
-                        className="pgn__icon"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="none"
-                          focusable={false}
-                          height={24}
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width={24}
-                          xmlns="http://www.w3.org/2000/svg"
+                        <div
+                          className="pgn__data-table-status-left"
+                        />
+                        <div
+                          className="pgn__data-table-actions-right"
                         >
-                          <path
-                            d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
-                            fill="currentColor"
+                          <div
+                            className="pgn__data-table-toggle"
                           />
-                        </svg>
-                      </span>
-                      <span
-                        className="sr-only"
+                          <div>
+                            <div
+                              className="pgn__table-actions"
+                              data-testid="table-actions"
+                            >
+                              <div
+                                className="pgn__datatable__visible-actions"
+                              >
+                                <button
+                                  aria-disabled={true}
+                                  aria-live="assertive"
+                                  className="pgn__stateful-btn pgn__stateful-btn-state-pageLoading download-button disabled btn btn-primary"
+                                  data-testid="module-activity-download"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="d-flex align-items-center justify-content-center"
+                                  >
+                                    <span
+                                      className="pgn__stateful-btn-icon"
+                                    >
+                                      <span
+                                        className="pgn__icon"
+                                        variant="light"
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          fill="none"
+                                          focusable={false}
+                                          height={24}
+                                          role="img"
+                                          viewBox="0 0 24 24"
+                                          width={24}
+                                          xmlns="http://www.w3.org/2000/svg"
+                                        >
+                                          <path
+                                            d="M19 9h-4V3H9v6H5l7 7 7-7ZM5 18v2h14v-2H5Z"
+                                            fill="currentColor"
+                                          />
+                                        </svg>
+                                      </span>
+                                    </span>
+                                    <span>
+                                      Download module activity
+                                    </span>
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="pgn__data-table-container is-loading"
+                      data-testid="data-table-container"
+                    >
+                      <div
+                        className="pgn__data-table-spinner"
+                        data-testid="data-table-spinner"
                       >
-                        submit search
-                      </span>
-                    </button>
-                  </form>
+                        <div
+                          className="pgn__spinner spinner-border"
+                          role="status"
+                        >
+                          <span
+                            className="sr-only"
+                          >
+                            loading
+                          </span>
+                        </div>
+                      </div>
+                      <table
+                        className="pgn__data-table is-striped"
+                        role="table"
+                      >
+                        <thead>
+                          <tr
+                            role="row"
+                          >
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Email
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Course Title
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Module
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Grade
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  % Activities Complete
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Learning Hours
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Log Views
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody
+                          role="rowgroup"
+                        />
+                      </table>
+                    </div>
+                    <div
+                      className="pgn__data-table-footer"
+                      data-testid="table-footer"
+                    >
+                      <nav
+                        aria-label="table pagination"
+                        className="pagination-minimal"
+                      >
+                        <div
+                          aria-atomic={true}
+                          aria-live="polite"
+                          aria-relevant="text"
+                          className="sr-only"
+                        >
+                          Page 1, Current Page, of -1
+                        </div>
+                        <ul
+                          className="pagination"
+                        >
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Previous"
+                              className="btn-icon btn-icon-primary btn-icon-md previous page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M17.51 3.87 15.73 2.1 5.84 12l9.9 9.9 1.77-1.77L9.38 12l8.13-8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                          <li
+                            className="page-item disabled"
+                          >
+                            <button
+                              aria-label="Next, Page 2"
+                              className="btn-icon btn-icon-primary btn-icon-md next page-link"
+                              disabled={true}
+                              onClick={[Function]}
+                              tabIndex="-1"
+                              type="button"
+                            >
+                              <span
+                                className="btn-icon__icon-container"
+                              >
+                                <span
+                                  className="pgn__icon btn-icon__icon"
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m6.49 20.13 1.77 1.77 9.9-9.9-9.9-9.9-1.77 1.77L14.62 12l-8.13 8.13Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </button>
+                          </li>
+                        </ul>
+                      </nav>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-        <div
-          className="mt-3 mb-5"
-        />
       </div>
     </div>
   </div>

--- a/src/components/Admin/data/hooks/index.js
+++ b/src/components/Admin/data/hooks/index.js
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { logError } from '@edx/frontend-platform/logging';
+import EnterpriseDataApiService from '../../../../data/services/EnterpriseDataApiService';
+
+const useModuleActivityReport = ({
+  enterpriseId, page, filters, searchQuery,
+}) => {
+  const [isLoading, setIsLoading] = useState(true);
+
+  const [paginationData, setPaginationData] = useState({
+    itemCount: 0,
+    pageCount: 0,
+    data: [],
+  });
+
+  useEffect(() => {
+    // Reset the loading state
+    setIsLoading(true);
+
+    EnterpriseDataApiService.fetchEnterpriseModuleActivityReport(enterpriseId, {
+      page: page + 1,
+      search: searchQuery,
+      ...filters,
+    })
+      .then((response) => {
+        setPaginationData({
+          itemCount: response.data.count,
+          pageCount: response.data.num_pages,
+          data: response.data.results,
+          currentPage: response.data.currentPage,
+        });
+
+        // Reset the loading state
+        setIsLoading(false);
+      })
+      .catch((err) => {
+        logError(err);
+
+        // Reset the loading state
+        setIsLoading(false);
+      });
+  }, [
+    enterpriseId,
+    page,
+    filters,
+    searchQuery,
+  ]);
+
+  return {
+    isLoading,
+    paginationData,
+  };
+};
+
+export default useModuleActivityReport;

--- a/src/components/Admin/index.jsx
+++ b/src/components/Admin/index.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
-import { Alert, Icon } from '@openedx/paragon';
+import {
+  Alert, Icon, Tab, Tabs,
+} from '@openedx/paragon';
 import { Error, Undo } from '@openedx/paragon/icons';
 import { Link } from 'react-router-dom';
 import {
@@ -31,8 +33,17 @@ import { withLocation, withParams } from '../../hoc';
 import AIAnalyticsSummary from './AIAnalyticsSummary';
 import AIAnalyticsSummarySkeleton from './AIAnalyticsSummarySkeleton';
 import BudgetExpiryAlertAndModal from '../BudgetExpiryAlertAndModal';
+import ModuleActivityReport from './tabs/ModuleActivityReport';
 
 class Admin extends React.Component {
+  constructor() {
+    super();
+
+    this.state = {
+      activeTab: 'learner-progress-report',
+    };
+  }
+
   componentDidMount() {
     const { enterpriseId } = this.props;
     if (enterpriseId) {
@@ -391,7 +402,10 @@ class Admin extends React.Component {
       location: { search },
       insights,
       insightsLoading,
+      intl,
     } = this.props;
+    const { activeTab } = this.state;
+
     const queryParams = new URLSearchParams(search || '');
     const queryParamsLength = Array.from(queryParams.entries()).length;
     const filtersActive = queryParamsLength !== 0 && !(queryParamsLength === 1 && queryParams.has('ordering'));
@@ -468,47 +482,79 @@ class Admin extends React.Component {
                   </div>
                 </div>
               </div>
-              <div className="row">
-                <div className="col">
-                  {!error && !loading && !this.hasEmptyData() && (
-                    <>
-                      <div className="row pb-3">
-                        <div className="col-12 col-md-6  col-xl-4 pt-1 pb-3">
-                          {lastUpdatedDate
-                            && (
-                              <FormattedMessage
-                                id="admin.portal.lpr.data.refreshed.date.message"
-                                defaultMessage="Showing data as of {timestamp}"
-                                description="Message to show the last updated date of the data on lpr page"
-                                values={{
-                                  timestamp: <FormattedDate
-                                    value={formatTimestamp({ timestamp: lastUpdatedDate })}
-                                    year="numeric"
-                                    month="long"
-                                    day="numeric"
-                                  />,
-                                }}
+
+              <div className="tabs-container">
+                <div className="col-12 col-md-6  col-xl-4 pt-1 pb-3">
+                  {lastUpdatedDate
+                    && (
+                      <FormattedMessage
+                        id="admin.portal.lpr.data.refreshed.date.message"
+                        defaultMessage="Showing data as of {timestamp}"
+                        description="Message to show the last updated date of the data on lpr page"
+                        values={{
+                          timestamp: <FormattedDate
+                            value={formatTimestamp({ timestamp: lastUpdatedDate })}
+                            year="numeric"
+                            month="long"
+                            day="numeric"
+                          />,
+                        }}
+                      />
+                    )}
+                </div>
+                <Tabs
+                  variant="tabs"
+                  activeKey={activeTab}
+                  onSelect={(tab) => {
+                    this.setState({ activeTab: tab });
+                  }}
+                >
+                  <Tab
+                    eventKey="learner-progress-report"
+                    title={intl.formatMessage({
+                      id: 'adminPortal.lpr.tab.learnerProgressReport.title',
+                      defaultMessage: 'Learner Progress Report',
+                      description: 'Title for the learner progress report tab in admin portal.',
+                    })}
+                  >
+                    <div className="row">
+                      <div className="col">
+                        {!error && !loading && !this.hasEmptyData() && (
+                          <>
+                            <div className="row pb-3">
+                              <div className="col-12 col-md-6 col-xl-8">
+                                {this.renderDownloadButton()}
+                              </div>
+                            </div>
+                            {this.displaySearchBar() && (
+                              <AdminSearchForm
+                                searchParams={searchParams}
+                                searchEnrollmentsList={() => this.props.searchEnrollmentsList()}
+                                tableData={this.getTableData() ? this.getTableData().results : []}
                               />
                             )}
-                        </div>
-                        <div className="col-12 col-md-6 col-xl-8">
-                          {this.renderDownloadButton()}
+                          </>
+                        )}
+                        {csvErrorMessage && this.renderCsvErrorMessage(csvErrorMessage)}
+                        <div className="mt-3 mb-5">
+                          {enterpriseId && tableMetadata.component}
                         </div>
                       </div>
-                      {this.displaySearchBar() && (
-                        <AdminSearchForm
-                          searchParams={searchParams}
-                          searchEnrollmentsList={() => this.props.searchEnrollmentsList()}
-                          tableData={this.getTableData() ? this.getTableData().results : []}
-                        />
-                      )}
-                    </>
-                  )}
-                  {csvErrorMessage && this.renderCsvErrorMessage(csvErrorMessage)}
-                  <div className="mt-3 mb-5">
-                    {enterpriseId && tableMetadata.component}
-                  </div>
-                </div>
+                    </div>
+                  </Tab>
+                  <Tab
+                    eventKey="module-activity"
+                    title={intl.formatMessage({
+                      id: 'adminPortal.lpr.tab.moduleActivity.title',
+                      defaultMessage: 'Module Activity (Executive Education)',
+                      description: 'Title for the module activity tab in admin portal.',
+                    })}
+                  >
+                    <div className="mt-3">
+                      <ModuleActivityReport enterpriseId={enterpriseId} />
+                    </div>
+                  </Tab>
+                </Tabs>
               </div>
             </div>
           </>

--- a/src/components/Admin/tabs/DownloadCSVButton.jsx
+++ b/src/components/Admin/tabs/DownloadCSVButton.jsx
@@ -1,0 +1,110 @@
+import React, { useState, useEffect } from 'react';
+import { saveAs } from 'file-saver';
+import PropTypes from 'prop-types';
+import { useIntl } from '@edx/frontend-platform/i18n';
+
+import {
+  Toast, StatefulButton, Icon, Spinner, useToggle,
+} from '@openedx/paragon';
+import { Download, Check } from '@openedx/paragon/icons';
+import { logError } from '@edx/frontend-platform/logging';
+
+const DownloadCsvButton = ({ data, testId, fetchData }) => {
+  const [buttonState, setButtonState] = useState('pageLoading');
+  const [isOpen, open, close] = useToggle(false);
+  const intl = useIntl();
+
+  useEffect(() => {
+    if (data && data.length) {
+      setButtonState('default');
+    }
+  }, [data]);
+
+  const getCsvFileName = () => {
+    const currentDate = new Date();
+    const year = currentDate.getUTCFullYear();
+    const month = currentDate.getUTCMonth() + 1;
+    const day = currentDate.getUTCDate();
+    return `${year}-${month}-${day}-module-activity-report.csv`;
+  };
+
+  const handleClick = async () => {
+    fetchData().then((response) => {
+      setButtonState('pending');
+      const blob = new Blob([response.data], {
+        type: 'text/csv',
+      });
+      saveAs(blob, getCsvFileName());
+      open();
+      setButtonState('complete');
+    }).catch((err) => {
+      logError(err);
+    });
+  };
+
+  const toastText = intl.formatMessage({
+    id: 'adminPortal.LPR.moduleActivityReport.download.toast',
+    defaultMessage: 'Downloaded module activity report of your learners.',
+    description: 'Toast message for the download button in the module activity report page.',
+  });
+  return (
+    <>
+      { isOpen
+     && (
+     <Toast onClose={close} show={isOpen}>
+       {toastText}
+     </Toast>
+     )}
+      <StatefulButton
+        state={buttonState}
+        className="download-button"
+        data-testid={testId}
+        labels={{
+          default: intl.formatMessage({
+            id: 'adminPortal.LPR.moduleActivityReport.download.button',
+            defaultMessage: 'Download module activity',
+            description: 'Label for the download button in the module activity report page.',
+          }),
+          pending: intl.formatMessage({
+            id: 'adminPortal.LPR.moduleActivityReport.download.button.pending',
+            defaultMessage: 'Downloading',
+            description: 'Label for the download button in the module activity report page when the download is in progress.',
+          }),
+          complete: intl.formatMessage({
+            id: 'adminPortal.LPR.moduleActivityReport.download.button.complete',
+            defaultMessage: 'Downloaded',
+            description: 'Label for the download button in the module activity report page when the download is complete.',
+          }),
+          pageLoading: intl.formatMessage({
+            id: 'adminPortal.LPR.moduleActivityReport.download.button.loading',
+            defaultMessage: 'Download module activity',
+            description: 'Label for the download button in the module activity report page when the page is loading.',
+          }),
+        }}
+        icons={{
+          default: <Icon src={Download} />,
+          pending: <Spinner animation="border" variant="light" size="sm" />,
+          complete: <Icon src={Check} />,
+          pageLoading: <Icon src={Download} variant="light" />,
+        }}
+        disabledStates={['pending', 'pageLoading']}
+        onClick={handleClick}
+      />
+    </>
+  );
+};
+
+DownloadCsvButton.defaultProps = {
+  testId: 'download-csv-button',
+};
+
+DownloadCsvButton.propTypes = {
+  // eslint-disable-next-line react/forbid-prop-types
+  data: PropTypes.arrayOf(
+    PropTypes.object,
+  ),
+  fetchData: PropTypes.func.isRequired,
+  testId: PropTypes.string,
+};
+
+export default DownloadCsvButton;

--- a/src/components/Admin/tabs/DownloadCsvButton.test.jsx
+++ b/src/components/Admin/tabs/DownloadCsvButton.test.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { logError } from '@edx/frontend-platform/logging';
+import { act, render, screen } from '@testing-library/react';
+import { saveAs } from 'file-saver';
+
+import '@testing-library/jest-dom/extend-expect';
+
+import userEvent from '@testing-library/user-event';
+import DownloadCSVButton from './DownloadCSVButton';
+
+jest.mock('file-saver', () => ({
+  ...jest.requireActual('file-saver'),
+  saveAs: jest.fn(),
+}));
+
+jest.mock('@edx/frontend-platform/logging', () => ({
+  ...jest.requireActual('@edx/frontend-platform/logging'),
+  logError: jest.fn(),
+}));
+
+const getMockData = ({ count }) => {
+  const data = [];
+  for (let i = 0; i < count; i++) {
+    data.push({
+      module_performance_unique_id: i,
+      username: `Email ${i}`,
+      course_name: `Course ${i}`,
+      module_name: `Module ${i}`,
+      module_grade: `Module Grade ${i}`,
+      percentage_completed_activities: `${(i % 100)}%`,
+      hours_online: `${i} Hours Online`,
+      log_viewed: `${i} Log Views`,
+    });
+  }
+  return data;
+};
+
+const DEFAULT_PROPS = {
+  data: getMockData({ count: 10 }),
+  testId: 'test-id-1',
+  fetchData: jest.fn(() => Promise.resolve({ data: 'name\ntest-csv-file' })),
+};
+
+const DownloadCSVButtonWrapper = props => (
+  <IntlProvider locale="en">
+    <DownloadCSVButton {...props} />
+  </IntlProvider>
+);
+
+describe('DownloadCSVButton', () => {
+  const flushPromises = () => new Promise(setImmediate);
+
+  it('renders download csv button correctly.', async () => {
+    render(<DownloadCSVButtonWrapper {...DEFAULT_PROPS} />);
+    expect(screen.getByTestId('test-id-1')).toBeInTheDocument();
+
+    // Click the download button.
+    screen.getByTestId('test-id-1').click();
+    await flushPromises();
+
+    expect(DEFAULT_PROPS.fetchData).toHaveBeenCalled();
+    expect(saveAs).toHaveBeenCalled();
+  });
+  it('download button should handle error returned by the API endpoint.', async () => {
+    const props = {
+      ...DEFAULT_PROPS,
+      fetchData: jest.fn(() => Promise.reject(new Error('Error fetching data'))),
+    };
+    render(<DownloadCSVButtonWrapper {...props} />);
+    expect(screen.getByTestId('test-id-1')).toBeInTheDocument();
+
+    act(() => {
+      // Click the download button.
+      userEvent.click(screen.getByTestId('test-id-1'));
+    });
+
+    await flushPromises();
+
+    expect(DEFAULT_PROPS.fetchData).toHaveBeenCalled();
+    expect(logError).toHaveBeenCalled();
+  });
+});

--- a/src/components/Admin/tabs/ModuleActivityReport.jsx
+++ b/src/components/Admin/tabs/ModuleActivityReport.jsx
@@ -1,0 +1,170 @@
+import React, { useState, useCallback } from 'react';
+import { DataTable } from '@openedx/paragon';
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import EnterpriseDataApiService from '../../../data/services/EnterpriseDataApiService';
+import DownloadCsvButton from './DownloadCSVButton';
+import useModuleActivityReport from '../data/hooks';
+import SearchBar from '../../SearchBar';
+
+const ModuleActivityReport = ({ enterpriseId }) => {
+  const [currentPage, setCurrentPage] = useState(0);
+  const [currentFilters, setCurrentFilters] = useState({});
+  const [searchQuery, setSearchQuery] = useState('');
+  const { isLoading, paginationData } = useModuleActivityReport({
+    enterpriseId, page: currentPage, filters: currentFilters, searchQuery,
+  });
+  const intl = useIntl();
+
+  const fetchData = useCallback(
+    (args) => {
+      let newFilters = { ...currentFilters };
+      // disable pagination and sorting if the search query is not empty
+      const sortBy = args.sortBy.at(-1);
+      if (!_.isEmpty(sortBy)) {
+        const newSortBys = { ordering: `${sortBy.desc ? '-' : ''}${sortBy.id}` };
+        newFilters = { ...newFilters, ...newSortBys };
+      }
+
+      if (!_.isEqual(newFilters, currentFilters)) {
+        setCurrentFilters(newFilters);
+      }
+      if (args.pageIndex !== currentPage) {
+        setCurrentPage(args.pageIndex);
+      }
+    },
+    [currentFilters, currentPage, setCurrentFilters, setCurrentPage],
+  );
+  const onSearch = (query) => {
+    if (!_.isEqual(query, searchQuery)) {
+      setCurrentPage(0);
+      setSearchQuery(query);
+    }
+  };
+
+  const fetchCsvData = async () => EnterpriseDataApiService.fetchEnterpriseModuleActivityReport(
+    enterpriseId,
+    { ...currentFilters, search: searchQuery },
+    { csv: true },
+  );
+
+  return (
+    <>
+      <SearchBar
+        onSearch={_.debounce(onSearch, 500)}
+        onClear={() => onSearch('')}
+        onChange={_.debounce(onSearch, 500)}
+        className="mt-2 mb-2 w-25 "
+        placeholder={intl.formatMessage({
+          id: 'adminPortal.LPR.moduleActivityReport.search.placeholder',
+          defaultMessage: 'Search email or course title',
+          description: 'Placeholder text for the search input in the module activity report page.',
+        })}
+      />
+      <DataTable
+        isLoading={isLoading}
+        SelectionStatusComponent={DataTable.ControlledSelectionStatus}
+        isPaginated
+        manualPagination
+        isSortable
+        manualSortBy
+        initialState={{
+          pageSize: 50,
+          pageIndex: 0,
+        }}
+        initialTableOptions={{
+          getRowId: row => row.module_performance_unique_id,
+        }}
+        itemCount={paginationData.itemCount}
+        pageCount={paginationData.pageCount}
+        fetchData={fetchData}
+        data={paginationData.data}
+        columns={[
+          {
+            Header: intl.formatMessage({
+              id: 'adminPortal.LPR.moduleActivityReport.table.header.username',
+              defaultMessage: 'Email',
+              description: 'Header for the email column in the module activity report table',
+            }),
+            accessor: 'username',
+          },
+          {
+            Header: intl.formatMessage({
+              id: 'adminPortal.LPR.moduleActivityReport.table.header.course',
+              defaultMessage: 'Course Title',
+              description: 'Header for the course title column in the module activity report table',
+            }),
+            accessor: 'course_name',
+          },
+          {
+            Header: intl.formatMessage({
+              id: 'adminPortal.LPR.moduleActivityReport.table.header.module',
+              defaultMessage: 'Module',
+              description: 'Header for the module title column in the module activity report table',
+
+            }),
+            accessor: 'module_name',
+          },
+          {
+            Header: intl.formatMessage({
+              id: 'adminPortal.LPR.moduleActivityReport.table.header.moduleGrade',
+              defaultMessage: 'Grade',
+              description: 'Header for the module grade column in the module activity report table',
+
+            }),
+            accessor: 'module_grade',
+          },
+          {
+            Header: intl.formatMessage({
+              id: 'adminPortal.LPR.moduleActivityReport.table.header.percentageCompletedActivities',
+              defaultMessage: '% Activities Complete',
+              description: 'Header for the percentage of activities completed column in the module activity report table',
+            }),
+            accessor: 'percentage_completed_activities',
+          },
+          {
+            Header: intl.formatMessage({
+              id: 'adminPortal.LPR.moduleActivityReport.table.header.hoursOnline',
+              defaultMessage: 'Learning Hours',
+              description: 'Header for the learning hours column in the module activity report table',
+            }),
+            accessor: 'hours_online',
+          },
+          {
+            Header: intl.formatMessage({
+              id: 'adminPortal.LPR.moduleActivityReport.table.header.logViewed',
+              defaultMessage: 'Log Views',
+              description: 'Header for the log views column in the module activity report table',
+            }),
+            accessor: 'log_viewed',
+          },
+        ]}
+        tableActions={[
+          <DownloadCsvButton
+            fetchData={fetchCsvData}
+            data={paginationData.data}
+            testId="module-activity-download"
+          />,
+        ]}
+      >
+        <DataTable.TableControlBar />
+        <DataTable.Table />
+        <DataTable.EmptyTable
+          content={intl.formatMessage({
+            id: 'adminPortal.LPR.moduleActivityReport.table.empty',
+            defaultMessage: 'No results found.',
+            description: 'Message displayed when the module activity report table is empty',
+          })}
+        />
+        <DataTable.TableFooter />
+      </DataTable>
+    </>
+  );
+};
+
+ModuleActivityReport.propTypes = {
+  enterpriseId: PropTypes.string,
+};
+
+export default ModuleActivityReport;

--- a/src/components/Admin/tabs/ModuleActivityReport.test.jsx
+++ b/src/components/Admin/tabs/ModuleActivityReport.test.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import ModuleActivityReport from './ModuleActivityReport';
+import { TEST_ENTERPRISE_CUSTOMER_SLUG } from '../../subscriptions/tests/TestUtilities';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: jest.fn(),
+  useNavigate: jest.fn(),
+}));
+
+const DEFAULT_PROPS = {
+  enterpriseId: TEST_ENTERPRISE_CUSTOMER_SLUG,
+};
+const getMockData = ({ count }) => {
+  const data = [];
+  for (let i = 0; i < count; i++) {
+    data.push({
+      module_performance_unique_id: i,
+      username: `Email ${i}`,
+      course_name: `Course ${i}`,
+      module_name: `Module ${i}`,
+      module_grade: `Module Grade ${i}`,
+      percentage_completed_activities: `${(i % 100)}%`,
+      hours_online: `${i} Hours Online`,
+      log_viewed: `${i} Log Views`,
+    });
+  }
+  return data;
+};
+
+jest.mock('../data/hooks', () => (
+  jest.fn(() => ({
+    isLoading: false,
+    paginationData: {
+      itemCount: 500,
+      pageCount: 5,
+      data: getMockData(500),
+    },
+  }))
+));
+
+const ModuleActivityReportWrapper = props => (
+  <IntlProvider locale="en">
+    <ModuleActivityReport {...props} />
+  </IntlProvider>
+);
+
+describe('ModuleActivityReport', () => {
+  it('renders the module activity report correctly when table is empty.', async () => {
+    render(<ModuleActivityReportWrapper {...DEFAULT_PROPS} />);
+    expect(screen.getByText('Email')).toBeInTheDocument();
+    expect(screen.getByText('Course Title')).toBeInTheDocument();
+    expect(screen.getByText('Module')).toBeInTheDocument();
+    expect(screen.getByText('Grade')).toBeInTheDocument();
+    expect(screen.getByText('% Activities Complete')).toBeInTheDocument();
+    expect(screen.getByText('Learning Hours')).toBeInTheDocument();
+    expect(screen.getByText('Log Views')).toBeInTheDocument();
+  });
+});

--- a/src/data/services/EnterpriseDataApiService.js
+++ b/src/data/services/EnterpriseDataApiService.js
@@ -142,6 +142,24 @@ class EnterpriseDataApiService {
     const url = `${EnterpriseDataApiService.enterpriseAdminBaseUrl}insights/${enterpriseUUID}`;
     return EnterpriseDataApiService.apiClient().get(url);
   }
+
+  static fetchEnterpriseModuleActivityReport(enterpriseId, options, { csv } = {}) {
+    const enterpriseUUID = EnterpriseDataApiService.getEnterpriseUUID(enterpriseId);
+    const endpoint = csv ? 'module-performance.csv' : 'module-performance';
+
+    const queryParams = new URLSearchParams({
+      page: 1,
+      page_size: 50,
+      ...options,
+    });
+
+    if (csv) {
+      queryParams.set('no_page', csv);
+    }
+
+    const url = `${EnterpriseDataApiService.enterpriseBaseUrl}${enterpriseUUID}/${endpoint}/?${queryParams.toString()}`;
+    return EnterpriseDataApiService.apiClient().get(url);
+  }
 }
 
 export default EnterpriseDataApiService;


### PR DESCRIPTION
__Jira Ticket:__ [ENT-8186](https://2u-internal.atlassian.net/browse/ENT-8186)

__Description:__
This PR adds the UI components (DataTable) for module activity report on admin portal. 

**Note**: This PR depends on the presence of `/enterprise/api/v1/enterprise/<enterprise-customer-uui>/module-performance` and that in turn requires `exec_ed_lc_module_performance` on Aurora. So, this PR will only be merged and deployed when the table is present and the endpoint is returning correct data.

**Screenshots:**
<img width="1440" alt="Screenshot 2024-08-12 at 3 16 04 PM" src="https://github.com/user-attachments/assets/cd3a2a10-87f8-4f0b-ae19-1fe370217874">
<img width="1436" alt="Screenshot 2024-08-12 at 3 16 11 PM" src="https://github.com/user-attachments/assets/81b8a995-e1e1-490c-a533-8f94e4a86195">

When REST endpoint returns empty data set.
<img width="1451" alt="Screenshot 2024-08-12 at 3 17 17 PM" src="https://github.com/user-attachments/assets/677f5ec6-2f8b-4198-bbe5-63f81ded4754">


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
