### PR TITLE
feat: generate a universal link that includes the enterprise slug

### DIFF
--- a/src/components/settings/SettingsAccessTab/ActionsTableCell.jsx
+++ b/src/components/settings/SettingsAccessTab/ActionsTableCell.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { ActionRow, Button } from '@openedx/paragon';
 import PropTypes from 'prop-types';
-import { getConfig } from '@edx/frontend-platform/config';
 import { logError } from '@edx/frontend-platform/logging';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
@@ -9,8 +8,14 @@ import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import LinkDeactivationAlertModal from './LinkDeactivationAlertModal';
 import LinkCopiedToast from './LinkCopiedToast';
 import { SETTINGS_ACCESS_EVENTS } from '../../../eventTracking';
+import getInviteURL from './utils';
 
-const ActionsTableCell = ({ row, onDeactivateLink, enterpriseUUID }) => {
+const ActionsTableCell = ({
+  row,
+  onDeactivateLink,
+  enterpriseUUID,
+  enterpriseSlug,
+}) => {
   const [isLinkDeactivationModalOpen, setIsLinkDeactivationModalOpen] = useState(false);
   const [isCopyLinkToastOpen, setIsCopyLinkToastOpen] = useState(false);
   const { isValid, uuid: inviteKeyUUID } = row.original;
@@ -25,7 +30,7 @@ const ActionsTableCell = ({ row, onDeactivateLink, enterpriseUUID }) => {
       return;
     }
     const addToClipboard = async () => {
-      const inviteURL = `${getConfig().ENTERPRISE_LEARNER_PORTAL_URL}/invite/${inviteKeyUUID}`;
+      const inviteURL = getInviteURL(enterpriseSlug, inviteKeyUUID);
       try {
         await navigator.clipboard.writeText(inviteURL);
         setIsCopyLinkToastOpen(true);
@@ -107,6 +112,7 @@ ActionsTableCell.propTypes = {
   }).isRequired,
   onDeactivateLink: PropTypes.func,
   enterpriseUUID: PropTypes.string.isRequired,
+  enterpriseSlug: PropTypes.string.isRequired,
 };
 
 ActionsTableCell.defaultProps = {

--- a/src/components/settings/SettingsAccessTab/LinkTableCell.jsx
+++ b/src/components/settings/SettingsAccessTab/LinkTableCell.jsx
@@ -1,9 +1,10 @@
 import PropTypes from 'prop-types';
-import { getConfig } from '@edx/frontend-platform/config';
 
-const LinkTableCell = ({ row }) => {
+import getInviteURL from './utils';
+
+const LinkTableCell = ({ row, enterpriseSlug }) => {
   const { uuid } = row.original;
-  return `${getConfig().ENTERPRISE_LEARNER_PORTAL_URL}/invite/${uuid}`;
+  return getInviteURL(enterpriseSlug, uuid);
 };
 
 LinkTableCell.propTypes = {
@@ -12,6 +13,7 @@ LinkTableCell.propTypes = {
       uuid: PropTypes.string,
     }),
   }).isRequired,
+  enterpriseSlug: PropTypes.string.isRequired,
 };
 
 export default LinkTableCell;

--- a/src/components/settings/SettingsAccessTab/SettingsAccessLinkManagement.jsx
+++ b/src/components/settings/SettingsAccessTab/SettingsAccessLinkManagement.jsx
@@ -26,6 +26,7 @@ import { MAX_UNIVERSAL_LINKS } from '../data/constants';
 
 const SettingsAccessLinkManagement = ({
   enterpriseUUID,
+  enterpriseSlug,
   isUniversalLinkEnabled,
   updatePortalConfiguration,
 }) => {
@@ -157,7 +158,13 @@ const SettingsAccessLinkManagement = ({
                 description: 'Column header for the link management data table in the settings page.',
               }),
               accessor: 'link',
-              Cell: LinkTableCell,
+              // eslint-disable-next-line react/no-unstable-nested-components
+              Cell: (props) => (
+                <LinkTableCell
+                  {...props}
+                  enterpriseSlug={enterpriseSlug}
+                />
+              ),
             },
             {
               Header: intl.formatMessage({
@@ -196,6 +203,7 @@ const SettingsAccessLinkManagement = ({
                 <ActionsTableCell
                   {...props}
                   enterpriseUUID={enterpriseUUID}
+                  enterpriseSlug={enterpriseSlug}
                   onDeactivateLink={handleDeactivatedLink}
                 />
               ),
@@ -229,6 +237,7 @@ const SettingsAccessLinkManagement = ({
 
 const mapStateToProps = (state) => ({
   enterpriseUUID: state.portalConfiguration.enterpriseId,
+  enterpriseSlug: state.portalConfiguration.enterpriseSlug,
   isUniversalLinkEnabled: state.portalConfiguration.enableUniversalLink,
 });
 
@@ -238,6 +247,7 @@ const mapDispatchToProps = dispatch => ({
 
 SettingsAccessLinkManagement.propTypes = {
   enterpriseUUID: PropTypes.string.isRequired,
+  enterpriseSlug: PropTypes.string.isRequired,
   isUniversalLinkEnabled: PropTypes.bool.isRequired,
   updatePortalConfiguration: PropTypes.func.isRequired,
 };

--- a/src/components/settings/SettingsAccessTab/tests/ActionsTableCell.test.jsx
+++ b/src/components/settings/SettingsAccessTab/tests/ActionsTableCell.test.jsx
@@ -25,7 +25,7 @@ const TEST_INVITE_KEY_UUID = 'test-uuid-1';
 
 const ActionsTableCellWrapper = (props) => (
   <IntlProvider locale="en">
-    <ActionsTableCell enterpriseUUID="test-enterprise-id" {...props} />
+    <ActionsTableCell enterpriseUUID="test-enterprise-id" enterpriseSlug="test-enterprise" {...props} />
   </IntlProvider>
 );
 
@@ -65,7 +65,7 @@ describe('ActionsTableCell', () => {
     );
     const copyBtn = screen.getByText('Copy');
     userEvent.click(copyBtn);
-    const expectedURL = `http://localhost:8734/invite/${TEST_INVITE_KEY_UUID}`;
+    const expectedURL = `http://localhost:8734/test-enterprise/invite/${TEST_INVITE_KEY_UUID}`;
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expectedURL);
     await waitFor(() => expect(screen.getByText('Link copied to clipboard')));
   });

--- a/src/components/settings/SettingsAccessTab/tests/LinkTableCell.test.jsx
+++ b/src/components/settings/SettingsAccessTab/tests/LinkTableCell.test.jsx
@@ -15,6 +15,7 @@ describe('LinkTableCell', () => {
           uuid: 'test-invite-key-uuid',
         },
       },
+      enterpriseSlug: 'test-enterprise',
     };
     const tree = renderer
       .create(<LinkTableCell {...props} />)

--- a/src/components/settings/SettingsAccessTab/tests/__snapshots__/LinkTableCell.test.jsx.snap
+++ b/src/components/settings/SettingsAccessTab/tests/__snapshots__/LinkTableCell.test.jsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`LinkTableCell renders correctly 1`] = `"http://localhost:8734/invite/test-invite-key-uuid"`;
+exports[`LinkTableCell renders correctly 1`] = `"http://localhost:8734/test-enterprise/invite/test-invite-key-uuid"`;

--- a/src/components/settings/SettingsAccessTab/utils.js
+++ b/src/components/settings/SettingsAccessTab/utils.js
@@ -1,0 +1,5 @@
+import { getConfig } from '@edx/frontend-platform/config';
+
+export default function getInviteURL(enterpriseSlug, inviteUUID) {
+  return `${getConfig().ENTERPRISE_LEARNER_PORTAL_URL}/${enterpriseSlug}/invite/${inviteUUID}`;
+}


### PR DESCRIPTION
We want the universal link to get people into the B2B logistration flow.  Including the enterprise slug as part of the learner-portal link will do this for us. Depends on https://github.com/openedx/frontend-app-learner-portal-enterprise/pull/1200
<img width="1645" alt="image" src="https://github.com/user-attachments/assets/38493833-4ae6-40c7-91de-d6079da26efb">
The "copy" button now produces: `http://localhost:8734/test-enterprise/invite/8506d723-9a02-4650-bdcd-e3d1c45d6f8a`
ENT-9428
# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
