### PR TITLE
[ENT-9879] Validate 'ordering' parameter before sorting the data

### DIFF
--- a/src/components/TableComponent/index.jsx
+++ b/src/components/TableComponent/index.jsx
@@ -31,7 +31,7 @@ class TableComponent extends React.Component {
       const currentQueryParams = new URLSearchParams(location.search);
       const page = currentQueryParams.get('page');
       const ordering = currentQueryParams.get('ordering');
-      if (ordering !== prevOrdering) {
+      if (ordering && ordering !== prevOrdering) {
         this.props.sortTable(ordering);
       } else if (page !== prevPage) {
         this.props.paginateTable(parseInt(page, 10));

--- a/src/components/TableComponent/index.test.jsx
+++ b/src/components/TableComponent/index.test.jsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { shallow } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
+import TableComponent from './index';
+
+jest.mock('@edx/frontend-enterprise-utils', () => ({
+  sendEnterpriseTrackEvent: jest.fn(),
+}));
+jest.mock('../../utils', () => ({
+  updateUrl: jest.fn(),
+}));
+
+const mockPaginateTable = jest.fn();
+const mockSortTable = jest.fn();
+const mockClearTable = jest.fn();
+
+const mockDefaultProps = {
+  id: 'test-table',
+  columns: [],
+  formatData: jest.fn(data => data),
+  enterpriseId: 'enterprise-id',
+  paginateTable: mockPaginateTable,
+  sortTable: mockSortTable,
+  clearTable: mockClearTable,
+  location: { pathname: '/test', search: '' },
+  navigate: jest.fn(),
+};
+
+const TableComponentWrapper = props => (
+  <MemoryRouter>
+    <TableComponent {...props} />
+  </MemoryRouter>
+);
+
+describe('TableComponent', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the loading message when loading and no data is available', () => {
+    const defaultProps = {
+      ...mockDefaultProps,
+      loading: true,
+      data: undefined,
+    };
+
+    render(<TableComponentWrapper {...defaultProps} />);
+
+    expect(screen.getByText('Loading...'));
+  });
+
+  it('renders the error message when there is an error', () => {
+    const errorProps = { ...mockDefaultProps, error: new Error('Test Error') };
+    render(<TableComponentWrapper {...errorProps} />);
+    expect(screen.getByText('Unable to load data'));
+    expect(screen.getByText('Try refreshing your screen Test Error'));
+  });
+
+  it('renders the empty data message when no data is available', () => {
+    render(<TableComponentWrapper {...mockDefaultProps} data={[]} />);
+    expect(screen.getByText('There are no results.'));
+  });
+
+  it('renders the table content when data is available', () => {
+    const dataProps = {
+      ...mockDefaultProps,
+      data: [
+        {
+          user_email: 'testuser1@gmail.com',
+          enrollment_id: 6066,
+          enrollment_date: '2024-12-30',
+          course_key: 'TEFLx+GRA.30.1x',
+          courserun_key: 'course-v1:TEFLx+GRA.30.1x+3T2024',
+          course_title: '30-hour Grammar and Language Awareness',
+          passed_date: '2025-01-04',
+          current_grade: 0.98,
+        },
+        {
+          user_email: 'testuser2@gmail.com',
+          enrollment_id: 5055,
+          enrollment_date: '2024-07-13',
+          course_key: 'FEFRx+GIA.30.1x',
+          courserun_key: 'course-v1:FEFRx+GIA.30.1x+3T2024',
+          course_title: 'Project Management Professional',
+          passed_date: '2025-03-01',
+          current_grade: 0.88,
+        },
+      ],
+      columns: [
+        { key: 'user_email', label: 'Email', columnSortable: true },
+        { key: 'course_title', label: 'Course Title', columnSortable: false },
+        { key: 'current_grade', label: 'Current Grade', columnSortable: true },
+      ],
+      currentPage: 1,
+      pageCount: 1,
+      ordering: 'current_grade',
+      loading: false,
+      error: undefined,
+    };
+
+    render(<TableComponentWrapper {...dataProps} />);
+
+    expect(screen.getByText('Email'));
+    expect(screen.getByText('Course Title'));
+    expect(screen.getByText('Current Grade'));
+
+    expect(screen.getByText('testuser1@gmail.com'));
+    expect(screen.getByText('30-hour Grammar and Language Awareness'));
+    expect(screen.getByText('0.98'));
+
+    expect(screen.getByText('testuser2@gmail.com'));
+    expect(screen.getByText('Project Management Professional'));
+    expect(screen.getByText('0.88'));
+  });
+
+  it('calls paginateTable on mount', () => {
+    render(<TableComponentWrapper {...mockDefaultProps} />);
+
+    expect(mockPaginateTable).toHaveBeenCalled();
+  });
+
+  it('calls clearTable on unmount', () => {
+    const { unmount } = render(<TableComponentWrapper {...mockDefaultProps} />);
+    unmount();
+    expect(mockClearTable).toHaveBeenCalled();
+  });
+
+  it('Does not call sortTable when ordering is null or undefined', () => {
+    const prevOrdering = null;
+
+    let ordering;
+    const wrapper = shallow(
+      <TableComponentWrapper
+        ordering={ordering}
+        prevOrdering={prevOrdering}
+        sortTable={mockSortTable}
+      />,
+    );
+    expect(mockSortTable).not.toHaveBeenCalled();
+
+    ordering = null;
+    wrapper.setProps({ ordering });
+    expect(mockSortTable).not.toHaveBeenCalled();
+  });
+
+  it('calls sortTable when ordering changes', () => {
+    const defaultProps = {
+      ...mockDefaultProps,
+      location: { search: '?ordering=current_grade&page=1' },
+      sortTable: mockSortTable,
+      paginateTable: mockPaginateTable,
+    };
+
+    const { rerender } = render(<TableComponentWrapper {...defaultProps} />);
+
+    // Simulate a change in the query params, causing componentDidUpdate to be triggered
+    const newLocation = { search: '?ordering=-current_grade&page=2' };
+
+    rerender(<TableComponentWrapper {...defaultProps} location={newLocation} />);
+
+    expect(mockSortTable).toHaveBeenCalledWith('-current_grade');
+  });
+
+  it('does not call sortTable when ordering is null or undefined', () => {
+    const defaultProps = {
+      ...mockDefaultProps,
+      location: { search: '?ordering=null&page=1' }, // Set ordering to null in query params
+      sortTable: mockSortTable,
+      paginateTable: mockPaginateTable,
+    };
+
+    const { rerender } = render(<TableComponentWrapper {...defaultProps} />);
+
+    // Simulate a change where ordering is undefined in the query params
+    const newLocation = { search: '?ordering=&page=2' }; // ordering is undefined in query params
+
+    rerender(<TableComponentWrapper {...defaultProps} location={newLocation} />);
+
+    expect(mockSortTable).not.toHaveBeenCalled();
+  });
+});

