### PR TITLE
temp: move restrictionType check prior to check for late redemption

### DIFF
--- a/src/components/learner-credit-management/data/utils.js
+++ b/src/components/learner-credit-management/data/utils.js
@@ -720,13 +720,6 @@ export const getAssignableCourseRuns = ({ courseRuns, subsidyExpirationDatetime,
       // the current date and subsidy expiration date have failed.
       return false;
     }
-    if (hasEnrollBy && isLateRedemptionAllowed && isDateBeforeToday(enrollBy)) {
-      // Special case: late enrollment has been enabled by ECS for this budget, and
-      // isEligibleForEnrollment already succeeded, so we know that late enrollment
-      // would be happy given enrollment deadline of the course.  Now all we need
-      // to do is make sure the run itself is generally eligible for late enrollment
-      return isLateEnrollmentEligible;
-    }
     // ENT-9359 (epic for Custom Presentations/Restricted Runs):
     // Temporarily hide all restricted runs unconditionally on the run assignment
     // dropdown during implementation of the overall feature. ENT-9411 is most likely
@@ -734,6 +727,13 @@ export const getAssignableCourseRuns = ({ courseRuns, subsidyExpirationDatetime,
     // runs conditionally.
     if (restrictionType) {
       return false;
+    }
+    if (hasEnrollBy && isLateRedemptionAllowed && isDateBeforeToday(enrollBy)) {
+      // Special case: late enrollment has been enabled by ECS for this budget, and
+      // isEligibleForEnrollment already succeeded, so we know that late enrollment
+      // would be happy given enrollment deadline of the course.  Now all we need
+      // to do is make sure the run itself is generally eligible for late enrollment
+      return isLateEnrollmentEligible;
     }
     // General courseware filter
     return isActive;


### PR DESCRIPTION
Helps protect against a case where late redemption is enabled for a budget and a restricted course run's enroll-by date is within the 30 day late enrollment offset. Without this change, we'd potentially surface a restricted run to a customer without a restricted run allowed by any of the customer's catalogs.
# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
