### PR TITLE
fix: Email Matching in CSV upload should be case-insensitive

### DIFF
--- a/src/components/learner-credit-management/cards/data/utils.ts
+++ b/src/components/learner-credit-management/cards/data/utils.ts
@@ -147,7 +147,7 @@ export const isInviteEmailAddressesInputValueValid = ({
 }: LearnerEmailsValidityArgs): LearnerEmailsValidityReport => {
   let validationError;
   const learnerEmailsCount = learnerEmails.length;
-  const lowerCasedEmails: string[] = [];
+  const validatedEmails: string[] = [];
   const invalidEmails: string[] = [];
   const duplicateEmails: string[] = [];
   const emailsNotInOrg: string[] = [];
@@ -158,7 +158,7 @@ export const isInviteEmailAddressesInputValueValid = ({
     // Validate the email address
     if (!isEmail(email)) {
       invalidEmails.push(email);
-    } else if (lowerCasedEmails.includes(lowerCasedEmail)) {
+    } else if (validatedEmails.includes(lowerCasedEmail)) {
       // Check for duplicates (case-insensitive)
       duplicateEmails.push(email);
       // Check if email belongs in the org
@@ -166,12 +166,12 @@ export const isInviteEmailAddressesInputValueValid = ({
       emailsNotInOrg.push(email);
     } else {
       // Add to list of lower-cased emails already handled
-      lowerCasedEmails.push(lowerCasedEmail);
+      validatedEmails.push(lowerCasedEmail);
     }
   });
 
   const isValidInput = invalidEmails.length === 0 && learnerEmailsCount < MAX_EMAIL_ENTRY_LIMIT;
-  const canInvite = lowerCasedEmails.length > 0 && learnerEmailsCount < MAX_EMAIL_ENTRY_LIMIT;
+  const canInvite = validatedEmails.length > 0 && learnerEmailsCount < MAX_EMAIL_ENTRY_LIMIT;
 
   const ensureValidationErrorObjectExists = () => {
     if (!validationError) {
@@ -215,7 +215,7 @@ export const isInviteEmailAddressesInputValueValid = ({
   }
   return {
     canInvite,
-    lowerCasedEmails,
+    lowerCasedEmails: validatedEmails,
     duplicateEmails,
     invalidEmails,
     isValidInput,

--- a/src/components/learner-credit-management/cards/data/utils.ts
+++ b/src/components/learner-credit-management/cards/data/utils.ts
@@ -162,7 +162,7 @@ export const isInviteEmailAddressesInputValueValid = ({
       // Check for duplicates (case-insensitive)
       duplicateEmails.push(email);
       // Check if email belongs in the org
-    } else if (allEnterpriseLearners && !allEnterpriseLearners.includes(email)) {
+    } else if (allEnterpriseLearners && !allEnterpriseLearners.includes(lowerCasedEmail)) {
       emailsNotInOrg.push(email);
     } else {
       // Add to list of lower-cased emails already handled


### PR DESCRIPTION
[Jira Ticket](https://2u-internal.atlassian.net/browse/ENT-10195)

This fixes the issue when creating/adding users to a group via csv upload and getting an error when the email addresses differ from the org registered email in casing alone.

## Testing Instructions
- Go to the admin-portal repo and run `npm run start:stage`
- Navigate to https://localhost.stage.edx.org:1991/alc-general/admin/people-management
- Click 'Create group'
- Create a csv file containing the email of an org member with casing that differs from the People table
- Verify the uploaded user can be added, without any error messages indicating they aren't part of the org

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
