### PR TITLE
feat: add extension requests column in exec ed module table

### DIFF
--- a/src/components/Admin/__snapshots__/Admin.test.jsx.snap
+++ b/src/components/Admin/__snapshots__/Admin.test.jsx.snap
@@ -661,6 +661,50 @@ exports[`<Admin /> renders correctly calls fetchDashboardAnalytics prop 1`] = `
                                 className="d-flex align-items-center"
                               >
                                 <span>
+                                  Extension Requests
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
                                   Learning Hours
                                 </span>
                                 <span
@@ -2163,6 +2207,50 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # cou
                               >
                                 <span>
                                   % Activities Complete
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Extension Requests
                                 </span>
                                 <span
                                   className="pgn__icon"
@@ -3751,6 +3839,50 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                                 className="d-flex align-items-center"
                               >
                                 <span>
+                                  Extension Requests
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
                                   Learning Hours
                                 </span>
                                 <span
@@ -5253,6 +5385,50 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                               >
                                 <span>
                                   % Activities Complete
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Extension Requests
                                 </span>
                                 <span
                                   className="pgn__icon"
@@ -6841,6 +7017,50 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                                 className="d-flex align-items-center"
                               >
                                 <span>
+                                  Extension Requests
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
                                   Learning Hours
                                 </span>
                                 <span
@@ -8343,6 +8563,50 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders full 
                               >
                                 <span>
                                   % Activities Complete
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Extension Requests
                                 </span>
                                 <span
                                   className="pgn__icon"
@@ -9931,6 +10195,50 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                                 className="d-flex align-items-center"
                               >
                                 <span>
+                                  Extension Requests
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
                                   Learning Hours
                                 </span>
                                 <span
@@ -11433,6 +11741,50 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                               >
                                 <span>
                                   % Activities Complete
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Extension Requests
                                 </span>
                                 <span
                                   className="pgn__icon"
@@ -13021,6 +13373,50 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders learn
                                 className="d-flex align-items-center"
                               >
                                 <span>
+                                  Extension Requests
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
                                   Learning Hours
                                 </span>
                                 <span
@@ -14566,6 +14962,50 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders regis
                                 className="d-flex align-items-center"
                               >
                                 <span>
+                                  Extension Requests
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
                                   Learning Hours
                                 </span>
                                 <span
@@ -16068,6 +16508,50 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders top a
                               >
                                 <span>
                                   % Activities Complete
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Extension Requests
                                 </span>
                                 <span
                                   className="pgn__icon"
@@ -17705,6 +18189,50 @@ exports[`<Admin /> renders correctly with dashboard insights data renders dashbo
                                 className="d-flex align-items-center"
                               >
                                 <span>
+                                  Extension Requests
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
                                   Learning Hours
                                 </span>
                                 <span
@@ -18492,6 +19020,50 @@ exports[`<Admin /> renders correctly with error state 1`] = `
                               >
                                 <span>
                                   % Activities Complete
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Extension Requests
                                 </span>
                                 <span
                                   className="pgn__icon"
@@ -19339,6 +19911,50 @@ exports[`<Admin /> renders correctly with loading state 1`] = `
                               >
                                 <span>
                                   % Activities Complete
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Extension Requests
                                 </span>
                                 <span
                                   className="pgn__icon"
@@ -20929,6 +21545,50 @@ exports[`<Admin /> renders correctly with no dashboard insights data 1`] = `
                               >
                                 <span>
                                   % Activities Complete
+                                </span>
+                                <span
+                                  className="pgn__icon"
+                                  data-testid="arrow-drop-up-down"
+                                  style={
+                                    {
+                                      "opacity": 0.5,
+                                    }
+                                  }
+                                >
+                                  <svg
+                                    aria-hidden={true}
+                                    fill="none"
+                                    focusable={false}
+                                    height={24}
+                                    role="img"
+                                    viewBox="0 0 24 24"
+                                    width={24}
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="m7 10 5-5 5 5H7ZM7 14l5 5 5-5H7Z"
+                                      fill="currentColor"
+                                    />
+                                  </svg>
+                                </span>
+                              </span>
+                            </th>
+                            <th
+                              colSpan={1}
+                              onClick={[Function]}
+                              role="columnheader"
+                              style={
+                                {
+                                  "cursor": "pointer",
+                                }
+                              }
+                              title="Toggle SortBy"
+                            >
+                              <span
+                                className="d-flex align-items-center"
+                              >
+                                <span>
+                                  Extension Requests
                                 </span>
                                 <span
                                   className="pgn__icon"

--- a/src/components/Admin/tabs/DownloadCSVButton.jsx
+++ b/src/components/Admin/tabs/DownloadCSVButton.jsx
@@ -29,8 +29,8 @@ const DownloadCsvButton = ({ data, testId, fetchData }) => {
   };
 
   const handleClick = async () => {
+    setButtonState('pending');
     fetchData().then((response) => {
-      setButtonState('pending');
       const blob = new Blob([response.data], {
         type: 'text/csv',
       });

--- a/src/components/Admin/tabs/ModuleActivityReport.jsx
+++ b/src/components/Admin/tabs/ModuleActivityReport.jsx
@@ -125,6 +125,14 @@ const ModuleActivityReport = ({ enterpriseId }) => {
           },
           {
             Header: intl.formatMessage({
+              id: 'adminPortal.LPR.moduleActivityReport.table.header.extensionsRequested',
+              defaultMessage: 'Extension Requests',
+              description: 'Header for the extensions requested column in the module activity report table',
+            }),
+            accessor: 'extensions_requested',
+          },
+          {
+            Header: intl.formatMessage({
               id: 'adminPortal.LPR.moduleActivityReport.table.header.hoursOnline',
               defaultMessage: 'Learning Hours',
               description: 'Header for the learning hours column in the module activity report table',


### PR DESCRIPTION
**Description:** Add a new column(`Extension Requests`) in Module Activity (Executive Education) table on Learner Progress Report page.
**JIRA:** https://2u-internal.atlassian.net/browse/ENT-9566

**Screenshot**
<img width="1382" alt="Screenshot 2024-10-11 at 12 23 38 PM" src="https://github.com/user-attachments/assets/21bbea1c-1104-4061-a3b2-e09fa2e0fdbf">



# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
