### PR TITLE
feat: introduce `withAlgoliaSearch` and `useAlgoliaSearch`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ config.ignorePatterns = ["*.json", ".eslintrc.js", "*.config.js", "jsdom-with-gl
 
 config.overrides =  [
   {
-    files: ['*.test.js', '*.test.jsx'],
+    files: ['*.test.js', '*.test.jsx', '*.test.ts', '*.test.tsx'],
     parser: "@typescript-eslint/parser",
     parserOptions: {
       project: [
@@ -24,7 +24,7 @@ config.overrides =  [
     }
   },
   {
-    files: ['*.test.js', '*.test.jsx'],
+    files: ['*.test.js', '*.test.jsx', '*.test.ts', '*.test.tsx'],
     rules: {
       'react/prop-types': 'off',
       'react/jsx-no-constructed-context-values': 'off',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
       run: make validate-no-uncommitted-package-lock-changes
     - name: Install dependencies
       run: npm ci
+    - name: Check types
+      run: npm run check-types
     - name: Lint
       run: npm run lint
     - name: extract_translations

--- a/docs/decisions/0010-algolia-filters-catalog-query-uuids.rst
+++ b/docs/decisions/0010-algolia-filters-catalog-query-uuids.rst
@@ -1,0 +1,39 @@
+========================================================
+Architectural Decision Record: Algolia Search Filtering Migration
+========================================================
+
+Context
+-------
+We are transitioning from the legacy filtering system, which filters based on `enterprise_customer_uuids` and `enterprise_catalog_uuids`, to a new Algolia search filtering approach. This migration is being performed incrementally to ensure a smooth transition for all users.
+
+Decision
+--------
+The existing filtering method, which relies on `enterprise_customer_uuids` and `enterprise_catalog_uuids`, will be deprecated immediately and marked as such in documentation and code. Eventually, it will be fully removed once 100% of usages of Algolia search have transitioned to the new filtering system.
+
+Key Changes
+-----------
+- The legacy filtering functionality based on `enterprise_customer_uuids` and `enterprise_catalog_uuids` will remain available temporarily but is now marked as deprecated.
+- Usages of Algolia search are encouraged to transition to the new filtering system as soon as possible.
+- Once all usages of Algolia search have migrated, the legacy filtering method will be completely removed.
+- The transition will be managed using a Waffle-based feature flag exposed via `enterpriseFeatures` from the LMS `/api/v1/enterprise-learner/` API, allowing gradual enablement of the new Algolia search filtering system.
+
+Rationale
+---------
+- A gradual migration reduces risk and allows us to address any issues before full deprecation.
+- Ensuring a clear transition path improves developer experience and minimizes disruption.
+- The new Algolia search filtering system provides better performance, flexibility, and maintainability.
+
+Consequences
+------------
+**Short-term:**
+- Legacy filtering based on `enterprise_customer_uuids` and `enterprise_catalog_uuids` will still be available but should no longer be used for new implementations.
+
+**Long-term:**
+- The legacy filtering will be removed entirely, requiring all consumers to use the new Algolia search filtering system with the secured Algolia API key.
+
+Next Steps
+-----------
+1. Update internal documentation to reflect the changed approach in Algolia filtering within the Enterprise Learner and Admin Portal.
+2. Monitor rollout and adoption via Datadog (e.g., errors, performance, etc.).
+3. Gradually enable the new Algolia search filtering system using the Waffle-based feature flag via `enterpriseFeatures`.
+4. Fully remove the legacy filtering once the migration is complete.

--- a/docs/decisions/0010-algolia-filters-catalog-query-uuids.rst
+++ b/docs/decisions/0010-algolia-filters-catalog-query-uuids.rst
@@ -1,6 +1,11 @@
 ========================================================
-Architectural Decision Record: Algolia Search Filtering Migration
+10. Architectural Decision Record: Algolia Search Filtering Migration
 ========================================================
+
+Status
+------
+
+Accepted (March 2025)
 
 Context
 -------

--- a/docs/decisions/0010-algolia-filters-catalog-query-uuids.rst
+++ b/docs/decisions/0010-algolia-filters-catalog-query-uuids.rst
@@ -9,18 +9,18 @@ Accepted (March 2025)
 
 Context
 -------
-We are transitioning from the legacy filtering system, which filters based on `enterprise_customer_uuids` and `enterprise_catalog_uuids`, to a new Algolia search filtering approach. This migration is being performed incrementally to ensure a smooth transition for all users.
+We are transitioning from the legacy filtering system, which filters based on ``enterprise_customer_uuids`` and ``enterprise_catalog_uuids``, to a new Algolia search filtering approach. This migration is being performed incrementally to ensure a smooth transition for all users.
 
 Decision
 --------
-The existing filtering method, which relies on `enterprise_customer_uuids` and `enterprise_catalog_uuids`, will be deprecated immediately and marked as such in documentation and code. Eventually, it will be fully removed once 100% of usages of Algolia search have transitioned to the new filtering system.
+The existing filtering method, which relies on ``enterprise_customer_uuids`` and ``enterprise_catalog_uuids``, will be deprecated immediately and marked as such in documentation and code. Eventually, it will be fully removed once 100% of usages of Algolia search have transitioned to the new filtering system.
 
 Key Changes
 -----------
-- The legacy filtering functionality based on `enterprise_customer_uuids` and `enterprise_catalog_uuids` will remain available temporarily but is now marked as deprecated.
+- The legacy filtering functionality based on ``enterprise_customer_uuids`` and ``enterprise_catalog_uuids`` will remain available temporarily but is now marked as deprecated.
 - Usages of Algolia search are encouraged to transition to the new filtering system as soon as possible.
 - Once all usages of Algolia search have migrated, the legacy filtering method will be completely removed.
-- The transition will be managed using a Waffle-based feature flag exposed via `enterpriseFeatures` from the LMS `/api/v1/enterprise-learner/` API, allowing gradual enablement of the new Algolia search filtering system.
+- The transition will be managed using a Waffle-based feature flag exposed via ``enterpriseFeatures`` from the LMS ``/api/v1/enterprise-learner/`` API, allowing gradual enablement of the new Algolia search filtering system.
 
 Rationale
 ---------
@@ -31,7 +31,7 @@ Rationale
 Consequences
 ------------
 **Short-term:**
-- Legacy filtering based on `enterprise_customer_uuids` and `enterprise_catalog_uuids` will still be available but should no longer be used for new implementations.
+- Legacy filtering based on ``enterprise_customer_uuids`` and ``enterprise_catalog_uuids`` will still be available but should no longer be used for new implementations.
 
 **Long-term:**
 - The legacy filtering will be removed entirely, requiring all consumers to use the new Algolia search filtering system with the secured Algolia API key.
@@ -40,5 +40,5 @@ Next Steps
 -----------
 1. Update internal documentation to reflect the changed approach in Algolia filtering within the Enterprise Learner and Admin Portal.
 2. Monitor rollout and adoption via Datadog (e.g., errors, performance, etc.).
-3. Gradually enable the new Algolia search filtering system using the Waffle-based feature flag via `enterpriseFeatures`.
+3. Gradually enable the new Algolia search filtering system using the Waffle-based feature flag via ``enterpriseFeatures``.
 4. Fully remove the legacy filtering once the migration is complete.

--- a/src/components/NewFeatureAlertBrowseAndRequest/index.jsx
+++ b/src/components/NewFeatureAlertBrowseAndRequest/index.jsx
@@ -54,11 +54,7 @@ const NewFeatureAlertBrowseAndRequest = ({ enterpriseId, enterpriseSlug, intl })
           })}
         </Button>,
       ]}
-      dismissible={intl.formatMessage({
-        id: 'admin.portal.new.feature.alert.dismissible.text',
-        defaultMessage: 'Dismiss',
-        description: 'Text for dismissible alert.',
-      })}
+      dismissible
     >
       {intl.formatMessage({
         id: 'admin.portal.new.feature.alert.text',

--- a/src/components/algolia-search/index.ts
+++ b/src/components/algolia-search/index.ts
@@ -1,0 +1,2 @@
+export { default as withAlgoliaSearch } from './withAlgoliaSearch';
+export { default as useAlgoliaSearch } from './useAlgoliaSearch';

--- a/src/components/algolia-search/useAlgoliaSearch.ts
+++ b/src/components/algolia-search/useAlgoliaSearch.ts
@@ -1,0 +1,129 @@
+import { useEffect, useState } from 'react';
+import algoliasearch, { SearchClient } from 'algoliasearch/lite';
+import { logError } from '@edx/frontend-platform/logging';
+import { getAuthenticatedHttpClient, getAuthenticatedUser } from '@edx/frontend-platform/auth';
+import { camelCaseObject } from '@edx/frontend-platform/utils';
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import type { AxiosResponse } from 'axios';
+
+import { configuration } from '../../config';
+import { EnterpriseFeatures } from '../../types';
+
+interface UseSecuredAlgoliaApiKeyArgs {
+  isCatalogQueryFiltersEnabled: boolean;
+  enterpriseId: string;
+}
+
+function calculateStaleTime(validUntilISO) {
+  const validUntilDate = new Date(validUntilISO);
+  const now = new Date();
+  const timeDifference = validUntilDate.getTime() - now.getTime();
+
+  // Ensure staleTime is not negative (if the key has already expired)
+  return Math.max(0, timeDifference);
+}
+
+type CatalogUuidsToCatalogQueryUuids = Record<string, string>;
+
+interface SecuredAlgoliaApiKeyResponse {
+  algolia: {
+    secured_api_Key: string,
+    valid_Until: string,
+  },
+  catalog_uuids_to_catalog_query_uuids: CatalogUuidsToCatalogQueryUuids,
+}
+
+interface UseSecuredAlgoliaApiKeyResult {
+  apiKey: string;
+  validUntil: string;
+  catalogUuidsToCatalogQueryUuids: CatalogUuidsToCatalogQueryUuids;
+}
+
+async function fetchSecuredAlgoliaApiKey(enterpriseId: string): Promise<UseSecuredAlgoliaApiKeyResult> {
+  const url = `${configuration.ENTERPRISE_CATALOG_BASE_URL}/api/v1/enterprise-customer/${enterpriseId}/secured-algolia-api-key/`;
+  const response: AxiosResponse<SecuredAlgoliaApiKeyResponse> = await getAuthenticatedHttpClient().get(url);
+  const originalResult = response.data;
+  const result = camelCaseObject(originalResult);
+  return {
+    apiKey: result.algolia.securedApiKey,
+    validUntil: result.algolia.validUntil,
+    // Return the original mappings to avoid the camelCasing of uuid keys
+    catalogUuidsToCatalogQueryUuids: originalResult.catalog_uuids_to_catalog_query_uuids,
+  };
+}
+
+function useSecuredAlgoliaApiKey({
+  isCatalogQueryFiltersEnabled,
+  enterpriseId,
+}: UseSecuredAlgoliaApiKeyArgs) {
+  const [validUntil, setValidUntil] = useState<string | null>(null);
+  const authenticatedUser = getAuthenticatedUser();
+  const queryResult = useQuery({
+    queryKey: ['securedAlgoliaApiKey', 'enterpriseCustomer', enterpriseId, 'lmsUserId', authenticatedUser.userId],
+    queryFn: async () => fetchSecuredAlgoliaApiKey(enterpriseId),
+    staleTime: calculateStaleTime(validUntil),
+    enabled: isCatalogQueryFiltersEnabled,
+  });
+
+  useEffect(() => {
+    if (queryResult.data) {
+      setValidUntil(queryResult.data.validUntil);
+    }
+  }, [queryResult.data]);
+
+  return queryResult;
+}
+
+interface UseAlgoliaSearchArgs {
+  enterpriseId: string;
+  enterpriseFeatures: EnterpriseFeatures;
+}
+
+export interface UseAlgoliaSearchResult {
+  isCatalogQueryFiltersEnabled: boolean;
+  securedAlgoliaApiKey: UseQueryResult;
+  isLoading: boolean;
+  searchClient: SearchClient | null;
+  catalogUuidsToCatalogQueryUuids: Record<string, string> | undefined;
+}
+
+function useAlgoliaSearch({
+  enterpriseId,
+  enterpriseFeatures,
+}: UseAlgoliaSearchArgs): UseAlgoliaSearchResult {
+  const isCatalogQueryFiltersEnabled = !!enterpriseFeatures.catalogQuerySearchFiltersEnabled;
+  const securedAlgoliaApiKeyResult = useSecuredAlgoliaApiKey({
+    enterpriseId,
+    isCatalogQueryFiltersEnabled,
+  });
+  const {
+    data: securedAlgoliaApiKeyData,
+    isInitialLoading: isInitialLoadingSecuredAlgoliaApiKey,
+  } = securedAlgoliaApiKeyResult;
+
+  useEffect(() => {
+    if (isInitialLoadingSecuredAlgoliaApiKey) {
+      // Do nothing until the securedAlgoliaApiKey is loaded
+      return;
+    }
+    const hasApiKey = !!(securedAlgoliaApiKeyData?.apiKey || configuration.ALGOLIA.SEARCH_API_KEY);
+    if (!configuration.ALGOLIA.APP_ID || !hasApiKey) {
+      logError('Algolia not configured for the application. Please provide the Algolia APP_ID and SEARCH_API_KEY in the configuration.');
+    }
+  }, [isInitialLoadingSecuredAlgoliaApiKey, securedAlgoliaApiKeyData?.apiKey]);
+
+  let searchClient: SearchClient | null = null;
+  if (configuration.ALGOLIA.APP_ID && configuration.ALGOLIA.SEARCH_API_KEY) {
+    searchClient = algoliasearch(configuration.ALGOLIA.APP_ID, configuration.ALGOLIA.SEARCH_API_KEY);
+  }
+
+  return {
+    isCatalogQueryFiltersEnabled,
+    securedAlgoliaApiKey: securedAlgoliaApiKeyResult,
+    isLoading: isInitialLoadingSecuredAlgoliaApiKey,
+    searchClient,
+    catalogUuidsToCatalogQueryUuids: securedAlgoliaApiKeyData?.catalogUuidsToCatalogQueryUuids,
+  };
+}
+
+export default useAlgoliaSearch;

--- a/src/components/algolia-search/useAlgoliaSearch.ts
+++ b/src/components/algolia-search/useAlgoliaSearch.ts
@@ -107,17 +107,6 @@ function useAlgoliaSearch({
     isInitialLoading: isInitialLoadingSecuredAlgoliaApiKey,
   } = securedAlgoliaApiKeyResult;
 
-  useEffect(() => {
-    if (isInitialLoadingSecuredAlgoliaApiKey) {
-      // Do nothing until the securedAlgoliaApiKey is loaded
-      return;
-    }
-    const hasApiKey = !!(securedAlgoliaApiKeyData?.apiKey || configuration.ALGOLIA.SEARCH_API_KEY);
-    if (!configuration.ALGOLIA.APP_ID || !hasApiKey) {
-      logError('Algolia not configured for the application. Please provide the Algolia APP_ID and SEARCH_API_KEY in the configuration.');
-    }
-  }, [isInitialLoadingSecuredAlgoliaApiKey, securedAlgoliaApiKeyData?.apiKey]);
-
   const searchClient = useMemo(() => {
     if (!configuration.ALGOLIA.APP_ID || isInitialLoadingSecuredAlgoliaApiKey) {
       return null;

--- a/src/components/algolia-search/useAlgoliaSearch.ts
+++ b/src/components/algolia-search/useAlgoliaSearch.ts
@@ -41,7 +41,7 @@ export interface UseAlgoliaSearchResult {
   securedAlgoliaApiKey: UseQueryResult;
   isLoading: boolean;
   searchClient: SearchClient | null;
-  catalogUuidsToCatalogQueryUuids: Record<string, string> | undefined;
+  catalogUuidsToCatalogQueryUuids: CatalogUuidsToCatalogQueryUuids | undefined;
 }
 
 async function fetchSecuredAlgoliaApiKey(enterpriseId: string): Promise<UseSecuredAlgoliaApiKeyResult> {
@@ -57,9 +57,15 @@ async function fetchSecuredAlgoliaApiKey(enterpriseId: string): Promise<UseSecur
   };
 }
 
-function calculateStaleTime(validUntilISO) {
-  const timeDifference = dayjs(validUntilISO).diff(dayjs());
-  return Math.max(0, timeDifference);
+function calculateStaleTime(
+  validUntil,
+  bufferMs = 1000 * 60, // 1 minute
+) {
+  if (!validUntil) {
+    return undefined;
+  }
+  const timeDifference = dayjs(validUntil).diff(dayjs());
+  return Math.max(0, timeDifference - bufferMs);
 }
 
 function useSecuredAlgoliaApiKey({

--- a/src/components/algolia-search/useAlgoliaSearch.ts
+++ b/src/components/algolia-search/useAlgoliaSearch.ts
@@ -15,11 +15,6 @@ interface UseSecuredAlgoliaApiKeyArgs {
   enterpriseId: string;
 }
 
-function calculateStaleTime(validUntilISO) {
-  const timeDifference = dayjs(validUntilISO).diff(dayjs());
-  return Math.max(0, timeDifference);
-}
-
 type CatalogUuidsToCatalogQueryUuids = Record<string, string>;
 
 interface SecuredAlgoliaApiKeyResponse {
@@ -36,6 +31,19 @@ interface UseSecuredAlgoliaApiKeyResult {
   catalogUuidsToCatalogQueryUuids: CatalogUuidsToCatalogQueryUuids;
 }
 
+interface UseAlgoliaSearchArgs {
+  enterpriseId: string;
+  enterpriseFeatures: EnterpriseFeatures;
+}
+
+export interface UseAlgoliaSearchResult {
+  isCatalogQueryFiltersEnabled: boolean;
+  securedAlgoliaApiKey: UseQueryResult;
+  isLoading: boolean;
+  searchClient: SearchClient | null;
+  catalogUuidsToCatalogQueryUuids: Record<string, string> | undefined;
+}
+
 async function fetchSecuredAlgoliaApiKey(enterpriseId: string): Promise<UseSecuredAlgoliaApiKeyResult> {
   const url = `${configuration.ENTERPRISE_CATALOG_BASE_URL}/api/v1/enterprise-customer/${enterpriseId}/secured-algolia-api-key/`;
   const response: AxiosResponse<SecuredAlgoliaApiKeyResponse> = await getAuthenticatedHttpClient().get(url);
@@ -47,6 +55,11 @@ async function fetchSecuredAlgoliaApiKey(enterpriseId: string): Promise<UseSecur
     // Return the original mappings to avoid the camelCasing of uuid keys
     catalogUuidsToCatalogQueryUuids: originalResult.catalog_uuids_to_catalog_query_uuids,
   };
+}
+
+function calculateStaleTime(validUntilISO) {
+  const timeDifference = dayjs(validUntilISO).diff(dayjs());
+  return Math.max(0, timeDifference);
 }
 
 function useSecuredAlgoliaApiKey({
@@ -69,19 +82,6 @@ function useSecuredAlgoliaApiKey({
   }, [queryResult.data]);
 
   return queryResult;
-}
-
-interface UseAlgoliaSearchArgs {
-  enterpriseId: string;
-  enterpriseFeatures: EnterpriseFeatures;
-}
-
-export interface UseAlgoliaSearchResult {
-  isCatalogQueryFiltersEnabled: boolean;
-  securedAlgoliaApiKey: UseQueryResult;
-  isLoading: boolean;
-  searchClient: SearchClient | null;
-  catalogUuidsToCatalogQueryUuids: Record<string, string> | undefined;
 }
 
 function useAlgoliaSearch({

--- a/src/components/algolia-search/useAlgoliaSearch.ts
+++ b/src/components/algolia-search/useAlgoliaSearch.ts
@@ -5,6 +5,7 @@ import { getAuthenticatedHttpClient, getAuthenticatedUser } from '@edx/frontend-
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import type { AxiosResponse } from 'axios';
+import dayjs from 'dayjs';
 
 import { configuration } from '../../config';
 import { EnterpriseFeatures } from '../../types';
@@ -15,11 +16,7 @@ interface UseSecuredAlgoliaApiKeyArgs {
 }
 
 function calculateStaleTime(validUntilISO) {
-  const validUntilDate = new Date(validUntilISO);
-  const now = new Date();
-  const timeDifference = validUntilDate.getTime() - now.getTime();
-
-  // Ensure staleTime is not negative (if the key has already expired)
+  const timeDifference = dayjs(validUntilISO).diff(dayjs());
   return Math.max(0, timeDifference);
 }
 

--- a/src/components/algolia-search/withAlgoliaSearch.test.tsx
+++ b/src/components/algolia-search/withAlgoliaSearch.test.tsx
@@ -1,0 +1,164 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { render, screen, waitFor } from '@testing-library/react';
+import configureMockStore, { MockStore } from 'redux-mock-store';
+import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
+import type { ThunkDispatch } from 'redux-thunk';
+import type { AnyAction } from 'redux';
+import { getAuthenticatedUser, getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { QueryClientProvider } from '@tanstack/react-query';
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+import algoliasearch from 'algoliasearch/lite';
+import '@testing-library/jest-dom/extend-expect';
+
+import withAlgoliaSearch from './withAlgoliaSearch';
+import { UseAlgoliaSearchResult } from './useAlgoliaSearch';
+import { queryClient } from '../test/testUtils';
+import { configuration } from '../../config';
+
+jest.mock('@edx/frontend-platform/auth');
+jest.mock('algoliasearch/lite', () => {
+  const search = jest.fn(() => Promise.resolve({ hits: [] }));
+  const initIndex = jest.fn(() => ({ search }));
+  const algoliasearch = jest.fn(() => ({ initIndex }));
+  return algoliasearch;
+});
+
+const axiosMock = new MockAdapter(axios);
+getAuthenticatedHttpClient.mockReturnValue(axios);
+
+jest.mock('../../config', () => ({
+  configuration: {
+    ENTERPRISE_CATALOG_BASE_URL: 'http://test-catalog',
+    ALGOLIA: {
+      APP_ID: 'testAppId',
+      SEARCH_API_KEY: 'testSearchApiKey',
+    },
+  },
+}));
+
+jest.mock('@edx/frontend-platform/auth', () => ({
+  ...jest.requireActual('@edx/frontend-platform/auth'),
+  getAuthenticatedUser: jest.fn(),
+  getAuthenticatedHttpClient: jest.fn(),
+}));
+
+const mockStore = configureMockStore([thunk]);
+
+interface PortalConfigurationState {
+  enterpriseId: string;
+  enterpriseFeatures: {
+    catalogQuerySearchFiltersEnabled: boolean;
+  };
+}
+
+interface RootState {
+  portalConfiguration: PortalConfigurationState;
+}
+
+type DispatchExts = ThunkDispatch<RootState, undefined, AnyAction>;
+
+interface MyComponentProps {
+  algolia: UseAlgoliaSearchResult;
+  enterpriseId: string;
+  className?: string;
+}
+const MyComponent: React.FC<MyComponentProps> = ({ algolia, enterpriseId, className }) => (
+  <div className={className}>
+    <h1>My Component</h1>
+    <div>{enterpriseId}</div>
+    {algolia.searchClient && <div>Search Client Loaded</div>}
+  </div>
+);
+interface MyComponentWrapperProps {
+  store: MockStore<RootState, DispatchExts>;
+}
+
+const MyComponentWithAlgoliaSearch = withAlgoliaSearch(MyComponent);
+
+const Wrapper: React.FC<MyComponentWrapperProps> = ({ store }) => (
+  <QueryClientProvider client={queryClient()}>
+    <Provider store={store || mockStore()}>
+      <MyComponentWithAlgoliaSearch />
+    </Provider>
+  </QueryClientProvider>
+);
+
+describe('withAlgoliaSearch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getAuthenticatedUser.mockReturnValue({ userId: 3 });
+  });
+
+  afterEach(() => {
+    axiosMock.reset();
+  });
+
+  it.each([
+    // Legacy filters, enterprise customer specific attributes
+    {
+      hasCatalogQuerySearchFiltersEnabled: false,
+    },
+    // New filters, catalog query specific attributes
+    {
+      hasCatalogQuerySearchFiltersEnabled: true,
+      hasErrorOnSecuredAlgoliaApiKeyRequest: false,
+    },
+    {
+      hasCatalogQuerySearchFiltersEnabled: true,
+      hasErrorOnSecuredAlgoliaApiKeyRequest: true,
+    },
+  ])('should render WrappedComponent with expected injected props (%s)', async ({
+    hasCatalogQuerySearchFiltersEnabled,
+    hasErrorOnSecuredAlgoliaApiKeyRequest,
+  }) => {
+    const mockEnterpriseId = 'test-enterprise-id';
+    const mockSecuredApiKey = 'securedApiKey';
+    const store: MockStore<RootState, DispatchExts> = mockStore({
+      portalConfiguration: {
+        enterpriseId: mockEnterpriseId,
+        enterpriseFeatures: {
+          catalogQuerySearchFiltersEnabled: hasCatalogQuerySearchFiltersEnabled,
+        },
+      },
+    });
+    if (hasCatalogQuerySearchFiltersEnabled) {
+      const apiUrl = `${configuration.ENTERPRISE_CATALOG_BASE_URL}/api/v1/enterprise-customer/${mockEnterpriseId}/secured-algolia-api-key/`;
+      const mockSecuredAlgoliaApiKeyResponse = {
+        algolia: {
+          securedApiKey: 'securedApiKey',
+          validUntil: '2023-10-01T00:00:00Z',
+        },
+        catalog_uuids_to_catalog_query_uuids: {
+          'catalog-uuid-1': 'catalog-query-uuid-1',
+          'catalog-uuid-2': 'catalog-query-uuid-2',
+        },
+      };
+      if (hasErrorOnSecuredAlgoliaApiKeyRequest) {
+        axiosMock.onGet(apiUrl).reply(500);
+      } else {
+        axiosMock.onGet(apiUrl).reply(200, mockSecuredAlgoliaApiKeyResponse);
+      }
+    }
+    render(<Wrapper store={store} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('My Component')).toBeInTheDocument();
+      expect(screen.getByText(mockEnterpriseId)).toBeInTheDocument();
+      expect(screen.getByText('Search Client Loaded')).toBeInTheDocument();
+    });
+
+    if (hasCatalogQuerySearchFiltersEnabled && !hasErrorOnSecuredAlgoliaApiKeyRequest) {
+      expect(algoliasearch).toHaveBeenCalledWith(
+        configuration.ALGOLIA.APP_ID,
+        mockSecuredApiKey,
+      );
+    } else {
+      expect(algoliasearch).toHaveBeenCalledWith(
+        configuration.ALGOLIA.APP_ID,
+        configuration.ALGOLIA.SEARCH_API_KEY,
+      );
+    }
+  });
+});

--- a/src/components/algolia-search/withAlgoliaSearch.test.tsx
+++ b/src/components/algolia-search/withAlgoliaSearch.test.tsx
@@ -21,8 +21,8 @@ jest.mock('@edx/frontend-platform/auth');
 jest.mock('algoliasearch/lite', () => {
   const search = jest.fn(() => Promise.resolve({ hits: [] }));
   const initIndex = jest.fn(() => ({ search }));
-  const algoliasearch = jest.fn(() => ({ initIndex }));
-  return algoliasearch;
+  const mockAlgoliasearch = jest.fn(() => ({ initIndex }));
+  return mockAlgoliasearch;
 });
 
 const axiosMock = new MockAdapter(axios);

--- a/src/components/algolia-search/withAlgoliaSearch.tsx
+++ b/src/components/algolia-search/withAlgoliaSearch.tsx
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import useAlgoliaSearch from './useAlgoliaSearch';
+
+const withAlgoliaSearch = (WrappedComponent) => {
+  const WithAlgoliaSearch = ({ enterpriseId, enterpriseFeatures, ...rest }) => {
+    const algolia = useAlgoliaSearch({
+      enterpriseId,
+      enterpriseFeatures,
+    });
+    return <WrappedComponent algolia={algolia} enterpriseId={enterpriseId} {...rest} />;
+  };
+  WithAlgoliaSearch.propTypes = {
+    enterpriseId: PropTypes.string.isRequired,
+    enterpriseFeatures: PropTypes.shape({}).isRequired,
+  };
+  const mapStateToProps = (state) => ({
+    enterpriseId: state.portalConfiguration.enterpriseId,
+    enterpriseFeatures: state.portalConfiguration.enterpriseFeatures,
+  });
+  return connect(mapStateToProps)(WithAlgoliaSearch);
+};
+
+export default withAlgoliaSearch;

--- a/src/components/settings/SettingsLMSTab/UnsavedChangesModal.tsx
+++ b/src/components/settings/SettingsLMSTab/UnsavedChangesModal.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import { ModalDialog, ActionRow, Button } from '@openedx/paragon';
-import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 
 import { UnsavedChangesModalProps } from '../../forms/FormWorkflow';
 
@@ -11,61 +10,62 @@ const UnsavedChangesModal = ({
   close,
   exitWithoutSaving,
   saveDraft,
-}: UnsavedChangesModalProps) => (
-  <ModalDialog
-    title={(
-      <FormattedMessage
-        id="adminPortal.settings.learningPlatformTab.unsavedChangesModal.cancelModalTitle"
-        defaultMessage="Cancel Modal"
-        description="Title for the cancel modal on learning platform tab"
-      />
-  )}
-    isOpen={isOpen}
-    onClose={close}
-    variant="default"
-  >
-    <ModalDialog.Header>
-      <ModalDialog.Title>
+}: UnsavedChangesModalProps) => {
+  const intl = useIntl();
+  return (
+    <ModalDialog
+      title={intl.formatMessage({
+        id: 'adminPortal.settings.learningPlatformTab.unsavedChangesModal.cancelModalTitle',
+        defaultMessage: 'Cancel Modal',
+        description: 'Title for the cancel modal on learning platform tab',
+      })}
+      isOpen={isOpen}
+      onClose={close}
+      variant="default"
+    >
+      <ModalDialog.Header>
+        <ModalDialog.Title>
+          <FormattedMessage
+            id="adminPortal.settings.learningPlatformTab.unsavedChangesModal.exitConfigurationTitle"
+            defaultMessage="Exit configuration"
+            description="Title for exiting configuration modal dialog"
+          />
+        </ModalDialog.Title>
+      </ModalDialog.Header>
+      <ModalDialog.Body>
         <FormattedMessage
-          id="adminPortal.settings.learningPlatformTab.unsavedChangesModal.exitConfigurationTitle"
-          defaultMessage="Exit configuration"
-          description="Title for exiting configuration modal dialog"
+          id="adminPortal.settings.learningPlatformTab.unsavedChangesModal.saveDraftMessage"
+          defaultMessage="Your configuration data will be saved under your Learning Platform settings"
+          description="Message for saving draft in configuration modal dialog"
         />
-      </ModalDialog.Title>
-    </ModalDialog.Header>
-    <ModalDialog.Body>
-      <FormattedMessage
-        id="adminPortal.settings.learningPlatformTab.unsavedChangesModal.saveDraftMessage"
-        defaultMessage="Your configuration data will be saved under your Learning Platform settings"
-        description="Message for saving draft in configuration modal dialog"
-      />
-    </ModalDialog.Body>
-    <ModalDialog.Footer>
-      <ActionRow>
-        <Button onClick={close} variant="outline-primary">
-          <FormattedMessage
-            id="adminPortal.settings.learningPlatformTab.unsavedChangesModal.cancelButton"
-            defaultMessage="Cancel"
-            description="Cancel button text in configuration modal dialog"
-          />
-        </Button>
-        <Button onClick={exitWithoutSaving} variant="outline-primary">
-          <FormattedMessage
-            id="adminPortal.settings.learningPlatformTab.unsavedChangesModal.exitWithoutSavingButton"
-            defaultMessage="Exit without saving"
-            description="Exit without saving button text in configuration modal dialog"
-          />
-        </Button>
-        <Button onClick={saveDraft} variant="primary">
-          <FormattedMessage
-            id="adminPortal.settings.learningPlatformTab.unsavedChangesModal.exitButton"
-            defaultMessage="Exit"
-            description="Exit button text in configuration modal dialog"
-          />
-        </Button>
-      </ActionRow>
-    </ModalDialog.Footer>
-  </ModalDialog>
-);
+      </ModalDialog.Body>
+      <ModalDialog.Footer>
+        <ActionRow>
+          <Button onClick={close} variant="outline-primary">
+            <FormattedMessage
+              id="adminPortal.settings.learningPlatformTab.unsavedChangesModal.cancelButton"
+              defaultMessage="Cancel"
+              description="Cancel button text in configuration modal dialog"
+            />
+          </Button>
+          <Button onClick={exitWithoutSaving} variant="outline-primary">
+            <FormattedMessage
+              id="adminPortal.settings.learningPlatformTab.unsavedChangesModal.exitWithoutSavingButton"
+              defaultMessage="Exit without saving"
+              description="Exit without saving button text in configuration modal dialog"
+            />
+          </Button>
+          <Button onClick={saveDraft} variant="primary">
+            <FormattedMessage
+              id="adminPortal.settings.learningPlatformTab.unsavedChangesModal.exitButton"
+              defaultMessage="Exit"
+              description="Exit button text in configuration modal dialog"
+            />
+          </Button>
+        </ActionRow>
+      </ModalDialog.Footer>
+    </ModalDialog>
+  );
+};
 
 export default UnsavedChangesModal;

--- a/src/components/settings/SettingsSSOTab/steps/NewSSOConfigConfirmStep.tsx
+++ b/src/components/settings/SettingsSSOTab/steps/NewSSOConfigConfirmStep.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import {
-  Alert, Hyperlink, OverlayTrigger, Popover,
+  Alert, Button, OverlayTrigger, Popover,
 } from '@openedx/paragon';
 import { Info } from '@openedx/paragon/icons';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
@@ -22,13 +21,13 @@ const IncognitoPopover = () => (
       </Popover>
       )}
   >
-    <Hyperlink>
+    <Button variant="link" size="inline">
       <FormattedMessage
         id="adminPortal.settings.ssoConfigAuthorizeStep.incognitoWindow"
         defaultMessage="incognito window"
         description="Link text for opening a new window in incognito mode"
       />
-    </Hyperlink>
+    </Button>
   </OverlayTrigger>
 );
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -27,4 +27,8 @@ export type EnterpriseGroup = {
   created: string,
 };
 
+export type EnterpriseFeatures = {
+  catalogQuerySearchFiltersEnabled?: boolean,
+};
+
 export as namespace Types;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@edx/typescript-config",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "dist",
+    "outDir": "dist"
   },
   "include": ["src/**/*", "__mocks__/**/*"],
   "exclude": ["dist", "src/icons/*"],


### PR DESCRIPTION
[ENT-10080](https://2u-internal.atlassian.net/browse/ENT-10080)

Introduces `withAlgoliaSearch` Higher-Order-Component (HOC) for consuming components to get access to the Algolia search client to serve search results.

The `withAlgoliaSearch` component is connected to the Redux store to get access to the feature flag and the enterprise customer UUID. The rest of the logic is encapsulated within `useAlgoliaSearch`.

Based on the `enterpriseFeatures.catalogQuerySearchFiltersEnabled`, `useAlgoliaSearch` will conditionally make an API call to `<enterprise-catalog>/api/v1/enterprise-customer/<enterprise_id>/secured-algolia-api-key/` to generate a secured Algolia API key and get the mappings of catalog uuids <> catalog query UUIDs for further filtering.

If the feature flag is enabled and a secured Algolia API key was returned, use it to initialize the Algolia `searchClient`. Otherwise, fallback to continuing to use the generic (unscoped) `searchClient`, requiring customer-specific attributes to be explicitly passed as filters (undesired).

See example reference for its usage: https://github.com/openedx/frontend-app-admin-portal/pull/1443

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
