### PR TITLE
fix: validate insights before rendering analytics summary & improve error message

### DIFF
--- a/src/components/Admin/AIAnalyticsSummary.jsx
+++ b/src/components/Admin/AIAnalyticsSummary.jsx
@@ -19,7 +19,7 @@ const AnalyticsDetailCard = ({
   const messages = defineMessages({
     errorMessage: {
       id: 'adminPortal.analyticsCardText.errorMessage',
-      defaultMessage: 'An error occurred: {error_message}',
+      defaultMessage: 'We encountered an issue while fetching analytics data. Kindly try again later or contact support for assistance. (Error: {error_message})',
       description: 'Message shown to the user in case of error returned byt analytics API.',
       values: { error_message: error?.message },
     },
@@ -38,7 +38,7 @@ const AnalyticsDetailCard = ({
         </Badge>
         <Stack gap={1} direction="horizontal">
           <p className="card-text text-justify small">
-            ${
+            {
               error ? (
                 <FormattedMessage {...messages.errorMessage} />
               ) : (

--- a/src/components/Admin/index.jsx
+++ b/src/components/Admin/index.jsx
@@ -423,6 +423,8 @@ class Admin extends React.Component {
       searchBudgetQuery: queryParams.get('budget_uuid') || '',
     };
 
+    const hasCompleteInsights = insights?.learner_engagement && insights?.learner_progress;
+
     return (
       <main role="main" className="learner-progress-report">
         {!loading && !error && !this.hasAnalyticsData() ? <EnterpriseAppSkeleton /> : (
@@ -445,7 +447,7 @@ class Admin extends React.Component {
               <div className="row mt-4">
                 <div className="col">
                   {insightsLoading ? <AIAnalyticsSummarySkeleton /> : (
-                    insights && <AIAnalyticsSummary enterpriseId={enterpriseId} />
+                    hasCompleteInsights && <AIAnalyticsSummary enterpriseId={enterpriseId} />
                   )}
                 </div>
               </div>


### PR DESCRIPTION
**Ticket:** 
https://2u-internal.atlassian.net/browse/ENT-8817

**Description:** 
For test enterprises, there is incomplete data in analytics, which was causing the `analytics-summary` API to return a bad request error. A validation check has been added to ensure the `Summarize Analytics` button is only displayed for users with complete insights data, against which the analytics summary can be tailored. 
Additionally, the error message has been improved to provide clearer information in case of any technical issues.

# For all changes
- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
