### PR TITLE
fix: adding a little space

### DIFF
--- a/src/components/PeopleManagement/AddMembersModal/AddMembersModalContent.jsx
+++ b/src/components/PeopleManagement/AddMembersModal/AddMembersModalContent.jsx
@@ -52,7 +52,7 @@ const AddMembersModalContent = ({
         <Col>
           <FormattedMessage
             id="people.management.add.members.modal"
-            defaultMessage="Only members registered with your organization can be added to a group."
+            defaultMessage="Only members registered with your organization can be added to a group. "
             description="Subtitle for the add members modal"
           />
           <Hyperlink

--- a/src/components/PeopleManagement/CreateGroupModalContent.jsx
+++ b/src/components/PeopleManagement/CreateGroupModalContent.jsx
@@ -67,7 +67,7 @@ const CreateGroupModalContent = ({
         <Col>
           <FormattedMessage
             id="people.management.create.groups.modal"
-            defaultMessage="Only members registered with your organization can be added to a group."
+            defaultMessage="Only members registered with your organization can be added to a group. "
             description="Subtitle for the create group modal"
           />
           <Hyperlink


### PR DESCRIPTION
Adding a single space before the "Learn more" hyperlink in the new group modal. 
[Jira ticket.](https://2u-internal.atlassian.net/browse/ENT-10044) 
![image](https://github.com/user-attachments/assets/0417f57c-e465-494e-8e34-556c777bb0d4)

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
