### PR TITLE
fix: refresh group list after adding group

### DIFF
--- a/src/components/PeopleManagement/CreateGroupModal.jsx
+++ b/src/components/PeopleManagement/CreateGroupModal.jsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState, useEffect } from 'react';
 import { logError } from '@edx/frontend-platform/logging';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { useQueryClient } from '@tanstack/react-query';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { snakeCaseObject } from '@edx/frontend-platform/utils';
 import {
@@ -10,6 +11,7 @@ import {
 import LmsApiService from '../../data/services/LmsApiService';
 import SystemErrorAlertModal from '../learner-credit-management/cards/assignment-allocation-status-modals/SystemErrorAlertModal';
 import CreateGroupModalContent from './CreateGroupModalContent';
+import { learnerCreditManagementQueryKeys } from '../learner-credit-management/data';
 
 const CreateGroupModal = ({
   isModalOpen,
@@ -27,6 +29,7 @@ const CreateGroupModal = ({
     closeModal();
     setCreateButtonState('default');
   };
+  const queryClient = useQueryClient();
 
   const handleCreateGroup = async () => {
     setCreateButtonState('pending');
@@ -49,6 +52,9 @@ const CreateGroupModal = ({
         learnerEmails,
       });
       await LmsApiService.inviteEnterpriseLearnersToGroup(groupCreationResponse.data.uuid, requestBody);
+      queryClient.invalidateQueries({
+        queryKey: learnerCreditManagementQueryKeys.group(enterpriseUUID),
+      });
       setCreateButtonState('complete');
       handleCloseCreateGroupModal();
     } catch (err) {

--- a/src/components/PeopleManagement/tests/PeopleManagementPage.test.jsx
+++ b/src/components/PeopleManagement/tests/PeopleManagementPage.test.jsx
@@ -33,6 +33,11 @@ const subsEnterpriseSubsidiesContextValue = {
   isLoading: false,
 };
 
+jest.mock('@tanstack/react-query', () => ({
+  ...jest.requireActual('@tanstack/react-query'),
+  useQueryClient: jest.fn(),
+}));
+
 jest.mock('../../learner-credit-management/data', () => ({
   ...jest.requireActual('../../learner-credit-management/data'),
   useAllEnterpriseGroups: jest.fn(),


### PR DESCRIPTION
[Jira Ticket](https://2u-internal.atlassian.net/browse/ENT-9694)

# Testing

- Checkout branch mkeating/ENT-9694 and visit link https://localhost.stage.edx.org:1991/alc-general/admin/people-management
- Click 'Create group' and go through the group creation process
-  Verify that after creating group, the new group immediately appears in the group listings page without manually refreshing the page


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