--- a/src/data/actions/table.js
+++ b/src/data/actions/table.js
@@ -119,14 +119,17 @@ const sortTable = (tableId, fetchMethod, ordering) => (
 
     // If we can sort client-side because we have all of the data, do that
     if (tableState.data && tableState.data.num_pages === 1) {
-      const isDesc = ordering.startsWith('-');
+      const isDesc = ordering && ordering.startsWith('-');
       const orderField = isDesc ? ordering.substring(1) : ordering;
-      const result = sortBy(tableState.data.results, orderField);
 
-      return dispatch(sortSuccess(tableId, ordering, {
-        ...tableState.data,
-        results: isDesc ? result.reverse() : result,
-      }));
+      if (orderField) {
+        const result = sortBy(tableState.data.results, orderField);
+
+        return dispatch(sortSuccess(tableId, ordering, {
+          ...tableState.data,
+          results: isDesc ? result.reverse() : result,
+        }));
+      }
     }
 
     return fetchMethod(enterpriseId, options).then((response) => {

--- a/src/data/actions/table.test.js
+++ b/src/data/actions/table.test.js
@@ -22,6 +22,49 @@ describe('actions', () => {
   describe('sortTable', () => {
     const tableId = 'table-id';
 
+    it('does not sort table data when ordering is null or undefined', async () => {
+      const initialTableState = {
+        count: 3,
+        num_pages: 1,
+        results: [
+          {
+            current_grade: 0.92,
+            enrollment_date: '2023-12-21',
+          },
+          {
+            current_grade: 0.82,
+            enrollment_date: '2023-09-12',
+          },
+        ],
+      };
+      const orderingKey = null;
+
+      const mockFetchMethod = jest.fn().mockResolvedValue({ data: initialTableState });
+
+      const store = mockStore({
+        portalConfiguration: {
+          enterpriseId: 'test-enterprise',
+        },
+        table: {
+          'table-id': {
+            data: initialTableState,
+          },
+        },
+      });
+
+      await store.dispatch(sortTable('table-id', mockFetchMethod, orderingKey));
+
+      const sortSuccessAction = store.getActions().find(action => action.type === 'SORT_SUCCESS');
+
+      // Assert that the SORT_SUCCESS action was dispatched with unchanged data
+      expect(sortSuccessAction).toBeDefined();
+      expect(sortSuccessAction.payload).toEqual({
+        tableId: 'table-id',
+        ordering: null,
+        data: initialTableState,
+      });
+    });
+
     describe('sorts tables based on', () => {
       const initialTableState = {
         count: 3,


### PR DESCRIPTION
**Ticket:**
https://2u-internal.atlassian.net/browse/ENT-9879

**Description:**
Added a truthy check for the ordering parameter to ensure the application does not throw runtime errors when the ordering query parameter is temporarily missing or null. 
# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
