### PR TITLE
feat: updates groups page to show only flex groups for customer

### DIFF
--- a/src/components/PeopleManagement/index.jsx
+++ b/src/components/PeopleManagement/index.jsx
@@ -15,7 +15,7 @@ import Hero from '../Hero';
 import { SUBSIDY_TYPES } from '../../data/constants/subsidyTypes';
 import { EnterpriseSubsidiesContext } from '../EnterpriseSubsidiesContext';
 import CreateGroupModal from './CreateGroupModal';
-import { useAllEnterpriseGroups } from '../learner-credit-management/data';
+import { useAllFlexEnterpriseGroups } from '../learner-credit-management/data';
 import ZeroState from './ZeroState';
 import GroupCardGrid from './GroupCardGrid';
 import PeopleManagementTable from './PeopleManagementTable';
@@ -29,7 +29,7 @@ const PeopleManagementPage = ({ enterpriseId }) => {
   });
 
   const { enterpriseSubsidyTypes } = useContext(EnterpriseSubsidiesContext);
-  const { data, isLoading: isGroupsLoading } = useAllEnterpriseGroups(enterpriseId);
+  const { data, isLoading: isGroupsLoading } = useAllFlexEnterpriseGroups(enterpriseId);
 
   const hasLearnerCredit = enterpriseSubsidyTypes.includes(SUBSIDY_TYPES.budget);
   const hasOtherSubsidyTypes = enterpriseSubsidyTypes.includes(SUBSIDY_TYPES.license)

--- a/src/components/PeopleManagement/tests/PeopleManagementPage.test.jsx
+++ b/src/components/PeopleManagement/tests/PeopleManagementPage.test.jsx
@@ -7,7 +7,7 @@ import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 
-import { useAllEnterpriseGroups } from '../../learner-credit-management/data';
+import { useAllFlexEnterpriseGroups } from '../../learner-credit-management/data';
 import { EnterpriseSubsidiesContext } from '../../EnterpriseSubsidiesContext';
 import PeopleManagementPage from '..';
 
