### PR TITLE
fix: allow catalog selection in reporting config form

### DIFF
--- a/src/components/ReportingConfig/ReportingConfigForm.jsx
+++ b/src/components/ReportingConfig/ReportingConfigForm.jsx
@@ -498,6 +498,7 @@ class ReportingConfigForm extends React.Component {
             </Form.Label>
             <Form.Control
               as="select"
+              name="enterpriseCustomerCatalogUuids"
               multiple
               defaultValue={selectedCatalogs}
             >


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-9413

Tested with https://localhost.stage.edx.org:1991/aj-test-co/admin/reporting

Prior to change - catalog selections were not persisting upon saving after reloading the page. After adding back the missing name attribute, the catalog selections are now persisting.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
