### PR TITLE
fix: analytics v2 fixes

### DIFF
--- a/src/components/AdvanceAnalyticsV2/charts/BarChart.jsx
+++ b/src/components/AdvanceAnalyticsV2/charts/BarChart.jsx
@@ -19,7 +19,7 @@ import PropTypes from 'prop-types';
 const BarChart = ({
   data, xKey, yKey, colorKey, colorMap, hovertemplate, xAxisTitle, yAxisTitle,
 }) => {
-  const categories = Object.keys(colorMap);
+  const categories = Object.keys(colorMap).sort();
 
   const traces = useMemo(() => categories.map(category => {
     const filteredData = data.filter(item => item[colorKey] === category);

--- a/src/components/AdvanceAnalyticsV2/charts/LineChart.jsx
+++ b/src/components/AdvanceAnalyticsV2/charts/LineChart.jsx
@@ -41,7 +41,6 @@ const LineChart = ({
     },
     xaxis: { title: xAxisTitle },
     yaxis: { title: yAxisTitle },
-    dragmode: false,
     autosize: true,
   };
 

--- a/src/components/AdvanceAnalyticsV2/tabs/Completions.jsx
+++ b/src/components/AdvanceAnalyticsV2/tabs/Completions.jsx
@@ -138,7 +138,7 @@ const Completions = ({
           chartType="BarChart"
           chartProps={{
             data: data?.topCoursesByCompletions,
-            xKey: 'courseTitle',
+            xKey: 'courseKey',
             yKey: 'completionCount',
             colorKey: 'enrollType',
             colorMap: chartColorMap,

--- a/src/components/AdvanceAnalyticsV2/tabs/Engagements.jsx
+++ b/src/components/AdvanceAnalyticsV2/tabs/Engagements.jsx
@@ -137,7 +137,7 @@ const Engagements = ({
           chartType="BarChart"
           chartProps={{
             data: data?.topCoursesByEngagement,
-            xKey: 'courseTitle',
+            xKey: 'courseKey',
             yKey: 'learningTimeHours',
             colorKey: 'enrollType',
             colorMap: chartColorMap,

--- a/src/components/AdvanceAnalyticsV2/tabs/Enrollments.jsx
+++ b/src/components/AdvanceAnalyticsV2/tabs/Enrollments.jsx
@@ -138,7 +138,7 @@ const Enrollments = ({
           chartType="BarChart"
           chartProps={{
             data: data?.topCoursesByEnrollments,
-            xKey: 'courseTitle',
+            xKey: 'courseKey',
             yKey: 'enrollmentCount',
             colorKey: 'enrollType',
             colorMap: chartColorMap,


### PR DESCRIPTION
**Description:** 
* Sorted the `audit` and `certificate` enrollment types so that `audit` data always comes first.
* Use the `courseKey` instead of `courseTitle` in top 10 courses charts so that we can compare the charts between V1 and V2. This change is needed because we are not `courseTitle` in V1 and this makes chart comparison difficult and add ambiguity. 

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
