### PR TITLE
fix: clear errors from invalid group email csv upload

### DIFF
--- a/src/components/PeopleManagement/CreateGroupModalContent.jsx
+++ b/src/components/PeopleManagement/CreateGroupModalContent.jsx
@@ -11,7 +11,7 @@ import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import InviteModalSummary from '../learner-credit-management/invite-modal/InviteModalSummary';
 import InviteSummaryCount from '../learner-credit-management/invite-modal/InviteSummaryCount';
 import FileUpload from '../learner-credit-management/invite-modal/FileUpload';
-import { isInviteEmailAddressesInputValueValid } from '../learner-credit-management/cards/data';
+import { isInviteEmailAddressesInputValueValid, removeInvalidEmailsFromList } from '../learner-credit-management/cards/data';
 import { HELP_CENTER_URL, MAX_LENGTH_GROUP_NAME } from './constants';
 import EnterpriseCustomerUserDataTable from './EnterpriseCustomerUserDataTable';
 import { useEnterpriseLearners } from '../learner-credit-management/data';
@@ -70,11 +70,13 @@ const CreateGroupModalContent = ({
   }, [onEmailAddressesChange]);
 
   const handleCsvUpload = useCallback((emails) => {
+    // Remove errored emails from the main list
+    const cleanEmails = removeInvalidEmailsFromList(learnerEmails, memberInviteMetadata);
     // Merge new emails with old emails (removing duplicates)
-    const allEmails = _.union(learnerEmails, splitAndTrim('\n', emails));
+    const allEmails = _.union(cleanEmails, splitAndTrim('\n', emails));
     setLearnerEmails(allEmails);
     setIsCreateGroupFileUpload(true);
-  }, [learnerEmails, setIsCreateGroupFileUpload]);
+  }, [learnerEmails, memberInviteMetadata, setIsCreateGroupFileUpload]);
 
   // Validate the learner emails emails from user input whenever it changes
   useEffect(() => {

--- a/src/components/PeopleManagement/tests/CreateGroupModal.test.jsx
+++ b/src/components/PeopleManagement/tests/CreateGroupModal.test.jsx
@@ -348,6 +348,40 @@ describe('<CreateGroupModal />', () => {
       expect(screen.getAllByText('testuser-2@2u.com')).toHaveLength(2);
     }, { timeout: EMAIL_ADDRESSES_INPUT_VALUE_DEBOUNCE_DELAY + 1000 });
   });
+  it('should clear errors from bad csv file after uploading good csv file', async () => {
+    render(<CreateGroupModalWrapper />);
+    const fakeFile = new File(['iamnotanemail'], 'bademails.csv', { type: 'text/csv' });
+    const dropzone = screen.getByText('Drag and drop your file here or click to upload.');
+    Object.defineProperty(dropzone, 'files', {
+      value: [fakeFile],
+      writable: true,
+    });
+    fireEvent.drop(dropzone);
+
+    await waitFor(() => {
+      expect(screen.getByText('bademails.csv')).toBeInTheDocument();
+      expect(screen.getByText("Members can't be invited as entered.")).toBeInTheDocument();
+      expect(screen.getByText('iamnotanemail is not a valid email.')).toBeInTheDocument();
+    }, { timeout: EMAIL_ADDRESSES_INPUT_VALUE_DEBOUNCE_DELAY + 1000 });
+
+    const dropzone2 = screen.getByText('bademails.csv');
+    const fakeFile2 = new File(['testuser-1@2u.com'], 'goodemails.csv', { type: 'text/csv' });
+    Object.defineProperty(dropzone2, 'files', {
+      value: [fakeFile2],
+    });
+    fireEvent.drop(dropzone2);
+
+    const groupNameInput = screen.getByTestId('group-name');
+    userEvent.type(groupNameInput, 'test group name');
+
+    await waitFor(() => {
+      expect(screen.getByText('goodemails.csv')).toBeInTheDocument();
+      expect(screen.getByText('Summary (1)')).toBeInTheDocument();
+      expect(screen.getAllByText('testuser-1@2u.com')).toHaveLength(2);
+    }, { timeout: EMAIL_ADDRESSES_INPUT_VALUE_DEBOUNCE_DELAY + 1000 });
+    expect(screen.queryByText("Members can't be invited as entered.")).not.toBeInTheDocument();
+    expect(screen.queryByText('iamnotanemail is not a valid email.')).not.toBeInTheDocument();
+  });
   it('displays error for email not belonging in an org', async () => {
     const mockGroupData = { uuid: 'test-uuid' };
     LmsApiService.createEnterpriseGroup.mockResolvedValue({ status: 201, data: mockGroupData });

--- a/src/utils.js
+++ b/src/utils.js
@@ -662,6 +662,19 @@ function splitAndTrim(separator, str) {
   return str.split(separator).map((subStr) => subStr.trim()).filter((subStr) => subStr.length > 0);
 }
 
+/**
+ *
+ * @param {Array<string>} list
+ *  List of strings to remove from
+ * @param {Array<string>} stringsToRemove
+ *  Strings that should be removed from list
+ * @returns {Array<string>}
+ */
+function removeStringsFromList(list, stringsToRemove) {
+  const removalSet = new Set([...stringsToRemove]);
+  return list.filter((item) => !removalSet.has(item));
+}
+
 export {
   camelCaseDict,
   camelCaseDictArray,
@@ -712,4 +725,5 @@ export {
   getTimeStampedFilename,
   downloadCsv,
   splitAndTrim,
+  removeStringsFromList,
 };

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -17,6 +17,7 @@ import {
   getTimeStampedFilename,
   downloadCsv,
   splitAndTrim,
+  removeStringsFromList,
 } from './utils';
 
 jest.mock('@edx/frontend-platform/logging', () => ({
@@ -216,6 +217,13 @@ describe('utils', () => {
     it('returns split and trimmed string array', () => {
       const csvStr = 'a,b,,c ,';
       expect(splitAndTrim(',', csvStr)).toEqual(['a', 'b', 'c']);
+    });
+  });
+  describe('removeStringsFromList', () => {
+    it('should remove strings from list', () => {
+      const list = ['a', 'b', 'c', 'd'];
+      const remove = ['b', 'd'];
+      expect(removeStringsFromList(list, remove)).toEqual(['a', 'c']);
     });
   });
 });


### PR DESCRIPTION
[Jira Ticket](https://2u-internal.atlassian.net/browse/ENT-10024)

This change makes it so that if an invalid email csv file is uploaded, the error will clear once a valid csv file is uploaded.

## Testing Instructions

- Go to the admin-portal repo, pull down branch, and run npm run start:stage
- Navigate to https://localhost.stage.edx.org:1991/alc-general/admin/people-management
- Click 'Create group'
- Upload csv file containing one or more invalid emails
- Verify error message is shown
- Upload csv file containing only valid emails
- Verify error message disappears

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
