### PR TITLE
fix: don't show groups cards zero state while groups data is loading

### DIFF
--- a/src/components/PeopleManagement/index.jsx
+++ b/src/components/PeopleManagement/index.jsx
@@ -3,7 +3,12 @@ import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
-import { ActionRow, Button, useToggle } from '@openedx/paragon';
+import {
+  ActionRow,
+  Button,
+  Skeleton,
+  useToggle,
+} from '@openedx/paragon';
 import { Add } from '@openedx/paragon/icons';
 
 import Hero from '../Hero';
@@ -24,7 +29,7 @@ const PeopleManagementPage = ({ enterpriseId }) => {
   });
 
   const { enterpriseSubsidyTypes } = useContext(EnterpriseSubsidiesContext);
-  const { data } = useAllEnterpriseGroups(enterpriseId);
+  const { data, isLoading: isGroupsLoading } = useAllEnterpriseGroups(enterpriseId);
 
   const hasLearnerCredit = enterpriseSubsidyTypes.includes(SUBSIDY_TYPES.budget);
   const hasOtherSubsidyTypes = enterpriseSubsidyTypes.includes(SUBSIDY_TYPES.license)
@@ -39,6 +44,15 @@ const PeopleManagementPage = ({ enterpriseId }) => {
       setGroups(data.results);
     }
   }, [data]);
+
+  let groupsCardSection = (<Skeleton height="20vh" />);
+  if (!isGroupsLoading) {
+    if (groups && groups.length > 0) {
+      groupsCardSection = (<GroupCardGrid groups={groups} />);
+    } else {
+      groupsCardSection = (<ZeroState />);
+    }
+  }
 
   return (
     <>
@@ -85,11 +99,7 @@ const PeopleManagementPage = ({ enterpriseId }) => {
             closeModal={closeModal}
           />
         </ActionRow>
-        {groups && groups.length > 0 ? (
-          <GroupCardGrid groups={groups} />
-        ) : (
-          <ZeroState />
-        )}
+        {groupsCardSection}
         <h3 className="mt-3">
           <FormattedMessage
             id="adminPortal.peopleManagement.dataTable.title"


### PR DESCRIPTION
[Jira Ticket](https://2u-internal.atlassian.net/browse/ENT-9851)

This change adds a loading skeleton for the groups cards section while groups are loading.

## Testing Instructions

- Check out branch and start with `npm run start:stage`
- Navigate to https://localhost.stage.edx.org:1991/exec-ed-2u-integration-qa/admin/people-management
- Verify groups cards section has a loading Skeleton, which is replaced by the groups cards when loading finishes

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots