### PR TITLE
feat: swap start and enroll-by date in variant dropdown

### DIFF
--- a/src/components/learner-credit-management/assignment-modal/NewAssignmentModalDropdown.jsx
+++ b/src/components/learner-credit-management/assignment-modal/NewAssignmentModalDropdown.jsx
@@ -66,13 +66,13 @@ const NewAssignmentModalDropdown = ({
             onMouseUp={() => setClickedDropdownItem(null)}
           >
             <Stack>
-              {intl.formatMessage(messages.enrollBy, {
-                enrollByDate: dayjs(courseRun.enrollBy).format(SHORT_MONTH_DATE_FORMAT),
+              {intl.formatMessage(messages.startDate, {
+                startLabel: startLabel(courseRun),
+                startDate: dayjs(courseRun.start).format(SHORT_MONTH_DATE_FORMAT),
               })}
               <span className={`small ${getDropdownItemClassName(courseRun)}`}>
-                {intl.formatMessage(messages.startDate, {
-                  startLabel: startLabel(courseRun),
-                  startDate: dayjs(courseRun.start).format(SHORT_MONTH_DATE_FORMAT),
+                {intl.formatMessage(messages.enrollBy, {
+                  enrollByDate: dayjs(courseRun.enrollBy).format(SHORT_MONTH_DATE_FORMAT),
                 })}
               </span>
             </Stack>

--- a/src/components/learner-credit-management/data/utils.js
+++ b/src/components/learner-credit-management/data/utils.js
@@ -736,10 +736,17 @@ export const getAssignableCourseRuns = ({ courseRuns, subsidyExpirationDatetime,
   });
   // Sorts by the enrollBy date. If enrollBy is equivalent, sort by start.
   const sortedAssignableCourseRuns = assignableCourseRuns.sort((a, b) => {
-    if (a.enrollBy === b.enrollBy) {
-      return dayjs(a.start).unix() - dayjs(b.start).unix();
+    // Label relevant timestamps when to timestamp to milliseconds for the most granular sort
+    const prevEnrollByDateTimestamp = dayjs(a.enrollBy).valueOf();
+    const nextEnrollByDateTimestamp = dayjs(b.enrollBy).valueOf();
+    const prevStartDateTimestamp = dayjs(a.start).valueOf();
+    const nextStartDateTimestamp = dayjs(b.start).valueOf();
+
+    // Compare start dates to verify they are equivalent
+    if (dayjs(a.start).isSame(b.start, 'day')) {
+      return prevEnrollByDateTimestamp - nextEnrollByDateTimestamp;
     }
-    return a.enrollBy - b.enrollBy;
+    return prevStartDateTimestamp - nextStartDateTimestamp;
   });
   return sortedAssignableCourseRuns;
 };


### PR DESCRIPTION
Swaps the enroll-by and start date position in the variant dropdown for learner credit to highlight start dates vs the enroll-by date.

Also swaps the sorting logic to check the start date first as opposed to the enroll-by date. 

![Screenshot 2024-09-27 at 11 04 17 AM](https://github.com/user-attachments/assets/d151a3df-32bd-4114-a95e-ca87840d1818)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
