### PR TITLE
feat: no 14-day threshold for allowed refundable time

### DIFF
--- a/src/components/learner-credit-management/data/constants.js
+++ b/src/components/learner-credit-management/data/constants.js
@@ -102,9 +102,6 @@ export const ENROLL_BY_DATE_DAYS_THRESHOLD = 10;
 // Allocation assignment expiration dropoff threshold
 export const DAYS_UNTIL_ASSIGNMENT_ALLOCATION_EXPIRATION = 90;
 
-// Maximum days allowed from enrollment for a refund on assignments related to policies
-export const MAX_ALLOWABLE_REFUND_THRESHOLD_DAYS = 14;
-
 // When the start date is before this number of days before today, display the alternate start date (fixed to today).
 export const START_DATE_DEFAULT_TO_TODAY_THRESHOLD_DAYS = 14;
 

--- a/src/components/learner-credit-management/data/utils.js
+++ b/src/components/learner-credit-management/data/utils.js
@@ -14,7 +14,6 @@ import {
   DAYS_UNTIL_ASSIGNMENT_ALLOCATION_EXPIRATION,
   LATE_ENROLLMENTS_BUFFER_DAYS,
   LOW_REMAINING_BALANCE_PERCENT_THRESHOLD,
-  MAX_ALLOWABLE_REFUND_THRESHOLD_DAYS,
   NO_BALANCE_REMAINING_DOLLAR_THRESHOLD,
   START_DATE_DEFAULT_TO_TODAY_THRESHOLD_DAYS,
 } from './constants';
@@ -566,7 +565,7 @@ export const isLmsBudget = (
  */
 export const isDateBeforeToday = date => dayjs(date).isBefore(dayjs());
 
-const subsidyExpirationRefundCutoffDate = ({ subsidyExpirationDatetime }) => dayjs(subsidyExpirationDatetime).subtract(MAX_ALLOWABLE_REFUND_THRESHOLD_DAYS, 'days').toDate();
+const subsidyExpirationRefundCutoffDate = ({ subsidyExpirationDatetime }) => dayjs(subsidyExpirationDatetime).toDate();
 
 export const isCourseSelfPaced = ({ pacingType }) => pacingType === COURSE_PACING_MAP.SELF_PACED;
 


### PR DESCRIPTION
Before change, course starts tomorrow, subsidy expires in two days:
<img width="1640" alt="image" src="https://github.com/user-attachments/assets/86ec8707-c480-4ece-8f63-5cf3f60e2276">

After change, same dates for course and subsidy record:
<img width="1633" alt="image" src="https://github.com/user-attachments/assets/396e245d-bdc0-4962-8bec-bf6c96888fce">

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
