### PR TITLE
fix: disabale dropdowns while loading data on analyticsV2

### DIFF
--- a/src/components/AdvanceAnalyticsV2/AnalyticsV2Page.jsx
+++ b/src/components/AdvanceAnalyticsV2/AnalyticsV2Page.jsx
@@ -43,7 +43,7 @@ const AnalyticsV2Page = ({ enterpriseId }) => {
                 id="advance.analytics.data.refresh.msg"
                 defaultMessage="Data updated on {date}"
                 description="Data refresh message"
-                values={{ date: data?.lastUpdatedAt || '' }}
+                values={{ date: data?.lastUpdatedAt || currentDate }}
               />
             </span>
           </div>
@@ -64,6 +64,7 @@ const AnalyticsV2Page = ({ enterpriseId }) => {
                 value={startDate || data?.minEnrollmentDate}
                 min={data?.minEnrollmentDate}
                 onChange={(e) => setStartDate(e.target.value)}
+                disabled={isFetching}
               />
             </Form.Group>
           </div>
@@ -81,6 +82,7 @@ const AnalyticsV2Page = ({ enterpriseId }) => {
                 value={endDate || currentDate}
                 max={currentDate}
                 onChange={(e) => setEndDate(e.target.value)}
+                disabled={isFetching}
               />
             </Form.Group>
           </div>
@@ -97,6 +99,7 @@ const AnalyticsV2Page = ({ enterpriseId }) => {
                 as="select"
                 value={granularity}
                 onChange={(e) => setGranularity(e.target.value)}
+                disabled={isFetching}
               >
                 <option value={GRANULARITY.DAILY}>
                   {intl.formatMessage({
@@ -142,6 +145,7 @@ const AnalyticsV2Page = ({ enterpriseId }) => {
                 as="select"
                 value={calculation}
                 onChange={(e) => setCalculation(e.target.value)}
+                disabled={isFetching}
               >
                 <option value={CALCULATION.TOTAL}>
                   {intl.formatMessage({


### PR DESCRIPTION
**Description**

- I disable the startDate, endDate, Granularity, and Calculation dropdowns while loading aggregates data. 
- Added currentDate as a default date for `Data Updated on`


JIRA -> [ENT-9590](https://2u-internal.atlassian.net/browse/ENT-9590)

![image](https://github.com/user-attachments/assets/d20f1ece-fdc4-40da-b3cf-a4ab6dd97812)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