@@ -40,7 +40,7 @@ jest.mock('@tanstack/react-query', () => ({
 
 jest.mock('../../learner-credit-management/data', () => ({
   ...jest.requireActual('../../learner-credit-management/data'),
-  useAllEnterpriseGroups: jest.fn(),
+  useAllFlexEnterpriseGroups: jest.fn(),
 }));
 
 const mockGroupsResponse = [{
@@ -89,7 +89,7 @@ const PeopleManagementPageWrapper = ({
 
 describe('<PeopleManagementPage >', () => {
   it('renders the PeopleManagementPage zero state', () => {
-    useAllEnterpriseGroups.mockReturnValue({ data: { results: {} } });
+    useAllFlexEnterpriseGroups.mockReturnValue({ data: { results: {} } });
     render(<PeopleManagementPageWrapper />);
     expect(document.querySelector('h3').textContent).toEqual("Your organization's groups");
     expect(screen.getByText("You don't have any groups yet.")).toBeInTheDocument();
@@ -98,7 +98,7 @@ describe('<PeopleManagementPage >', () => {
     )).toBeInTheDocument();
   });
   it('renders the PeopleManagementPage zero state without LC', () => {
-    useAllEnterpriseGroups.mockReturnValue({ data: { results: [] } });
+    useAllFlexEnterpriseGroups.mockReturnValue({ data: { results: [] } });
     const store = getMockStore(initialStoreState);
     render(
       <IntlProvider locale="en">
@@ -116,7 +116,7 @@ describe('<PeopleManagementPage >', () => {
     expect(screen.getByText("Once a group is created, you can track members' progress.")).toBeInTheDocument();
   });
   it('renders the PeopleManagementPage group card grid', () => {
-    useAllEnterpriseGroups.mockReturnValue({ data: mockGroupsResponse });
+    useAllFlexEnterpriseGroups.mockReturnValue({ data: mockGroupsResponse });
     const store = getMockStore(initialStoreState);
     render(
       <IntlProvider locale="en">
@@ -131,7 +131,7 @@ describe('<PeopleManagementPage >', () => {
     expect(screen.getByText('4 members')).toBeInTheDocument();
   });
   it('renders the PeopleManagementPage group card grid with collapsible', async () => {
-    useAllEnterpriseGroups.mockReturnValue({ data: mockMultipleGroupsResponse });
+    useAllFlexEnterpriseGroups.mockReturnValue({ data: mockMultipleGroupsResponse });
     const store = getMockStore(initialStoreState);
     render(
       <IntlProvider locale="en">

--- a/src/components/learner-credit-management/data/hooks/index.js
+++ b/src/components/learner-credit-management/data/hooks/index.js
@@ -17,7 +17,7 @@ export { default as useEnterpriseGroupLearners } from './useEnterpriseGroupLearn
 export { default as useEnterpriseGroupMembersTableData } from './useEnterpriseGroupMembersTableData';
 export { default as useEnterpriseCustomer } from './useEnterpriseCustomer';
 export { default as useEnterpriseGroup } from './useEnterpriseGroup';
-export { default as useAllEnterpriseGroups } from './useAllEnterpriseGroups';
+export { default as useAllFlexEnterpriseGroups } from './useAllFlexEnterpriseGroups';
 export { default as useContentMetadata } from './useContentMetadata';
 export { default as useEnterpriseRemovedGroupMembers } from './useEnterpriseRemovedGroupMembers';
 export { default as useEnterpriseFlexGroups } from './useEnterpriseFlexGroups';

--- a/src/components/learner-credit-management/data/hooks/useAllFlexEnterpriseGroups.js
+++ b/src/components/learner-credit-management/data/hooks/useAllFlexEnterpriseGroups.js
@@ -10,15 +10,16 @@ import { fetchPaginatedData } from '../../../../data/services/apiServiceUtils';
  * @param {*} queryKey The queryKey from the associated `useQuery` call.
  * @returns The enterprise group object
  */
-const getAllEnterpriseGroups = async ({ enterpriseId }) => {
-  const { results } = await fetchPaginatedData(`${LmsApiService.enterpriseGroupListUrl}?enterprise_uuids${enterpriseId}?group_type=flex`);
-  return results;
+const getAllFlexEnterpriseGroups = async ({ enterpriseId }) => {
+  const { results } = await fetchPaginatedData(`${LmsApiService.enterpriseGroupListUrl}?enterprise_uuids=${enterpriseId}`);
+  const flexGroups = results.filter(result => result.groupType === 'flex');
+  return flexGroups;
 };
 
-const useAllEnterpriseGroups = (enterpriseId, { queryOptions } = {}) => useQuery({
+const useAllFlexEnterpriseGroups = (enterpriseId, { queryOptions } = {}) => useQuery({
   queryKey: learnerCreditManagementQueryKeys.group(enterpriseId),
-  queryFn: () => getAllEnterpriseGroups({ enterpriseId }),
+  queryFn: () => getAllFlexEnterpriseGroups({ enterpriseId }),
   ...queryOptions,
 });
 
-export default useAllEnterpriseGroups;
+export default useAllFlexEnterpriseGroups;


### PR DESCRIPTION
# Description
Fixes bug on the People Management view that is currently displaying all groups (both flex and budget) to all customers. The behavior we want is to only show `flex` groups that were created by that customer.

![Screenshot 2025-01-15 at 3 24 17 PM](https://github.com/user-attachments/assets/f0dea8f4-de4b-47ac-8b34-5fd6873b9c15)

![Screenshot 2025-01-15 at 3 24 42 PM](https://github.com/user-attachments/assets/d7ff795d-e529-4397-b181-9fcaab867ac1)

https://2u-internal.atlassian.net/browse/ENT-9913

# Testing instructions
1. check out this branch locally and run `npm run start:stage`
2. visit link https://localhost.stage.edx.org:1991/aj-test-co/admin/people-management and confirm that you do not see any group cards displayed. Ensure that you also do not see any results from this endpoint https://courses.stage.edx.org/enterprise/api/v1/enterprise_group/?enterprise_uuids=e035cce5-24dd-4be4-896d-497157c09a39. Lastly, confirm that there are no flex groups for that customer here https://internal.courses.stage.edx.org/admin/enterprise/enterprisegroup/ 
3. Repeat the steps above for a second customer (e.g. adam-autoapplied-enterprise)
- https://localhost.stage.edx.org:1991/adam-autoapplied-enterprise/admin/people-management
- https://courses.stage.edx.org/enterprise/api/v1/enterprise_group/?enterprise_uuids=02982884-1f1f-4103-b6d7-3a602c1afcbd
- https://internal.courses.stage.edx.org/admin/enterprise/enterprisegroup/ 

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
