### PR TITLE
fix: resolve some issue on analytics v2

### DIFF
--- a/src/components/AdvanceAnalyticsV2/AnalyticsV2Page.jsx
+++ b/src/components/AdvanceAnalyticsV2/AnalyticsV2Page.jsx
@@ -31,6 +31,10 @@ const AnalyticsV2Page = ({ enterpriseId }) => {
     endDate,
   });
   const currentDate = new Date().toISOString().split('T')[0];
+  const formatDate = (dateString) => {
+    const options = { year: 'numeric', month: 'long', day: 'numeric' };
+    return new Date(dateString).toLocaleDateString(undefined, options);
+  };
   return (
     <>
       <Helmet title={PAGE_TITLE} />
@@ -43,7 +47,7 @@ const AnalyticsV2Page = ({ enterpriseId }) => {
                 id="advance.analytics.data.refresh.msg"
                 defaultMessage="Data updated on {date}"
                 description="Data refresh message"
-                values={{ date: data?.lastUpdatedAt || currentDate }}
+                values={{ date: formatDate(data?.lastUpdatedAt || currentDate) }}
               />
             </span>
           </div>
@@ -191,6 +195,7 @@ const AnalyticsV2Page = ({ enterpriseId }) => {
         <div className="tabs-container">
           <Tabs
             variant="tabs"
+            className="d-flex justify-content-between px-2"
             activeKey={activeTab}
             onSelect={(tab) => {
               setActiveTab(tab);

--- a/src/components/AdvanceAnalyticsV2/tabs/AnalyticsTable.jsx
+++ b/src/components/AdvanceAnalyticsV2/tabs/AnalyticsTable.jsx
@@ -62,7 +62,7 @@ const AnalyticsTable = ({
           title={tableTitle}
           subtitle={tableSubtitle}
           DownloadCSVComponent={(
-            <Link to={CSVDownloadURL} target="_blank" className="btn btn-sm btn-outline-primary ml-0 ml-md-3 mr-3">
+            <Link to={CSVDownloadURL} target="_blank" className="btn btn-sm btn-primary float-right">
               <Icon src={Download} className="mr-2" />
               <FormattedMessage
                 id="adminPortal.AnalyticsV2.downloadCSV.button"


### PR DESCRIPTION
**Description**
- Analytics Tabs were not evenly spaced on analytics V2. So fix that issue.
- The last updated date format did not match with original analytics last updated format for fix that issue.
- Download CSV button styles and alignment did not match with original analytics. So fix that issue.

![image](https://github.com/user-attachments/assets/9240b957-76d1-4794-8a7d-bedc179c095e)
![image](https://github.com/user-attachments/assets/750980a7-2569-4c80-8c8d-2b333ebda2e1)
![image](https://github.com/user-attachments/assets/e9590149-9382-4aeb-8111-92e1f2412e06)


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
