### PR TITLE
fix: create group support multiple csv files

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -655,6 +655,13 @@ function downloadCsv(fileName, data, headers, dataEntryToRow) {
   saveAs(blob, fileName);
 }
 
+/**
+ * Split a string by given separator, and return array of trimmed, non-blank string entries
+ */
+function splitAndTrim(separator, str) {
+  return str.split(separator).map((subStr) => subStr.trim()).filter((subStr) => subStr.length > 0);
+}
+
 export {
   camelCaseDict,
   camelCaseDictArray,
@@ -704,4 +711,5 @@ export {
   isFalsy,
   getTimeStampedFilename,
   downloadCsv,
+  splitAndTrim,
 };

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -16,6 +16,7 @@ import {
   i18nFormatProgressStatus,
   getTimeStampedFilename,
   downloadCsv,
+  splitAndTrim,
 } from './utils';
 
 jest.mock('@edx/frontend-platform/logging', () => ({
@@ -209,6 +210,12 @@ describe('utils', () => {
         type: 'text/csv',
       });
       expect(saveAs).toHaveBeenCalledWith({}, fileName);
+    });
+  });
+  describe('splitAndTrim', () => {
+    it('returns split and trimmed string array', () => {
+      const csvStr = 'a,b,,c ,';
+      expect(splitAndTrim(',', csvStr)).toEqual(['a', 'b', 'c']);
     });
   });
 });


### PR DESCRIPTION
[Jira Ticket](https://2u-internal.atlassian.net/browse/ENT-9932)

This change fixes some bugs in the behavior of uploading csv lists of enterprise members to add to a new group.

## Testing Instructions

- Go to the admin-portal repo, pull down branch, and run npm run start:stage
- Navigate to https://localhost.stage.edx.org:1991/alc-general/admin/people-management
- Click 'Create group'
- Upload csv file containing enterprise members
- Click check box next to one of the added members, and click 'Remove'
- Upload same csv file again
- Verify the removed member was re-added

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
