### PR TITLE
fix: budget invite text entry bugs

### DIFF
--- a/src/components/learner-credit-management/invite-modal/tests/InviteMemberModal.test.jsx
+++ b/src/components/learner-credit-management/invite-modal/tests/InviteMemberModal.test.jsx
@@ -165,6 +165,7 @@ describe('<InviteMemberModal />', () => {
 
     userEvent.type(textareaInput, mockLearnerEmails.join('{enter}'));
     expect(textareaInput).toHaveValue(mockLearnerEmails.join('\n'));
+    userEvent.tab();
     await waitFor(() => {
       expect(screen.getByText(`Summary (${mockLearnerEmails.length})`)).toBeInTheDocument();
     }, { timeout: EMAIL_ADDRESSES_INPUT_VALUE_DEBOUNCE_DELAY + 1000 });
@@ -255,7 +256,8 @@ describe('<InviteMemberModal />', () => {
       value: [fakeFile],
     });
     fireEvent.drop(dropzone);
-
+    // TODO: Test csv upload
+    userEvent.tab();
     await waitFor(() => {
       expect(screen.getByText('tammiswanson is not a valid email.')).toBeInTheDocument();
     }, { timeout: EMAIL_ADDRESSES_INPUT_VALUE_DEBOUNCE_DELAY + 1000 });
@@ -269,6 +271,7 @@ describe('<InviteMemberModal />', () => {
     const textareaInputLabel = screen.getByLabelText('Member email addresses');
     const textareaInput = textareaInputLabel.closest('textarea');
     userEvent.type(textareaInput, mockLearnerEmails.join('{enter}'));
+    userEvent.tab();
     expect(textareaInput).toHaveValue(mockLearnerEmails.join('\n'));
     await waitFor(() => {
       expect(screen.getByText(`Summary (${mockLearnerEmails.length})`)).toBeInTheDocument();
@@ -290,6 +293,7 @@ describe('<InviteMemberModal />', () => {
     const textareaInputLabel = screen.getByLabelText('Member email addresses');
     const textareaInput = textareaInputLabel.closest('textarea');
     userEvent.type(textareaInput, 'sillygoosethisisntanemail');
+    userEvent.tab();
     await waitFor(() => {
       expect(screen.getByText('Members can\'t be invited as entered.')).toBeInTheDocument();
       expect(screen.getByText('Please check your member emails and try again.')).toBeInTheDocument();
@@ -305,6 +309,7 @@ describe('<InviteMemberModal />', () => {
     userEvent.type(textareaInput, 'sillygoosethisisntanemail');
     userEvent.type(textareaInput, '{enter}');
     userEvent.type(textareaInput, 'neitheristhis');
+    userEvent.tab();
     await waitFor(() => {
       expect(screen.getByText('Members can\'t be invited as entered.')).toBeInTheDocument();
       expect(screen.getByText('Please check your member emails and try again.')).toBeInTheDocument();
@@ -322,6 +327,7 @@ describe('<InviteMemberModal />', () => {
     userEvent.type(textareaInput, 'neitheristhis');
     userEvent.type(textareaInput, '{enter}');
     userEvent.type(textareaInput, 'but@this.is');
+    userEvent.tab();
     await waitFor(() => {
       expect(screen.getByText('Summary (1)')).toBeInTheDocument();
       expect(screen.getByText('Members can\'t be invited as entered.')).toBeInTheDocument();
@@ -337,6 +343,7 @@ describe('<InviteMemberModal />', () => {
     userEvent.type(textareaInput, 'oopsallberries@example.com');
     userEvent.type(textareaInput, '{enter}');
     userEvent.type(textareaInput, 'oopsallberries@example.com');
+    userEvent.tab();
     await waitFor(() => {
       expect(screen.getByText('Summary (1)')).toBeInTheDocument();
       expect(screen.getByText('oopsallberries@example.com was entered more than once.')).toBeInTheDocument();
@@ -354,6 +361,7 @@ describe('<InviteMemberModal />', () => {
     userEvent.type(textareaInput, 'oopsallberries@example.com');
     userEvent.type(textareaInput, '{enter}');
     userEvent.type(textareaInput, 'sillygoosethisisntanemail');
+    userEvent.tab();
     await waitFor(() => {
       expect(screen.getByText('Summary (1)')).toBeInTheDocument();
       expect(screen.getByText('sillygoosethisisntanemail is not a valid email.')).toBeInTheDocument();
@@ -372,6 +380,7 @@ describe('<InviteMemberModal />', () => {
     userEvent.type(textareaInput, 'oopsallberries@example.com');
     userEvent.type(textareaInput, '{enter}');
     userEvent.type(textareaInput, 'sillygoosethisisntanemail');
+    userEvent.tab();
     await waitFor(() => {
       expect(screen.getByText('Summary (1)')).toBeInTheDocument();
       expect(screen.getByText('sillygoosethisisntanemail is not a valid email.')).toBeInTheDocument();


### PR DESCRIPTION
[Jira Ticket](https://2u-internal.atlassian.net/browse/ENT-9846)

This change fixes some issues around email input validation on the Learner Credit Browse and Enroll Add Members modal.

## Testing
### Setup
- Go to the admin-portal repo and run `npm run start:stage`
- Navigate to https://localhost.stage.edx.org:1991/timtam/admin/learner-credit/ecdfe8e7-94cd-461b-bd9d-205094f04f46/members
- Click 'New members'

### Verify
- While typing, no error messages on the incomplete email addresses appear.
- Validation happens under the following conditions
  - Enter is pressed
  - The mouse moves
  - The text input field is navigated away from via keyboard (Tab key)
- If the part of a valid email address before the '@' is altered, it will not register duplicate emails

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
