### PR TITLE
fix: createEnterpriseGroup response camelCase

### DIFF
--- a/src/data/services/LmsApiService.ts
+++ b/src/data/services/LmsApiService.ts
@@ -66,14 +66,20 @@ class LmsApiService {
 
   static enterpriseLearnerUrl = `${LmsApiService.baseUrl}/enterprise/api/v1/enterprise-learner/`;
 
-  static createEnterpriseGroup({ groupName, enterpriseUUID }: CreateEnterpriseGroupArgs): EnterpriseGroup {
+  static async createEnterpriseGroup(
+    {
+      groupName,
+      enterpriseUUID,
+    }: CreateEnterpriseGroupArgs,
+  ): EnterpriseGroupResponse {
     const postParams = {
       name: groupName,
       enterprise_customer: enterpriseUUID,
       members: [],
     };
     const createEnterpriseGroupUrl = `${LmsApiService.enterpriseGroupListUrl}`;
-    return camelCaseObject(LmsApiService.apiClient().post(createEnterpriseGroupUrl, postParams));
+    const response = await LmsApiService.apiClient().post(createEnterpriseGroupUrl, postParams);
+    return camelCaseObject(response);
   }
 
   static fetchEnterpriseSsoOrchestrationRecord(configurationUuid) {

--- a/src/data/services/tests/LmsApiService.test.js
+++ b/src/data/services/tests/LmsApiService.test.js
@@ -100,10 +100,10 @@ describe('LmsApiService', () => {
       },
     });
     const response = await LmsApiService.createEnterpriseGroup({
-      name: 'test-name',
-      enterprise_customer: 'test-customer-uuid',
-      members: [],
+      groupName: 'test-name',
+      enterpriseUUID: 'test-customer-uuid',
     });
+
     expect(response).toEqual({
       status: 201,
       data: {
@@ -113,6 +113,14 @@ describe('LmsApiService', () => {
         members: [],
       },
     });
+    expect(axios.post).toHaveBeenCalledWith(
+      `${lmsBaseUrl}/enterprise/api/v1/enterprise_group/`,
+      {
+        name: 'test-name',
+        enterprise_customer: 'test-customer-uuid',
+        members: [],
+      },
+    );
   });
   test('fetchReportingConfigs returns reporting configs', async () => {
     axios.get.mockResolvedValue({


### PR DESCRIPTION
This change fixes an issue with group creation introduced in https://github.com/openedx/frontend-app-admin-portal/pull/1426.

## Testing Instructions

- Go to the admin-portal repo, pull down branch, and run npm run start:stage
- Navigate to https://localhost.stage.edx.org:1991/alc-general/admin/people-management
- Click 'Create group'
- Add name, members, and click 'Create'
- Verify group is created with learners populated and no error messages


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
