### PR TITLE
feat: update pagination for reporting configurations

### DIFF
--- a/src/data/services/LmsApiService.js
+++ b/src/data/services/LmsApiService.js
@@ -120,7 +120,7 @@ class LmsApiService {
   }
 
   static fetchReportingConfigs(uuid) {
-    return LmsApiService.apiClient().get(`${LmsApiService.reportingConfigUrl}?enterprise_customer=${uuid}`);
+    return LmsApiService.apiClient().get(`${LmsApiService.reportingConfigUrl}?enterprise_customer=${uuid}&page_size=100`);
   }
 
   static fetchReportingConfigTypes(uuid) {

--- a/src/data/services/tests/LmsApiService.test.js
+++ b/src/data/services/tests/LmsApiService.test.js
@@ -114,4 +114,29 @@ describe('LmsApiService', () => {
       },
     });
   });
+  test('fetchReportingConfigs returns reporting configs', async () => {
+    axios.get.mockResolvedValue({
+      status: 200,
+      data: {
+        results: [{
+          active: true,
+          data_type: 'test-data-type',
+          uuid: 'test-uuid',
+          enterprise_customer: 'test-enterprise-customer',
+        }],
+      },
+    });
+    const response = await LmsApiService.fetchReportingConfigs();
+    expect(response).toEqual({
+      status: 200,
+      data: {
+        results: [{
+          active: true,
+          data_type: 'test-data-type',
+          uuid: 'test-uuid',
+          enterprise_customer: 'test-enterprise-customer',
+        }],
+      },
+    });
+  });
 });


### PR DESCRIPTION
**Description**
These changes are to resolve the issue that NUS is facing. Only 10 reports are showing up on the admin portal. This is a temporary solution, I am working on implementing pagination on the Reporting Configuration page.

Issue: https://2u-internal.atlassian.net/browse/ENT-9728

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
