### PR TITLE
fix: reference correct track event name

### DIFF
--- a/src/components/learner-credit-management/assignment-modal/AssignmentModalContent.jsx
+++ b/src/components/learner-credit-management/assignment-modal/AssignmentModalContent.jsx
@@ -4,12 +4,7 @@ import React, {
 import PropTypes from 'prop-types';
 import debounce from 'lodash.debounce';
 import {
-  Container,
-  Stack,
-  Row,
-  Col,
-  Form,
-  Card,
+  Card, Col, Container, Form, Row, Stack,
 } from '@openedx/paragon';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
@@ -56,7 +51,7 @@ const AssignmentModalContent = ({ enterpriseId, course, onEmailAddressesChange }
     debouncedHandleEmailAddressesChanged(emailAddressesInputValue);
   }, [emailAddressesInputValue, debouncedHandleEmailAddressesChanged]);
 
-  // Validate the learner emails emails from user input whenever it changes
+  // Validate the learner emails from user input whenever it changes
   useEffect(() => {
     const allocationMetadata = isAssignEmailAddressesInputValueValid({
       learnerEmails,
@@ -67,7 +62,7 @@ const AssignmentModalContent = ({ enterpriseId, course, onEmailAddressesChange }
     if (allocationMetadata.validationError?.reason) {
       sendEnterpriseTrackEvent(
         enterpriseId,
-        EVENT_NAMES.LEARNER_CREDIT_MANAGEMENT.EMAIL_ADDRESS_VALIDATION,
+        EVENT_NAMES.LEARNER_CREDIT_MANAGEMENT.ASSIGNMENT_EMAIL_ADDRESS_VALIDATION,
         { validationErrorReason: allocationMetadata.validationError.reason },
       );
     }


### PR DESCRIPTION
Updates track event name used in segment events to an existing track event name. Issue derived from the following DD error. 
![Screenshot 2024-08-12 at 9 38 19 AM](https://github.com/user-attachments/assets/2d4e79f3-20c0-427a-9761-744a8f09ff08)

The event name has [always existed](https://github.com/openedx/frontend-app-admin-portal/blob/67f42b70c27d561d8c79f09f77654ed46f1ff449/src/eventTracking.js#L176) but was incorrectly referenced. 

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
