### PR TITLE
fix: in group creation don't show duplicate error message when members added again

### DIFF
--- a/src/components/PeopleManagement/CreateGroupModalContent.jsx
+++ b/src/components/PeopleManagement/CreateGroupModalContent.jsx
@@ -56,7 +56,8 @@ const CreateGroupModalContent = ({
       onEmailAddressesChange([]);
       return;
     }
-    setLearnerEmails(prev => [...prev, ...value]);
+    // Merge new emails with old emails (removing duplicates)
+    setLearnerEmails(prev => _.union(prev, value));
     setIsCreateGroupListSelection(true);
   }, [onEmailAddressesChange, setIsCreateGroupListSelection]);
 

--- a/src/components/PeopleManagement/tests/CreateGroupModal.test.jsx
+++ b/src/components/PeopleManagement/tests/CreateGroupModal.test.jsx
@@ -405,4 +405,22 @@ describe('<CreateGroupModal />', () => {
       )).toBeInTheDocument();
     });
   });
+  it('does not show duplicate error when members are bulk added multiple times', async () => {
+    render(<CreateGroupModalWrapper />);
+    // testing interaction with adding members from the datatable
+    const membersCheckboxes = screen.getAllByRole('checkbox');
+    // skipping first one because its the select all checkbox
+    userEvent.click(membersCheckboxes[1]);
+    const addMembersButton = screen.getByText('Add');
+    userEvent.click(addMembersButton);
+    // Select a second member while keeping first selected, and add again
+    userEvent.click(membersCheckboxes[2]);
+    userEvent.click(addMembersButton);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('testuser-1@2u.com')).toHaveLength(2);
+      expect(screen.getAllByText('testuser-2@2u.com')).toHaveLength(2);
+    });
+    expect(screen.queryByText('Only 1 invite per email address will be sent.')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
[Jira Ticket](https://2u-internal.atlassian.net/browse/ENT-10046)

This change makes it so that when members are repeatedly added to a group from the member table, a duplicate error is not shown.

## Testing Instructions

- Go to the admin-portal repo, pull down branch, and run npm run start:stage
- Navigate to https://localhost.stage.edx.org:1991/alc-general/admin/people-management
- Click 'Create group'
- Check one member and click 'Add' button
- While leaving first member checked, check another member in the table, click 'Add' again
- Verify that both members are shown in the Summary section, and there is no error message indicating duplicate members have been added.

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
