### PR TITLE
fix: Update threshold dates for displaying course runs

### DIFF
--- a/__mocks__/react-instantsearch-dom.jsx
+++ b/__mocks__/react-instantsearch-dom.jsx
@@ -13,11 +13,14 @@ const mockEndDate = dayjs().add(2, 'years').toISOString();
 const mockEnrollByDate = dayjs().add(9, 'months').toISOString();
 const mockEnrollByTimestamp = dayjs(mockEnrollByDate).unix();
 const mockUpgradeDeadlineTimestamp = dayjs().add(3, 'months').unix();
+const mockEnrollStartDate = dayjs().add(2, 'months').toISOString();
+const mockEnrollStartTimestamp = dayjs(mockEnrollStartDate).unix();
 
 const mockNormalizedData = {
   start_date: mockCurrentStartDate,
   end_date: mockEndDate,
   enroll_by_date: mockEnrollByDate,
+  enroll_start_date: mockEnrollStartDate,
 };
 
 /* eslint-disable camelcase */
@@ -36,6 +39,8 @@ const fakeHits = [
       end: mockEndDate,
       enroll_by: mockEnrollByTimestamp,
       has_enroll_by: true,
+      enroll_start: mockEnrollStartTimestamp,
+      has_enroll_start: true,
       is_active: true,
       max_effort: 5,
       min_effort: 1,
@@ -53,6 +58,8 @@ const fakeHits = [
         end: mockEndDate,
         enroll_by: mockEnrollByTimestamp,
         has_enroll_by: true,
+        enroll_start: mockEnrollStartTimestamp,
+        has_enroll_start: true,
         is_active: true,
         max_effort: 5,
         min_effort: 1,
@@ -67,6 +74,8 @@ const fakeHits = [
         end: dayjs('2020-09-09T04:00:00Z').add(1, 'year').toISOString(),
         enroll_by: mockEnrollByTimestamp,
         has_enroll_by: true,
+        enroll_start: mockEnrollStartTimestamp,
+        has_enroll_start: true,
         is_active: true,
         max_effort: 5,
         min_effort: 1,
@@ -90,6 +99,8 @@ const fakeHits = [
       end: mockEndDate,
       enroll_by: mockEnrollByTimestamp,
       has_enroll_by: true,
+      enroll_start: mockEnrollStartTimestamp,
+      has_enroll_start: true,
       is_active: true,
       max_effort: 5,
       min_effort: 1,
@@ -107,6 +118,8 @@ const fakeHits = [
         end: dayjs('2022-10-09T04:00:00Z').add(1, 'year').toISOString(),
         enroll_by: mockEnrollByTimestamp,
         has_enroll_by: true,
+        enroll_start: mockEnrollStartTimestamp,
+        has_enroll_start: true,
         is_active: true,
         max_effort: 5,
         min_effort: 1,

--- a/src/components/learner-credit-management/assignment-modal/NewAssignmentModalButton.jsx
+++ b/src/components/learner-credit-management/assignment-modal/NewAssignmentModalButton.jsx
@@ -1,29 +1,26 @@
-import React, { useCallback, useContext, useState } from 'react';
-import PropTypes from 'prop-types';
-import { generatePath, useNavigate, useParams } from 'react-router-dom';
+import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
+import { getConfig } from '@edx/frontend-platform/config';
+import { camelCaseObject, snakeCaseObject } from '@edx/frontend-platform/utils';
 import {
   ActionRow, Button, FullscreenModal, Hyperlink, StatefulButton, useToggle,
 } from '@openedx/paragon';
-import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { camelCaseObject, snakeCaseObject } from '@edx/frontend-platform/utils';
+import PropTypes from 'prop-types';
+import React, { useCallback, useContext, useState } from 'react';
 import { connect } from 'react-redux';
-import { getConfig } from '@edx/frontend-platform/config';
+import { generatePath, useNavigate, useParams } from 'react-router-dom';
 
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import { logError } from '@edx/frontend-platform/logging';
-import AssignmentModalContent from './AssignmentModalContent';
 import EnterpriseAccessApiService from '../../../data/services/EnterpriseAccessApiService';
+import EVENT_NAMES from '../../../eventTracking';
+import { BudgetDetailPageContext } from '../BudgetDetailPageWrapper';
 import {
-  getAssignableCourseRuns,
-  LEARNER_CREDIT_ROUTE,
-  learnerCreditManagementQueryKeys,
-  useBudgetId,
+  getAssignableCourseRuns, learnerCreditManagementQueryKeys, LEARNER_CREDIT_ROUTE, useBudgetId,
   useSubsidyAccessPolicy,
 } from '../data';
+import AssignmentModalContent from './AssignmentModalContent';
 import CreateAllocationErrorAlertModals from './CreateAllocationErrorAlertModals';
-import { BudgetDetailPageContext } from '../BudgetDetailPageWrapper';
-import EVENT_NAMES from '../../../eventTracking';
 import NewAssignmentModalDropdown from './NewAssignmentModalDropdown';
 
 const useAllocateContentAssignments = () => useMutation({
@@ -88,7 +85,7 @@ const NewAssignmentModalButton = ({ enterpriseId, course, children }) => {
     setAssignmentRun(selectedCourseRun);
     if (!selectedCourseRun) {
       logError(`[handleOpenAssignmentModal]: Unable to open learner credit management allocation modal,
-        selectedCourseRun: ${selectedCourseRun}, 
+        selectedCourseRun: ${selectedCourseRun},
         parentContentKey: ${course.key},
         contentKey: ${selectedCourseRun.key},
         enterpriseUuid: ${enterpriseId},

--- a/src/components/learner-credit-management/assignment-modal/NewAssignmentModalDropdown.jsx
+++ b/src/components/learner-credit-management/assignment-modal/NewAssignmentModalDropdown.jsx
@@ -1,7 +1,7 @@
+import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
 import { Dropdown, Stack } from '@openedx/paragon';
 import dayjs from 'dayjs';
 import PropTypes from 'prop-types';
-import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
 import { useState } from 'react';
 import { SHORT_MONTH_DATE_FORMAT } from '../data';
 
@@ -29,7 +29,10 @@ const messages = defineMessages({
 });
 
 const NewAssignmentModalDropdown = ({
-  id: courseKey, onClick: openAssignmentModal, courseRuns, children,
+  id: courseKey,
+  onClick: openAssignmentModal,
+  courseRuns,
+  children,
 }) => {
   const intl = useIntl();
   const [clickedDropdownItem, setClickedDropdownItem] = useState(null);

--- a/src/components/learner-credit-management/cards/tests/CourseCard.test.jsx
+++ b/src/components/learner-credit-management/cards/tests/CourseCard.test.jsx
@@ -51,9 +51,11 @@ jest.mock('../../data', () => ({
 }));
 jest.mock('../../../../data/services/EnterpriseAccessApiService');
 
-const futureStartDate = dayjs().add(5, 'days').toISOString();
-const pastStartDate = dayjs().subtract(5, 'days').toISOString();
-const enrollByTimestamp = dayjs().add(2, 'days').unix();
+const futureStartDate = dayjs().add(10, 'days').toISOString();
+const pastStartDate = dayjs().subtract(10, 'days').toISOString();
+const enrollStartDate = dayjs().add(3, 'days').toISOString();
+const enrollStartTimestamp = dayjs(enrollStartDate).unix();
+const enrollByTimestamp = dayjs().add(5, 'days').unix();
 const enrollByDropdownText = `Enroll by ${dayjs.unix(enrollByTimestamp).format(SHORT_MONTH_DATE_FORMAT)}`;
 
 const originalData = {
@@ -64,6 +66,7 @@ const originalData = {
   normalized_metadata: {
     enroll_by_date: dayjs.unix(1892678399).toISOString(),
     start_date: futureStartDate,
+    enroll_start_date: enrollStartDate,
     content_price: 100,
   },
   original_image_url: '',
@@ -77,6 +80,8 @@ const originalData = {
       pacing_type: 'self_paced',
       enroll_by: enrollByTimestamp,
       has_enroll_by: true,
+      enroll_start: enrollStartTimestamp,
+      has_enroll_start: true,
       is_active: true,
       weeks_to_complete: 60,
       end: dayjs().add(1, 'years').toISOString(),
@@ -90,6 +95,8 @@ const originalData = {
     pacing_type: 'self_paced',
     enroll_by: enrollByTimestamp,
     has_enroll_by: true,
+    enroll_start: enrollStartTimestamp,
+    has_enroll_start: true,
     is_active: true,
     weeks_to_complete: 60,
     end: dayjs().add(1, 'year').toISOString(),
@@ -123,6 +130,8 @@ const execEdData = {
       pacing_type: 'instructor_paced',
       enroll_by: enrollByTimestamp,
       has_enroll_by: true,
+      enroll_start: enrollStartTimestamp,
+      has_enroll_start: true,
       is_active: true,
       weeks_to_complete: 60,
       end: dayjs().add(1, 'year').toISOString(),
@@ -136,6 +145,8 @@ const execEdData = {
     pacing_type: 'instructor_paced',
     enroll_by: enrollByTimestamp,
     has_enroll_by: true,
+    enroll_start: enrollStartTimestamp,
+    has_enroll_start: true,
     is_active: true,
     weeks_to_complete: 60,
     end: dayjs().add(1, 'year').toISOString(),

--- a/src/components/learner-credit-management/data/constants.js
+++ b/src/components/learner-credit-management/data/constants.js
@@ -114,6 +114,8 @@ export const EMPTY_CONTENT_PRICE_VALUE = 0;
 // Late enrollments feature
 export const LATE_ENROLLMENTS_BUFFER_DAYS = 30;
 
+export const MAX_MILLISECONDS = 8640000000000000;
+
 // Query Key factory for the learner credit management module, intended to be used with `@tanstack/react-query`.
 // Inspired by https://tkdodo.eu/blog/effective-react-query-keys#use-query-key-factories.
 export const learnerCreditManagementQueryKeys = {

--- a/src/components/learner-credit-management/data/utils.js
+++ b/src/components/learner-credit-management/data/utils.js
@@ -587,11 +587,11 @@ const isStartDateWithinThreshold = ({ enrollStart, start, subsidyExpirationDatet
 
 const isEnrollByDateWithinThreshold = ({ enrollBy, isLateRedemptionAllowed = false }) => {
   if (!enrollBy) { return true; }
-  let enrollByCutoffDate = dayjs();
+  let enrollmentEffectiveDate = dayjs();
   if (isLateRedemptionAllowed) {
-    enrollByCutoffDate = enrollByCutoffDate.subtract(LATE_ENROLLMENTS_BUFFER_DAYS, 'days');
+    enrollmentEffectiveDate = enrollmentEffectiveDate.subtract(LATE_ENROLLMENTS_BUFFER_DAYS, 'days');
   }
-  return dayjs(enrollBy).isAfter(enrollByCutoffDate, 'seconds');
+  return dayjs(enrollBy).isAfter(enrollmentEffectiveDate, 'seconds');
 };
 
 export const isCourseSelfPaced = ({ pacingType }) => pacingType === COURSE_PACING_MAP.SELF_PACED;


### PR DESCRIPTION
Updates the logic which determines the course runs displayed in the learner credit assignment dropdown.
Ensures the following logic:
  - Given an existing `enrollBy` date for a course run, the `enrollBy` date is after today's date. If late enrollment is allowed, the `enrollBy` date is after today - `LATE_ENROLLMENTS_BUFFER_DAYS`
  - Given an existing `enrollmentStart` and `start` date for a course run, the minimum date between an enrollmentStart and start date must be before the `subsidyExpirationDate` - `MAX_ALLOWABLE_REFUND_THRESHOLD_DAYS`

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
