### PR TITLE
feat: surface time in the enroll-by date column

### DIFF
--- a/src/components/learner-credit-management/AssignmentEnrollByDateCell.jsx
+++ b/src/components/learner-credit-management/AssignmentEnrollByDateCell.jsx
@@ -1,10 +1,8 @@
 import PropTypes from 'prop-types';
-import {
-  Icon, IconButtonWithTooltip, Stack,
-} from '@openedx/paragon';
+import { Icon, IconButtonWithTooltip, Stack } from '@openedx/paragon';
 import { Warning } from '@openedx/paragon/icons';
 import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
-import { ENROLL_BY_DATE_DAYS_THRESHOLD, formatDate } from './data';
+import { DATETIME_FORMAT, ENROLL_BY_DATE_DAYS_THRESHOLD, formatDate } from './data';
 import { isTodayWithinDateThreshold } from '../../utils';
 
 const messages = defineMessages({
@@ -33,7 +31,7 @@ const ExpiringIconButtonWithTooltip = () => {
 const AssignmentEnrollByDateCell = ({ row }) => {
   const { original: { earliestPossibleExpiration: { date } } } = row;
 
-  const formattedEnrollByDate = formatDate(date);
+  const formattedEnrollByDate = formatDate(date, DATETIME_FORMAT);
   const isAssignmentExpiringSoon = isTodayWithinDateThreshold({
     days: ENROLL_BY_DATE_DAYS_THRESHOLD,
     date,

--- a/src/components/learner-credit-management/AssignmentEnrollByDateHeader.jsx
+++ b/src/components/learner-credit-management/AssignmentEnrollByDateHeader.jsx
@@ -11,7 +11,7 @@ const messages = defineMessages({
   },
   headerTooltipContent: {
     id: 'lcm.budget.detail.page.assignments.table.columns.enroll-by-date.header.tooltip-content',
-    defaultMessage: 'Failure to enroll by the enrollment deadline date will release funds back into the budget',
+    defaultMessage: 'Failure to enroll by the enrollment deadline will release funds back into the budget',
     description: 'On hover tool tip message for the enroll-by date column',
   },
 });

--- a/src/components/learner-credit-management/AssignmentEnrollByDateHeader.jsx
+++ b/src/components/learner-credit-management/AssignmentEnrollByDateHeader.jsx
@@ -1,9 +1,5 @@
 import React from 'react';
-import {
-  Stack,
-  Icon,
-  IconButtonWithTooltip,
-} from '@openedx/paragon';
+import { Icon, IconButtonWithTooltip, Stack } from '@openedx/paragon';
 import { InfoOutline } from '@openedx/paragon/icons';
 import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
 
@@ -15,7 +11,7 @@ const messages = defineMessages({
   },
   headerTooltipContent: {
     id: 'lcm.budget.detail.page.assignments.table.columns.enroll-by-date.header.tooltip-content',
-    defaultMessage: 'Failure to enroll by midnight of enrollment deadline date will release funds back into the budget',
+    defaultMessage: 'Failure to enroll by the enrollment deadline date will release funds back into the budget',
     description: 'On hover tool tip message for the enroll-by date column',
   },
 });

--- a/src/components/learner-credit-management/data/constants.js
+++ b/src/components/learner-credit-management/data/constants.js
@@ -38,7 +38,7 @@ export const NO_BALANCE_REMAINING_DOLLAR_THRESHOLD = 100;
 
 export const DATE_FORMAT = 'MMMM DD, YYYY';
 
-export const SHORT_MONTH_DATE_FORMAT = 'MMM DD, YYYY';
+export const SHORT_MONTH_DATE_FORMAT = 'MMM D, YYYY';
 export const DATETIME_FORMAT = 'MMM D, YYYY h:mma';
 
 export const EXEC_ED_OFFER_TYPE = 'learner_credit';

--- a/src/components/learner-credit-management/data/utils.js
+++ b/src/components/learner-credit-management/data/utils.js
@@ -280,11 +280,12 @@ export const orderBudgets = (intl, budgets) => {
 
 /**
  * Formats a date string to MMM D, YYYY format.
- * @param {string} date Date string.
- * @returns Formatted date string.
+ * @param {string} date
+ * @param {string} format
+ * @returns {string}
  */
-export function formatDate(date) {
-  return dayjs(date).format('MMM D, YYYY');
+export function formatDate(date, format = 'MMM D, YYYY') {
+  return dayjs(date).format(format);
 }
 
 // Exec ed and open courses cards should display either the enrollment deadline

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -17,21 +17,21 @@ import EnterpriseAccessApiService from '../../../data/services/EnterpriseAccessA
 
 import BudgetDetailPage from '../BudgetDetailPage';
 import {
+  DEFAULT_PAGE,
   formatDate,
   formatPrice,
+  PAGE_SIZE,
   useBudgetContentAssignments,
   useBudgetDetailActivityOverview,
   useBudgetRedemptions,
   useEnterpriseCustomer,
   useEnterpriseGroup,
   useEnterpriseGroupLearners,
-  useEnterpriseRemovedGroupMembers,
   useEnterpriseOffer,
+  useEnterpriseRemovedGroupMembers,
   useIsLargeOrGreater,
   useSubsidyAccessPolicy,
   useSubsidySummaryAnalyticsApi,
-  DEFAULT_PAGE,
-  PAGE_SIZE,
 } from '../data';
 import { EnterpriseSubsidiesContext } from '../../EnterpriseSubsidiesContext';
 import {
@@ -2573,7 +2573,7 @@ describe('<BudgetDetailPage />', () => {
 
     userEvent.hover(enrollByDateTooltip);
     await waitFor(() => expect(screen.getByText(
-      'Failure to enroll by midnight of enrollment deadline date will release funds back into the budget',
+      'Failure to enroll by the enrollment deadline will release funds back into the budget',
     )).toBeTruthy());
   });
 });


### PR DESCRIPTION
Surfaces the enroll by date time within the learner credit allocation table.
Updates the text within the enroll by tool tip to remove any indication of time. 

![Screenshot 2024-09-18 at 1 26 05 PM](https://github.com/user-attachments/assets/bd4ee1b7-c534-42ec-a661-46967f786dde)


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
