### PR TITLE
feat: View group progress button should link to LPR page filtered by group

### DIFF
--- a/src/components/PeopleManagement/GroupDetailPage/GroupDetailPage.jsx
+++ b/src/components/PeopleManagement/GroupDetailPage/GroupDetailPage.jsx
@@ -122,7 +122,7 @@ const GroupDetailPage = () => {
               <Hyperlink
                 className="btn btn-primary"
                 target="_blank"
-                destination={`/${enterpriseSlug}/admin/${ROUTE_NAMES.learners}`}
+                destination={`/${enterpriseSlug}/admin/${ROUTE_NAMES.learners}?group_uuid=${groupUuid}`}
               >
                 View group progress
               </Hyperlink>

--- a/src/components/PeopleManagement/tests/GroupDetailPage.test.jsx
+++ b/src/components/PeopleManagement/tests/GroupDetailPage.test.jsx
@@ -99,6 +99,8 @@ describe('<GroupDetailPageWrapper >', () => {
     expect(screen.getByText('View group progress')).toBeInTheDocument();
     expect(screen.getByText('Add and remove group members.')).toBeInTheDocument();
     expect(screen.getByText('Test 2u')).toBeInTheDocument();
+    const lprUrl = screen.getByText('View group progress');
+    expect(lprUrl).toHaveAttribute('href', '/test-enterprise/admin/learners?group_uuid=12345');
     userEvent.click(screen.getByText('Member details'));
     await waitFor(() => expect(mockFetchEnterpriseGroupLearnersTableData).toHaveBeenCalledWith({
       filters: [],


### PR DESCRIPTION
[Jira Ticket](https://2u-internal.atlassian.net/browse/ENT-9920)

This change makes the 'View group progress' button on the Group detail page navigate to the Learner Progress Report page with the filter set to the group in question.

## Test Instructions
- Check out branch and start with npm run start:stage
- Navigate to https://localhost.stage.edx.org:1991/alc-general/admin/people-management/3de34823-664e-4eee-9756-12c25f0172de
- Verify 'View group progress' url has parameter `group_uuid=3de34823-664e-4eee-9756-12c25f0172de`

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
