### PR TITLE
feat: Create group base detail page 

### DIFF
--- a/src/components/EnterpriseApp/EnterpriseAppRoutes.jsx
+++ b/src/components/EnterpriseApp/EnterpriseAppRoutes.jsx
@@ -20,6 +20,7 @@ import { EnterpriseSubsidiesContext } from '../EnterpriseSubsidiesContext';
 import ContentHighlights from '../ContentHighlights';
 import LearnerCreditManagementRoutes from '../learner-credit-management';
 import PeopleManagementPage from '../PeopleManagement';
+import GroupDetailPage from '../PeopleManagement/GroupDetailPage';
 
 const EnterpriseAppRoutes = ({
   email,
@@ -121,12 +122,20 @@ const EnterpriseAppRoutes = ({
         />
       )}
 
-      {enterpriseGroupsV2 && enterpriseAppPage === ROUTE_NAMES.peopleManagement && (
+      {enterpriseGroupsV2 && enterpriseAppPage === ROUTE_NAMES.peopleManagement && ([
+        <Route
+          path="/:groupUuid"
+          key="group-detail"
+          element={(
+            <GroupDetailPage />
+          )}
+        />,
         <Route
           path="/*"
+          key="people-management"
           element={<PeopleManagementPage />}
-        />
-      )}
+        />,
+      ])}
 
       {enableContentHighlightsPage && enterpriseAppPage === ROUTE_NAMES.contentHighlights && (
         <Route

--- a/src/components/EnterpriseApp/index.jsx
+++ b/src/components/EnterpriseApp/index.jsx
@@ -214,6 +214,7 @@ EnterpriseApp.propTypes = {
   enableAnalyticsScreen: PropTypes.bool,
   enableReportingConfigurationsScreen: PropTypes.bool,
   enablePortalLearnerCreditManagementScreen: PropTypes.bool,
+  enterpriseGroupsV2: PropTypes.bool,
   error: PropTypes.instanceOf(Error),
   loading: PropTypes.bool,
 };

--- a/src/components/PeopleManagement/DeleteGroupModal.jsx
+++ b/src/components/PeopleManagement/DeleteGroupModal.jsx
@@ -2,10 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { logError } from '@edx/frontend-platform/logging';
 import {
   ActionRow, Button, ModalDialog, useToggle,
 } from '@openedx/paragon';
 import { RemoveCircleOutline } from '@openedx/paragon/icons';
+
 import GeneralErrorModal from './GeneralErrorModal';
 import { ROUTE_NAMES } from '../EnterpriseApp/data/constants';
 
@@ -17,12 +19,15 @@ const DeleteGroupModal = ({
   const { enterpriseSlug } = useParams();
   const [isErrorOpen, openError, closeError] = useToggle(false);
   const removeEnterpriseGroup = async () => {
-    const response = await LmsApiService.removeEnterpriseGroup(group?.uuid);
-    if (response.status === 204) {
-      close();
-      // redirect back to the people management page
-      window.location.href = `/${enterpriseSlug}/admin/${ROUTE_NAMES.peopleManagement}`;
-    } else {
+    try {
+      const response = await LmsApiService.removeEnterpriseGroup(group?.uuid);
+      if (response.status === 204) {
+        close();
+        // redirect back to the people management page
+        window.location.href = `/${enterpriseSlug}/admin/${ROUTE_NAMES.peopleManagement}`;
+      }
+    } catch (error) {
+      logError(error);
       openError();
     }
   };

--- a/src/components/PeopleManagement/DeleteGroupModal.jsx
+++ b/src/components/PeopleManagement/DeleteGroupModal.jsx
@@ -57,7 +57,7 @@ const DeleteGroupModal = ({
             id="people.management.delete.group.modal.body.2"
             defaultMessage={
             'By deleting this group you will no longer be able to track analytics associated'
-            + 'with this group and the group will be removed from your People Management page.'
+            + ' with this group and the group will be removed from your People Management page.'
           }
             description="Warning shown when deleting a group part 2."
           />

--- a/src/components/PeopleManagement/DeleteGroupModal.jsx
+++ b/src/components/PeopleManagement/DeleteGroupModal.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useParams } from 'react-router-dom';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import {
+  ActionRow, Button, ModalDialog, useToggle,
+} from '@openedx/paragon';
+import { RemoveCircleOutline } from '@openedx/paragon/icons';
+import GeneralErrorModal from './GeneralErrorModal';
+import { ROUTE_NAMES } from '../EnterpriseApp/data/constants';
+
+import LmsApiService from '../../data/services/LmsApiService';
+
+const DeleteGroupModal = ({
+  group, isOpen, close,
+}) => {
+  const { enterpriseSlug } = useParams();
+  const [isErrorOpen, openError, closeError] = useToggle(false);
+  const removeEnterpriseGroup = async () => {
+    const response = await LmsApiService.removeEnterpriseGroup(group?.uuid);
+    if (response.status === 204) {
+      close();
+      // redirect back to the people management page
+      window.location.href = `/${enterpriseSlug}/admin/${ROUTE_NAMES.peopleManagement}`;
+    } else {
+      openError();
+    }
+  };
+  return (
+    <>
+      <GeneralErrorModal
+        isOpen={isErrorOpen}
+        close={closeError}
+      />
+      <ModalDialog
+        title="Delete group"
+        isOpen={isOpen}
+        onClose={close}
+        hasCloseButton
+        isFullscreenOnMobile
+      >
+        <ModalDialog.Header>
+          <ModalDialog.Title>Delete group?</ModalDialog.Title>
+        </ModalDialog.Header>
+        <ModalDialog.Body>
+          <p className="pb-3">
+            <FormattedMessage
+              id="people.management.delete.group.modal.body.1"
+              defaultMessage="This action cannot be undone."
+              description="Warning shown when deleting a group."
+            />
+          </p>
+          <FormattedMessage
+            id="people.management.delete.group.modal.body.2"
+            defaultMessage={
+            'By deleting this group you will no longer be able to track analytics associated'
+            + 'with this group and the group will be removed from your People Management page.'
+          }
+            description="Warning shown when deleting a group part 2."
+          />
+        </ModalDialog.Body>
+        <ModalDialog.Footer>
+          <ActionRow>
+            <ModalDialog.CloseButton variant="tertiary">
+              Go back
+            </ModalDialog.CloseButton>
+            <Button variant="danger" data-testid="delete-group-button" onClick={removeEnterpriseGroup} iconBefore={RemoveCircleOutline}>
+              Delete group
+            </Button>
+          </ActionRow>
+        </ModalDialog.Footer>
+      </ModalDialog>
+    </>
+  );
+};
+
+DeleteGroupModal.propTypes = {
+  group: PropTypes.shape({
+    uuid: PropTypes.string.isRequired,
+  }),
+  isOpen: PropTypes.bool.isRequired,
+  close: PropTypes.func.isRequired,
+};
+
+export default DeleteGroupModal;

--- a/src/components/PeopleManagement/EditGroupNameModal.jsx
+++ b/src/components/PeopleManagement/EditGroupNameModal.jsx
@@ -1,0 +1,131 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import {
+  ActionRow, Form, ModalDialog, Spinner, StatefulButton, useToggle,
+} from '@openedx/paragon';
+
+import MAX_LENGTH_GROUP_NAME from './constants';
+import LmsApiService from '../../data/services/LmsApiService';
+import GeneralErrorModal from './GeneralErrorModal';
+
+const EditGroupNameModal = ({
+  group, isOpen, close, setShowToast, setToastMessage, forceUpdate,
+}) => {
+  const intl = useIntl();
+  const [isErrorOpen, openError, closeError] = useToggle(false);
+  const [name, setName] = useState(group.name);
+  const [nameLength, setNameLength] = useState(group.name.length || 0);
+  const [buttonState, setButtonState] = useState('default');
+
+  const handleGroupNameChange = (e) => {
+    if (!e.target.value) {
+      setName('');
+      return;
+    }
+    if (e.target.value?.length > MAX_LENGTH_GROUP_NAME) {
+      return;
+    }
+    setNameLength(e.target.value?.length);
+    setName(e.target.value);
+  };
+
+  const editEnterpriseGroup = async () => {
+    setButtonState('pending');
+    try {
+      const formData = { name };
+      const response = await LmsApiService.updateEnterpriseGroup(group.uuid, formData);
+      if (response.status === 200) {
+        setButtonState('complete');
+        close();
+        setShowToast(true);
+        setToastMessage('Group name updated');
+        forceUpdate();
+      }
+    } catch (error) {
+      openError();
+    }
+    setButtonState('default');
+  };
+
+  return (
+    <>
+      <GeneralErrorModal isOpen={isErrorOpen} close={closeError} />
+      <ModalDialog
+        title="Edit group"
+        isOpen={isOpen}
+        onClose={close}
+        hasCloseButton
+        isFullscreenOnMobile
+      >
+        <ModalDialog.Header>
+          <ModalDialog.Title>Edit group name</ModalDialog.Title>
+        </ModalDialog.Header>
+        <ModalDialog.Body>
+          <Form.Control
+            value={name}
+            onChange={handleGroupNameChange}
+            label="name-your-group"
+            data-testid="group name input"
+            placeholder="Name"
+          />
+          <Form.Control.Feedback>
+            {nameLength} / {MAX_LENGTH_GROUP_NAME}
+          </Form.Control.Feedback>
+        </ModalDialog.Body>
+
+        <ModalDialog.Footer>
+          <ActionRow>
+            <ModalDialog.CloseButton variant="tertiary">
+              Cancel
+            </ModalDialog.CloseButton>
+            <StatefulButton
+              state={buttonState}
+              labels={{
+                default: intl.formatMessage({
+                  id: 'adminPortal.peopleManagement.editGroupNameModal.button.save',
+                  defaultMessage: 'Save',
+                  description:
+                    'Label for the download button in the module activity report page.',
+                }),
+                pending: intl.formatMessage({
+                  id: 'adminPortal.peopleManagement.editGroupNameModal.button.pending',
+                  defaultMessage: 'Saving',
+                  description:
+                    'Label for the download button in the module activity report page when the download is in progress.',
+                }),
+                complete: intl.formatMessage({
+                  id: 'adminPortal.peopleManagement.editGroupNameModal.button.complete',
+                  defaultMessage: 'Saved',
+                  description:
+                    'Label for the download button in the module activity report page when the download is complete.',
+                }),
+              }}
+              icons={{
+                pending: (
+                  <Spinner animation="border" variant="light" size="sm" />
+                ),
+              }}
+              disabledStates={['pending']}
+              onClick={editEnterpriseGroup}
+            />
+          </ActionRow>
+        </ModalDialog.Footer>
+      </ModalDialog>
+    </>
+  );
+};
+
+EditGroupNameModal.propTypes = {
+  group: PropTypes.shape({
+    uuid: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+  }),
+  isOpen: PropTypes.bool.isRequired,
+  close: PropTypes.func.isRequired,
+  setShowToast: PropTypes.func.isRequired,
+  setToastMessage: PropTypes.func.isRequired,
+  forceUpdate: PropTypes.func.isRequired,
+};
+
+export default EditGroupNameModal;

--- a/src/components/PeopleManagement/EditGroupNameModal.jsx
+++ b/src/components/PeopleManagement/EditGroupNameModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from '@edx/frontend-platform/i18n';
+import { logError } from '@edx/frontend-platform/logging';
 import {
   ActionRow, Form, ModalDialog, Spinner, StatefulButton, useToggle,
 } from '@openedx/paragon';
@@ -10,7 +11,7 @@ import LmsApiService from '../../data/services/LmsApiService';
 import GeneralErrorModal from './GeneralErrorModal';
 
 const EditGroupNameModal = ({
-  group, isOpen, close, setShowToast, setToastMessage, forceUpdate,
+  group, isOpen, close, handleNameUpdate,
 }) => {
   const intl = useIntl();
   const [isErrorOpen, openError, closeError] = useToggle(false);
@@ -30,19 +31,20 @@ const EditGroupNameModal = ({
     setName(e.target.value);
   };
 
+  const handleCloseModal = (newName) => {
+    close();
+    handleNameUpdate(newName);
+    setButtonState('complete');
+  };
+
   const editEnterpriseGroup = async () => {
     setButtonState('pending');
     try {
       const formData = { name };
       const response = await LmsApiService.updateEnterpriseGroup(group.uuid, formData);
-      if (response.status === 200) {
-        setButtonState('complete');
-        close();
-        setShowToast(true);
-        setToastMessage('Group name updated');
-        forceUpdate();
-      }
+      handleCloseModal(response.data.name);
     } catch (error) {
+      logError(error);
       openError();
     }
     setButtonState('default');
@@ -123,9 +125,7 @@ EditGroupNameModal.propTypes = {
   }),
   isOpen: PropTypes.bool.isRequired,
   close: PropTypes.func.isRequired,
-  setShowToast: PropTypes.func.isRequired,
-  setToastMessage: PropTypes.func.isRequired,
-  forceUpdate: PropTypes.func.isRequired,
+  handleNameUpdate: PropTypes.func.isRequired,
 };
 
 export default EditGroupNameModal;

--- a/src/components/PeopleManagement/GeneralErrorModal.jsx
+++ b/src/components/PeopleManagement/GeneralErrorModal.jsx
@@ -1,0 +1,46 @@
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import PropTypes from 'prop-types';
+import {
+  ActionRow, Button, ModalDialog,
+} from '@openedx/paragon';
+
+const GeneralErrorModal = ({ isOpen, close }) => (
+  <ModalDialog
+    title="Something went wrong"
+    isOpen={isOpen}
+    onClose={close}
+    hasCloseButton
+    isFullscreenOnMobile
+  >
+    <ModalDialog.Header>
+      <ModalDialog.Title>
+        <FormattedMessage
+          id="adminPortal.peopleManagement.errorModal.title"
+          defaultMessage="Something went wrong"
+          description="Title for error modal."
+        />
+      </ModalDialog.Title>
+    </ModalDialog.Header>
+
+    <ModalDialog.Body>
+      <FormattedMessage
+        id="adminPortal.peopleManagement.errorModal.body"
+        defaultMessage="We're sorry. Something went wrong behind the scenes. Please try again, or reach out to customer support for help."
+        description="Message for error modal."
+      />
+    </ModalDialog.Body>
+
+    <ModalDialog.Footer>
+      <ActionRow>
+        <Button onClick={close} variant="primary">Exit</Button>
+      </ActionRow>
+    </ModalDialog.Footer>
+  </ModalDialog>
+);
+
+GeneralErrorModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  close: PropTypes.func.isRequired,
+};
+
+export default GeneralErrorModal;

--- a/src/components/PeopleManagement/GroupDetailPage.jsx
+++ b/src/components/PeopleManagement/GroupDetailPage.jsx
@@ -1,0 +1,127 @@
+import React, { useReducer, useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
+import {
+  Breadcrumb, Card, Hyperlink, Icon, IconButton, IconButtonWithTooltip, Skeleton, Toast, useToggle,
+} from '@openedx/paragon';
+import { Delete, Edit } from '@openedx/paragon/icons';
+
+import { useEnterpriseGroupUuid } from '../learner-credit-management/data';
+import { ROUTE_NAMES } from '../EnterpriseApp/data/constants';
+import DeleteGroupModal from './DeleteGroupModal';
+import EditGroupNameModal from './EditGroupNameModal';
+
+const GroupDetailPage = () => {
+  const intl = useIntl();
+  const { enterpriseSlug, groupUuid } = useParams();
+  const { data: enterpriseGroup } = useEnterpriseGroupUuid(groupUuid);
+  const [isDeleteModalOpen, openDeleteModal, closeDeleteModal] = useToggle(false);
+  const [isEditModalOpen, openEditModal, closeEditModal] = useToggle(false);
+  const [showToast, setShowToast] = useState(false);
+  const [toastMessage, setToastMessage] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [, forceUpdate] = useReducer(x => x + 1, 0);
+
+  useEffect(() => {
+    if (enterpriseGroup !== undefined) {
+      setIsLoading(false);
+    }
+  }, [enterpriseGroup]);
+
+  const tooltipContent = (
+    <FormattedMessage
+      id="adminPortal.peopleManagement.groupDetail.deleteGroup.icon"
+      defaultMessage="Delete group"
+      description="Tooltip to confirm meaning of trash icon."
+    />
+  );
+
+  return (
+    <div className="pt-4 pl-4">
+      {isLoading && <Skeleton className="mt-3" height={200} count={1} />}
+      {!isLoading && (
+        <>
+          <Toast onClose={() => setShowToast(false)} show={showToast}>
+            {toastMessage}
+          </Toast>
+          <DeleteGroupModal
+            group={enterpriseGroup}
+            isOpen={isDeleteModalOpen}
+            close={closeDeleteModal}
+          />
+          <EditGroupNameModal
+            group={enterpriseGroup}
+            isOpen={isEditModalOpen}
+            close={closeEditModal}
+            setShowToast={setShowToast}
+            setToastMessage={setToastMessage}
+            forceUpdate={forceUpdate}
+          />
+          <Breadcrumb
+            aria-label="people management breadcrumb navigation"
+            links={[
+              {
+                label: intl.formatMessage({
+                  id: 'adminPortal.peopleManagement.breadcrumb',
+                  defaultMessage: 'People Management',
+                  description:
+                    'Breadcrumb label for the people management page',
+                }),
+                href: `/${enterpriseSlug}/admin/${ROUTE_NAMES.peopleManagement}`,
+              },
+            ]}
+            activeLabel={enterpriseGroup.name}
+          />
+          <Card orientation="horizontal">
+            <Card.Body>
+              <Card.Header
+                title={(
+                  <>
+                    <span className="pr-1">{enterpriseGroup.name}</span>
+                    <IconButton
+                      key="editGroupTooltip"
+                      src={Edit}
+                      iconAs={Icon}
+                      alt="Edit group"
+                      className="mr-2"
+                      onClick={openEditModal}
+                      size="sm"
+                      data-testid="edit-modal-icon"
+                    />
+                  </>
+              )}
+                subtitle={`${enterpriseGroup.acceptedMembersCount} accepted members`}
+              />
+              <Card.Section className="pt-1 x-small">Created on</Card.Section>
+            </Card.Body>
+            <Card.Footer
+              className="justify-content-end"
+              orientation="horizontal"
+            >
+              <IconButtonWithTooltip
+                alt="icon to trash group"
+                key="trashGroupTooltip"
+                tooltipPlacement="top"
+                tooltipContent={tooltipContent}
+                src={Delete}
+                iconAs={Icon}
+                data-testid="delete-group-icon"
+                className="mr-2"
+                onClick={openDeleteModal}
+              />
+              <Hyperlink
+                className="btn btn-primary"
+                target="_blank"
+                destination={`/${enterpriseSlug}/admin/${ROUTE_NAMES.learners}`}
+              >
+                View group progress
+              </Hyperlink>
+            </Card.Footer>
+          </Card>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default GroupDetailPage;

--- a/src/components/PeopleManagement/GroupDetailPage.jsx
+++ b/src/components/PeopleManagement/GroupDetailPage.jsx
@@ -1,8 +1,8 @@
-import React, { useReducer, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
 import {
-  Breadcrumb, Card, Hyperlink, Icon, IconButton, IconButtonWithTooltip, Skeleton, Toast, useToggle,
+  Breadcrumb, Card, Hyperlink, Icon, IconButton, IconButtonWithTooltip, Skeleton, useToggle,
 } from '@openedx/paragon';
 import { Delete, Edit } from '@openedx/paragon/icons';
 
@@ -17,14 +17,17 @@ const GroupDetailPage = () => {
   const { data: enterpriseGroup } = useEnterpriseGroupUuid(groupUuid);
   const [isDeleteModalOpen, openDeleteModal, closeDeleteModal] = useToggle(false);
   const [isEditModalOpen, openEditModal, closeEditModal] = useToggle(false);
-  const [showToast, setShowToast] = useState(false);
-  const [toastMessage, setToastMessage] = useState('');
   const [isLoading, setIsLoading] = useState(true);
-  const [, forceUpdate] = useReducer(x => x + 1, 0);
+  const [groupName, setGroupName] = useState(enterpriseGroup?.name);
+
+  const handleNameUpdate = (name) => {
+    setGroupName(name);
+  };
 
   useEffect(() => {
     if (enterpriseGroup !== undefined) {
       setIsLoading(false);
+      handleNameUpdate(enterpriseGroup.name);
     }
   }, [enterpriseGroup]);
 
@@ -41,9 +44,6 @@ const GroupDetailPage = () => {
       {isLoading && <Skeleton className="mt-3" height={200} count={1} />}
       {!isLoading && (
         <>
-          <Toast onClose={() => setShowToast(false)} show={showToast}>
-            {toastMessage}
-          </Toast>
           <DeleteGroupModal
             group={enterpriseGroup}
             isOpen={isDeleteModalOpen}
@@ -53,9 +53,7 @@ const GroupDetailPage = () => {
             group={enterpriseGroup}
             isOpen={isEditModalOpen}
             close={closeEditModal}
-            setShowToast={setShowToast}
-            setToastMessage={setToastMessage}
-            forceUpdate={forceUpdate}
+            handleNameUpdate={handleNameUpdate}
           />
           <Breadcrumb
             aria-label="people management breadcrumb navigation"
@@ -70,14 +68,14 @@ const GroupDetailPage = () => {
                 href: `/${enterpriseSlug}/admin/${ROUTE_NAMES.peopleManagement}`,
               },
             ]}
-            activeLabel={enterpriseGroup.name}
+            activeLabel={groupName}
           />
           <Card orientation="horizontal">
             <Card.Body>
               <Card.Header
                 title={(
                   <>
-                    <span className="pr-1">{enterpriseGroup.name}</span>
+                    <span className="pr-1">{groupName}</span>
                     <IconButton
                       key="editGroupTooltip"
                       src={Edit}

--- a/src/components/PeopleManagement/GroupDetailPage.jsx
+++ b/src/components/PeopleManagement/GroupDetailPage.jsx
@@ -10,6 +10,7 @@ import { useEnterpriseGroupUuid } from '../learner-credit-management/data';
 import { ROUTE_NAMES } from '../EnterpriseApp/data/constants';
 import DeleteGroupModal from './DeleteGroupModal';
 import EditGroupNameModal from './EditGroupNameModal';
+import formatDates from './utils';
 
 const GroupDetailPage = () => {
   const intl = useIntl();
@@ -89,7 +90,9 @@ const GroupDetailPage = () => {
               )}
                 subtitle={`${enterpriseGroup.acceptedMembersCount} accepted members`}
               />
-              <Card.Section className="pt-1 x-small">Created on</Card.Section>
+              <Card.Section className="pt-1 x-small">
+                Created on {formatDates(enterpriseGroup.created)}
+              </Card.Section>
             </Card.Body>
             <Card.Footer
               className="justify-content-end"

--- a/src/components/PeopleManagement/constants.js
+++ b/src/components/PeopleManagement/constants.js
@@ -1,0 +1,2 @@
+const MAX_LENGTH_GROUP_NAME = 60;
+export default MAX_LENGTH_GROUP_NAME;

--- a/src/components/PeopleManagement/index.jsx
+++ b/src/components/PeopleManagement/index.jsx
@@ -21,9 +21,7 @@ const PeopleManagementPage = () => {
 
   const { enterpriseSubsidyTypes } = useContext(EnterpriseSubsidiesContext);
 
-  const hasLearnerCredit = enterpriseSubsidyTypes.includes(
-    SUBSIDY_TYPES.budget,
-  );
+  const hasLearnerCredit = enterpriseSubsidyTypes.includes(SUBSIDY_TYPES.budget);
   const hasOtherSubsidyTypes = enterpriseSubsidyTypes.includes(SUBSIDY_TYPES.license)
     || enterpriseSubsidyTypes.includes(SUBSIDY_TYPES.coupon);
 
@@ -40,7 +38,7 @@ const PeopleManagementPage = () => {
             <span className="d-flex">
               <h3 className="mt-2">
                 <FormattedMessage
-                  id="admin.portal.people.management.page.title"
+                  id="adminPortal.peopleManagement.title"
                   defaultMessage="Your organization's groups"
                   description="Title for people management zero state."
                 />
@@ -48,14 +46,14 @@ const PeopleManagementPage = () => {
             </span>
             {hasLearnerCredit && (
               <FormattedMessage
-                id="admin.portal.people.management.page.subtitle.lc"
+                id="adminPortal.peopleManagement.subtitle.lc"
                 defaultMessage="Monitor group learning progress, assign more courses, and invite members to new Learner Credit budgets."
                 description="Subtitle for people management with learner credit."
               />
             )}
             {!hasLearnerCredit && hasOtherSubsidyTypes && (
               <FormattedMessage
-                id="admin.portal.people.management.page.subtitle.noLc"
+                id="adminPortal.peopleManagement.subtitle.noLc"
                 defaultMessage="Monitor group learning progress."
                 description="Subtitle for people management without learner credit."
               />
@@ -64,7 +62,7 @@ const PeopleManagementPage = () => {
           <ActionRow.Spacer />
           <Button iconBefore={Add} onClick={openModal}>
             <FormattedMessage
-              id="admin.portal.people.management.page.newgroup.button"
+              id="adminPortal.peopleManagement.newGroup.button"
               defaultMessage="Create group"
               description="CTA button text to open new group modal."
             />
@@ -79,7 +77,7 @@ const PeopleManagementPage = () => {
           <span className="text-center align-self-center">
             <h2 className="h3 mb-3 mt-3">
               <FormattedMessage
-                id="admin.portal.people.management.page.zerostate.card.header"
+                id="adminPortal.peopleManagement.zeroStateCard.header"
                 defaultMessage="You don't have any groups yet."
                 description="Header message shown to admin there's no groups created yet."
               />
@@ -87,14 +85,14 @@ const PeopleManagementPage = () => {
             <p className="mx-2">
               {hasLearnerCredit && (
                 <FormattedMessage
-                  id="admin.portal.people.management.page.zerostate.card.subtitle.lc"
+                  id="adminPortal.peopleManagement.zeroStateCard.subtitle.lc"
                   defaultMessage="Once a group is created, you can track members' progress, assign extra courses, and invite them to additional budgets."
                   description="Detail message shown to admin benefits of creating a group with learner credit."
                 />
               )}
               {!hasLearnerCredit && hasOtherSubsidyTypes && (
                 <FormattedMessage
-                  id="admin.portal.people.management.page.zerostate.card.subtitle.noLc"
+                  id="adminPortal.peopleManagement.zeroStateCard.subtitle.noLc"
                   defaultMessage="Once a group is created, you can track members' progress."
                   description="Detail message shown to admin benefits of creating a group without learner credit."
                 />

--- a/src/components/PeopleManagement/tests/GroupDetailPage.test.jsx
+++ b/src/components/PeopleManagement/tests/GroupDetailPage.test.jsx
@@ -83,8 +83,6 @@ describe('<GroupDetailPageWrapper >', () => {
 
     const formData = { name: 'new name!' };
     await waitFor(() => expect(spy).toHaveBeenCalledWith(TEST_GROUP.uuid, formData));
-    // toast message
-    await waitFor(() => expect(screen.getByText('Group name updated')).toBeInTheDocument());
   });
   it('edit flex group name error', async () => {
     const spy = jest.spyOn(LmsApiService, 'updateEnterpriseGroup');
@@ -120,9 +118,13 @@ describe('<GroupDetailPageWrapper >', () => {
 
     await waitFor(() => expect(spy).toHaveBeenCalledWith(TEST_GROUP.uuid));
   });
-  it('delete flex group', async () => {
-    const spy = jest.spyOn(LmsApiService, 'removeEnterpriseGroup');
-    LmsApiService.removeEnterpriseGroup.mockResolvedValueOnce({ status: 404 });
+  it('delete flex group error', async () => {
+    const mockRemoveGroup = jest.spyOn(LmsApiService, 'removeEnterpriseGroup');
+    mockRemoveGroup.mockRejectedValue({
+      customAttributes: {
+        httpErrorStatus: 404,
+      },
+    });
     render(<GroupDetailPageWrapper />);
     const deleteGroupIcon = screen.getByTestId('delete-group-icon');
     deleteGroupIcon.click();
@@ -132,7 +134,7 @@ describe('<GroupDetailPageWrapper >', () => {
     const deleteGroupButton = screen.getByTestId('delete-group-button');
     deleteGroupButton.click();
 
-    await waitFor(() => expect(spy).toHaveBeenCalledWith(TEST_GROUP.uuid));
+    await waitFor(() => expect(mockRemoveGroup).toHaveBeenCalledWith(TEST_GROUP.uuid));
     // error modal
     await waitFor(() => expect(screen.getByText('Something went wrong')).toBeInTheDocument());
   });

--- a/src/components/PeopleManagement/tests/GroupDetailPage.test.jsx
+++ b/src/components/PeopleManagement/tests/GroupDetailPage.test.jsx
@@ -1,0 +1,139 @@
+import {
+  act, fireEvent, render, screen, waitFor,
+} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import thunk from 'redux-thunk';
+import configureMockStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { useEnterpriseGroupUuid } from '../../learner-credit-management/data';
+import GroupDetailPage from '../GroupDetailPage';
+import LmsApiService from '../../../data/services/LmsApiService';
+
+const TEST_ENTERPRISE_SLUG = 'test-enterprise';
+const enterpriseUUID = '1234';
+const TEST_GROUP = {
+  name: 'engineering team',
+  uuid: '12345',
+  acceptedMembersCount: 0,
+  groupType: 'flex',
+};
+const mockStore = configureMockStore([thunk]);
+const getMockStore = store => mockStore(store);
+
+jest.mock('../../learner-credit-management/data', () => ({
+  ...jest.requireActual('../../learner-credit-management/data'),
+  useEnterpriseGroupUuid: jest.fn(),
+}));
+jest.mock('../../../data/services/LmsApiService');
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({
+    enterpriseSlug: TEST_ENTERPRISE_SLUG,
+    groupUuid: TEST_GROUP.uuid,
+  }),
+}));
+
+const initialStoreState = {
+  portalConfiguration: {
+    enterpriseId: enterpriseUUID,
+    enterpriseSlug: TEST_ENTERPRISE_SLUG,
+    enterpriseGroupsV2: true,
+  },
+};
+
+const GroupDetailPageWrapper = ({
+  initialState = initialStoreState,
+}) => {
+  const store = getMockStore(initialState);
+  return (
+    <IntlProvider locale="en">
+      <Provider store={store}>
+        <GroupDetailPage />
+      </Provider>
+    </IntlProvider>
+  );
+};
+
+describe('<GroupDetailPageWrapper >', () => {
+  beforeEach(() => {
+    useEnterpriseGroupUuid.mockReturnValue({ data: TEST_GROUP });
+  });
+  it('renders the GroupDetailPage', () => {
+    render(<GroupDetailPageWrapper />);
+    expect(screen.queryAllByText(TEST_GROUP.name)).toHaveLength(2);
+    expect(screen.getByText('0 accepted members')).toBeInTheDocument();
+    expect(screen.getByText('View group progress')).toBeInTheDocument();
+  });
+  it('edit flex group name', async () => {
+    const spy = jest.spyOn(LmsApiService, 'updateEnterpriseGroup');
+    LmsApiService.updateEnterpriseGroup.mockResolvedValueOnce({ status: 200 });
+    render(<GroupDetailPageWrapper />);
+    const editGroupNameIcon = screen.getByTestId('edit-modal-icon');
+    editGroupNameIcon.click();
+
+    expect(screen.getByText('Edit group name')).toBeInTheDocument();
+    const input = screen.getByTestId('group name input');
+    act(() => {
+      fireEvent.change(input, { target: { value: 'new name!' } });
+    });
+    await waitFor(() => expect(screen.getByTestId('group name input')).toHaveValue('new name!'));
+    screen.getByText('Save').click();
+
+    const formData = { name: 'new name!' };
+    await waitFor(() => expect(spy).toHaveBeenCalledWith(TEST_GROUP.uuid, formData));
+    // toast message
+    await waitFor(() => expect(screen.getByText('Group name updated')).toBeInTheDocument());
+  });
+  it('edit flex group name error', async () => {
+    const spy = jest.spyOn(LmsApiService, 'updateEnterpriseGroup');
+    LmsApiService.updateEnterpriseGroup.mockResolvedValueOnce({ status: 404 });
+    render(<GroupDetailPageWrapper />);
+    const editGroupNameIcon = screen.getByTestId('edit-modal-icon');
+    editGroupNameIcon.click();
+
+    expect(screen.getByText('Edit group name')).toBeInTheDocument();
+    const input = screen.getByTestId('group name input');
+    act(() => {
+      fireEvent.change(input, { target: { value: 'new name!' } });
+    });
+    await waitFor(() => expect(screen.getByTestId('group name input')).toHaveValue('new name!'));
+    screen.getByText('Save').click();
+
+    const formData = { name: 'new name!' };
+    await waitFor(() => expect(spy).toHaveBeenCalledWith(TEST_GROUP.uuid, formData));
+    // error modal
+    await waitFor(() => expect(screen.getByText('Something went wrong')).toBeInTheDocument());
+  });
+  it('delete flex group', async () => {
+    const spy = jest.spyOn(LmsApiService, 'removeEnterpriseGroup');
+    LmsApiService.removeEnterpriseGroup.mockResolvedValueOnce({ status: 204 });
+    render(<GroupDetailPageWrapper />);
+    const deleteGroupIcon = screen.getByTestId('delete-group-icon');
+    deleteGroupIcon.click();
+
+    expect(screen.getByText('Delete group')).toBeInTheDocument();
+    expect(screen.getByText('This action cannot be undone.'));
+    const deleteGroupButton = screen.getByTestId('delete-group-button');
+    deleteGroupButton.click();
+
+    await waitFor(() => expect(spy).toHaveBeenCalledWith(TEST_GROUP.uuid));
+  });
+  it('delete flex group', async () => {
+    const spy = jest.spyOn(LmsApiService, 'removeEnterpriseGroup');
+    LmsApiService.removeEnterpriseGroup.mockResolvedValueOnce({ status: 404 });
+    render(<GroupDetailPageWrapper />);
+    const deleteGroupIcon = screen.getByTestId('delete-group-icon');
+    deleteGroupIcon.click();
+
+    expect(screen.getByText('Delete group')).toBeInTheDocument();
+    expect(screen.getByText('This action cannot be undone.'));
+    const deleteGroupButton = screen.getByTestId('delete-group-button');
+    deleteGroupButton.click();
+
+    await waitFor(() => expect(spy).toHaveBeenCalledWith(TEST_GROUP.uuid));
+    // error modal
+    await waitFor(() => expect(screen.getByText('Something went wrong')).toBeInTheDocument());
+  });
+});

--- a/src/components/PeopleManagement/utils.js
+++ b/src/components/PeopleManagement/utils.js
@@ -1,0 +1,12 @@
+import dayjs from 'dayjs';
+
+/**
+ * Formats provided dates for display
+ *
+ * @param {string} timestamp unformatted date timestamp
+ * @returns Formatted date string for display.
+ */
+export default function formatDates(timestamp) {
+  const DATE_FORMAT = 'MMMM DD, YYYY';
+  return dayjs(timestamp).format(DATE_FORMAT);
+}

--- a/src/components/learner-credit-management/data/hooks/index.js
+++ b/src/components/learner-credit-management/data/hooks/index.js
@@ -17,5 +17,6 @@ export { default as useEnterpriseGroupLearners } from './useEnterpriseGroupLearn
 export { default as useEnterpriseGroupMembersTableData } from './useEnterpriseGroupMembersTableData';
 export { default as useEnterpriseCustomer } from './useEnterpriseCustomer';
 export { default as useEnterpriseGroup } from './useEnterpriseGroup';
+export { default as useEnterpriseGroupUuid } from './useEnterpriseGroupUuid';
 export { default as useContentMetadata } from './useContentMetadata';
 export { default as useEnterpriseRemovedGroupMembers } from './useEnterpriseRemovedGroupMembers';

--- a/src/components/learner-credit-management/data/hooks/useEnterpriseGroup.js
+++ b/src/components/learner-credit-management/data/hooks/useEnterpriseGroup.js
@@ -6,7 +6,7 @@ import { learnerCreditManagementQueryKeys } from '../constants';
 import LmsApiService from '../../../../data/services/LmsApiService';
 
 /**
- * Retrieves a enterprise group by UUID from the API.
+ * Retrieves a enterprise group by the policy the  from the API.
  *
  * @param {*} queryKey The queryKey from the associated `useQuery` call.
  * @returns The enterprise group object

--- a/src/components/learner-credit-management/data/hooks/useEnterpriseGroupUuid.js
+++ b/src/components/learner-credit-management/data/hooks/useEnterpriseGroupUuid.js
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+import { camelCaseObject } from '@edx/frontend-platform/utils';
+
+import { learnerCreditManagementQueryKeys } from '../constants';
+import LmsApiService from '../../../../data/services/LmsApiService';
+
+/**
+ * Retrieves an enterprise group by group UUID from the API.
+ *
+ * @param {*} queryKey The queryKey from the associated `useQuery` call.
+ * @returns The enterprise group object
+ */
+const getEnterpriseGroupUuid = async ({ groupUuid }) => {
+  const response = await LmsApiService.fetchEnterpriseGroup(groupUuid);
+  const enterpriseGroup = camelCaseObject(response.data);
+  return enterpriseGroup;
+};
+
+const useEnterpriseGroupUuid = (groupUuid, { queryOptions } = {}) => useQuery({
+  queryKey: learnerCreditManagementQueryKeys.group(groupUuid),
+  queryFn: () => getEnterpriseGroupUuid({ groupUuid }),
+  ...queryOptions,
+});
+
+export default useEnterpriseGroupUuid;

--- a/src/data/services/LmsApiService.js
+++ b/src/data/services/LmsApiService.js
@@ -446,6 +446,16 @@ class LmsApiService {
     return LmsApiService.apiClient().get(enterpriseGroupLearnersEndpoint);
   };
 
+  static removeEnterpriseGroup = async (groupUuid) => {
+    const removeGroupEndpoint = `${LmsApiService.enterpriseGroupListUrl}${groupUuid}/`;
+    return LmsApiService.apiClient().delete(removeGroupEndpoint);
+  };
+
+  static updateEnterpriseGroup = async (groupUuid, formData) => {
+    const updateGroupEndpoint = `${LmsApiService.enterpriseGroupListUrl}${groupUuid}/`;
+    return LmsApiService.apiClient().patch(updateGroupEndpoint, formData);
+  };
+
   static removeEnterpriseLearnersFromGroup = async (groupUuid, formData) => {
     const removeLearnerEndpoint = `${LmsApiService.enterpriseGroupListUrl}${groupUuid}/remove_learners/`;
     return LmsApiService.apiClient().post(removeLearnerEndpoint, formData);


### PR DESCRIPTION
# Description
Creates the card for the groups detail page. Includes functionality for editing the group name and deleting the group. 
https://2u-internal.atlassian.net/browse/ENT-9506

# Test plan
- npm run start:stage
- because we don't actually have the button that will open it, just navigate straight to https://localhost.stage.edx.org:1991/exec-ed-2u-integration-qa/admin/people-management/89e6451c-b187-44b2-b546-ad4511fc34ea
- open up edit and delete modals

<img width="1365" alt="Screenshot 2024-10-04 at 1 01 50 PM" src="https://github.com/user-attachments/assets/ec8cf1d1-aa54-4b29-956e-b953afb79303">

<img width="605" alt="Screenshot 2024-10-04 at 1 01 56 PM" src="https://github.com/user-attachments/assets/9895a0ef-2e76-4a01-bffd-65cdad70dccb">
<img width="536" alt="Screenshot 2024-10-05 at 2 16 12 AM" src="https://github.com/user-attachments/assets/6724c407-492f-4eec-8c03-05ba5e4d0551">


# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
