### PR TITLE
fix: add/remove group member with non-lowercase email

### DIFF
--- a/src/components/PeopleManagement/AddMembersModal/AddMembersModal.jsx
+++ b/src/components/PeopleManagement/AddMembersModal/AddMembersModal.jsx
@@ -24,7 +24,7 @@ const AddMembersModal = ({
   groupUuid,
 }) => {
   const intl = useIntl();
-  const { lowerCasedEmails: learnerEmails, canInvite: canInviteMembers } = useValidatedEmailsContext();
+  const { validatedEmails: learnerEmails, canInvite: canInviteMembers } = useValidatedEmailsContext();
   const [addButtonState, setAddButtonState] = useState('default');
   const [isSystemErrorModalOpen, openSystemErrorModal, closeSystemErrorModal] = useToggle(false);
   const handleCloseAddMembersModal = () => {

--- a/src/components/PeopleManagement/AddMembersModal/AddMembersModalContent.jsx
+++ b/src/components/PeopleManagement/AddMembersModal/AddMembersModalContent.jsx
@@ -13,7 +13,7 @@ import FileUpload from '../../learner-credit-management/invite-modal/FileUpload'
 import EnterpriseCustomerUserDataTable from '../EnterpriseCustomerUserDataTable';
 import { useEnterpriseLearners } from '../../learner-credit-management/data';
 import { HELP_CENTER_URL } from '../constants';
-import { removeStringsFromList, splitAndTrim } from '../../../utils';
+import { removeStringsFromListCaseInsensitive, splitAndTrim } from '../../../utils';
 import { addEmailsAction, initializeEnterpriseEmailsAction } from '../data/actions';
 import { useValidatedEmailsContext } from '../data/ValidatedEmailsContext';
 
@@ -23,14 +23,14 @@ const AddMembersModalContent = ({
   enterpriseGroupLearners,
 }) => {
   const memberInviteMetadata = useValidatedEmailsContext();
-  const { dispatch, lowerCasedEmails } = memberInviteMetadata;
+  const { dispatch, validatedEmails } = memberInviteMetadata;
   const { allEnterpriseLearners } = useEnterpriseLearners({ enterpriseUUID });
 
   const handleCsvUpload = useCallback((csv) => {
     let emails = splitAndTrim('\n', csv);
-    emails = removeStringsFromList(emails, lowerCasedEmails);
+    emails = removeStringsFromListCaseInsensitive(emails, validatedEmails);
     dispatch(addEmailsAction({ emails, clearErroredEmails: true, actionType: 'UPLOAD_CSV_ACTION' }));
-  }, [dispatch, lowerCasedEmails]);
+  }, [dispatch, validatedEmails]);
 
   useEffect(() => {
     const groupEnterpriseLearners = enterpriseGroupLearners.map((learner) => learner?.memberDetails?.userEmail);

--- a/src/components/PeopleManagement/CreateGroupModal.jsx
+++ b/src/components/PeopleManagement/CreateGroupModal.jsx
@@ -25,7 +25,7 @@ const CreateGroupModal = ({
 }) => {
   const intl = useIntl();
   const {
-    lowerCasedEmails: learnerEmails,
+    validatedEmails: learnerEmails,
     canInvite: canInviteMembers,
     isCreateGroupFileUpload,
     isCreateGroupListSelection,

--- a/src/components/PeopleManagement/CreateGroupModalContent.jsx
+++ b/src/components/PeopleManagement/CreateGroupModalContent.jsx
@@ -12,7 +12,7 @@ import InviteSummaryCount from '../learner-credit-management/invite-modal/Invite
 import FileUpload from '../learner-credit-management/invite-modal/FileUpload';
 import { HELP_CENTER_URL, MAX_LENGTH_GROUP_NAME } from './constants';
 import EnterpriseCustomerUserDataTable from './EnterpriseCustomerUserDataTable';
-import { removeStringsFromList, splitAndTrim } from '../../utils';
+import { removeStringsFromListCaseInsensitive, splitAndTrim } from '../../utils';
 import { useValidatedEmailsContext } from './data/ValidatedEmailsContext';
 import { addEmailsAction, initializeEnterpriseEmailsAction } from './data/actions';
 
@@ -21,7 +21,7 @@ const CreateGroupModalContent = ({
   onSetGroupName,
 }) => {
   const memberInviteMetadata = useValidatedEmailsContext();
-  const { dispatch, lowerCasedEmails } = memberInviteMetadata;
+  const { dispatch, validatedEmails } = memberInviteMetadata;
   const [groupNameLength, setGroupNameLength] = useState(0);
   const [groupName, setGroupName] = useState('');
 
@@ -41,9 +41,9 @@ const CreateGroupModalContent = ({
 
   const handleCsvUpload = useCallback((csv) => {
     let emails = splitAndTrim('\n', csv);
-    emails = removeStringsFromList(emails, lowerCasedEmails);
+    emails = removeStringsFromListCaseInsensitive(emails, validatedEmails);
     dispatch(addEmailsAction({ emails, clearErroredEmails: true, actionType: 'UPLOAD_CSV_ACTION' }));
-  }, [dispatch, lowerCasedEmails]);
+  }, [dispatch, validatedEmails]);
 
   useEffect(() => {
     // Initialize upon first entry

--- a/src/components/PeopleManagement/EnterpriseCustomerUserDataTable.jsx
+++ b/src/components/PeopleManagement/EnterpriseCustomerUserDataTable.jsx
@@ -40,15 +40,17 @@ const deleteSelectedRowAction = (rowId) => ({
 
 const CustomSelectColumnCell = ({ row }) => {
   const { isSelected: isTableSelected } = row;
-  const selectedEmail = row?.original?.enterpriseCustomerUser?.email.toLowerCase();
+  const selectedEmail = row?.original?.enterpriseCustomerUser?.email;
   const dataTableContext = useContext(DataTableContext);
   const {
     itemCount,
     controlledTableSelections: [, dataTableDispatch],
   } = dataTableContext;
-  const { dispatch: validateEmailsDispatch, lowerCasedEmails, groupEnterpriseLearners } = useValidatedEmailsContext();
+  const {
+    dispatch: validateEmailsDispatch, lowerCasedEmails, groupEnterpriseLearners,
+  } = useValidatedEmailsContext();
   const isAddedMember = groupEnterpriseLearners.includes(selectedEmail);
-  const isValidated = lowerCasedEmails.includes(selectedEmail);
+  const isValidated = lowerCasedEmails.includes(selectedEmail.toLowerCase());
 
   const toggleSelected = useCallback(
     () => {

--- a/src/components/PeopleManagement/EnterpriseCustomerUserDataTable.jsx
+++ b/src/components/PeopleManagement/EnterpriseCustomerUserDataTable.jsx
@@ -40,7 +40,7 @@ const deleteSelectedRowAction = (rowId) => ({
 
 const CustomSelectColumnCell = ({ row }) => {
   const { isSelected: isTableSelected } = row;
-  const selectedEmail = row?.original?.enterpriseCustomerUser?.email;
+  const selectedEmail = row?.original?.enterpriseCustomerUser?.email.toLowerCase();
   const dataTableContext = useContext(DataTableContext);
   const {
     itemCount,

--- a/src/components/PeopleManagement/LearnerDetailPage/CourseEnrollments.jsx
+++ b/src/components/PeopleManagement/LearnerDetailPage/CourseEnrollments.jsx
@@ -17,13 +17,13 @@ const CourseEnrollments = ({ userEmail, lmsUserId, enterpriseUuid }) => {
       ) : (
         <>
           <h3>Enrollments</h3>
-          {enrollments.completed.map((enrollment) => (
+          {enrollments?.completed?.map((enrollment) => (
             <EnrollmentCard enrollment={enrollment} />
           ))}
-          {enrollments.inProgress.map((enrollment) => (
+          {enrollments?.inProgress?.map((enrollment) => (
             <EnrollmentCard enrollment={enrollment} />
           ))}
-          {enrollments.upcoming.map((enrollment) => (
+          {enrollments?.upcoming?.map((enrollment) => (
             <EnrollmentCard enrollment={enrollment} />
           ))}
         </>

--- a/src/components/PeopleManagement/data/ValidatedEmailsContext.tsx
+++ b/src/components/PeopleManagement/data/ValidatedEmailsContext.tsx
@@ -18,6 +18,7 @@ export const initialContext: ValidatedEmailsContext = {
   isValidInput: true,
   isCreateGroupFileUpload: false,
   isCreateGroupListSelection: false,
+  validatedEmails: [],
   lowerCasedEmails: [],
   duplicateEmails: [],
   invalidEmails: [],

--- a/src/components/PeopleManagement/data/reducer.ts
+++ b/src/components/PeopleManagement/data/reducer.ts
@@ -21,9 +21,19 @@ export type ValidatedEmailsReducerType = (
 const allEmails = (state: ValidatedEmailsContext) => {
   // Return all emails from the context regardless of error status
   const {
-    lowerCasedEmails, duplicateEmails, invalidEmails,
+    validatedEmails, duplicateEmails, invalidEmails,
   } = state;
-  return [lowerCasedEmails, duplicateEmails, invalidEmails].flatMap((list) => list || []);
+  return [validatedEmails, duplicateEmails, invalidEmails].flatMap((list) => list || []);
+};
+
+const removeEmailsFromState = (
+  state: ValidatedEmailsContext,
+  removedValidatedEmails: string[],
+): ValidatedEmailsContext => {
+  const validatedEmails = removeStringsFromList(state.validatedEmails as string[], removedValidatedEmails);
+  const lowerCasedEmailsToRemove = removedValidatedEmails.map((str) => str.toLowerCase());
+  const lowerCasedEmails = removeStringsFromList(state.lowerCasedEmails as string[], lowerCasedEmailsToRemove);
+  return { ...state, validatedEmails, lowerCasedEmails };
 };
 
 const getUpdatedEmailsAndState = (
@@ -36,7 +46,7 @@ const getUpdatedEmailsAndState = (
     const newState = {
       ...state, duplicateEmails: [], invalidEmails: [],
     };
-    return [newState, [...(newState.lowerCasedEmails || []), ...addedEmails]];
+    return [newState, [...(newState.validatedEmails || []), ...addedEmails]];
   }
 
   return [state, [...allEmails(state), ...addedEmails]];
@@ -69,10 +79,7 @@ export const ValidatedEmailsReducer: ValidatedEmailsReducerType = (
       return { ...newState, ...emailValidation };
     } case REMOVE_EMAILS: {
       const { emails: removedEmails } = action.arguments as RemoveEmailsArguments;
-      const newState = { ...state };
-      const emails = newState.lowerCasedEmails as string[];
-      newState.lowerCasedEmails = removeStringsFromList(emails, removedEmails);
-      return { ...newState };
+      return removeEmailsFromState(state, removedEmails);
     } default: {
       logError(`Unexpected action: ${action?.type}`);
       return state;

--- a/src/components/PeopleManagement/tests/CreateGroupModal.test.jsx
+++ b/src/components/PeopleManagement/tests/CreateGroupModal.test.jsx
@@ -432,7 +432,7 @@ describe('<CreateGroupModal />', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Summary (1)')).toBeInTheDocument();
-      expect(screen.getByText('testuser-nonlowercase@2u.com')).toBeInTheDocument();
+      expect(screen.getAllByText('testUser-NonLowercase@2u.com')).toHaveLength(2);
     }, { timeout: EMAIL_ADDRESSES_INPUT_VALUE_DEBOUNCE_DELAY + 1000 });
 
     // Remove non-lowercased member
@@ -440,7 +440,7 @@ describe('<CreateGroupModal />', () => {
 
     await waitFor(() => {
       expect(screen.queryByText('Summary (1)')).not.toBeInTheDocument();
-      expect(screen.queryByText('testuser-nonlowercase@2u.com')).not.toBeInTheDocument();
+      expect(screen.getAllByText('testUser-NonLowercase@2u.com')).toHaveLength(1);
     }, { timeout: EMAIL_ADDRESSES_INPUT_VALUE_DEBOUNCE_DELAY + 1000 });
   });
 });

--- a/src/components/learner-credit-management/cards/data/utils.ts
+++ b/src/components/learner-credit-management/cards/data/utils.ts
@@ -118,6 +118,8 @@ export type LearnerEmailsValidityReport = {
   canInvite: boolean,
   /* If there are no invalid emails and the count of emails is under the limit */
   isValidInput: boolean,
+  /* List of valid emails in their original casing */
+  validatedEmails: string[],
   /* List of valid lower-cased emails */
   lowerCasedEmails: string[],
   /* List of duplicate emails */
@@ -143,6 +145,7 @@ export const isInviteEmailAddressesInputValueValid = ({
 }: LearnerEmailsValidityArgs): LearnerEmailsValidityReport => {
   let validationError;
   const learnerEmailsCount = learnerEmails.length;
+  const lowerCasedEmails: string[] = [];
   const validatedEmails: string[] = [];
   const invalidEmails: string[] = [];
   const duplicateEmails: string[] = [];
@@ -153,12 +156,13 @@ export const isInviteEmailAddressesInputValueValid = ({
     // Validate the email address
     if (!isEmail(email)) {
       invalidEmails.push(email);
-    } else if (validatedEmails.includes(lowerCasedEmail)) {
+    } else if (lowerCasedEmails.includes(lowerCasedEmail)) {
       // Check for duplicates (case-insensitive)
       duplicateEmails.push(email);
     } else {
-      // Add to list of lower-cased emails already handled
-      validatedEmails.push(lowerCasedEmail);
+      // Add to list of emailss already handled
+      lowerCasedEmails.push(lowerCasedEmail);
+      validatedEmails.push(email);
     }
   });
 
@@ -199,7 +203,8 @@ export const isInviteEmailAddressesInputValueValid = ({
 
   return {
     canInvite,
-    lowerCasedEmails: validatedEmails,
+    lowerCasedEmails,
+    validatedEmails,
     duplicateEmails,
     invalidEmails,
     isValidInput,

--- a/src/components/learner-credit-management/invite-modal/InviteModalSummary.tsx
+++ b/src/components/learner-credit-management/invite-modal/InviteModalSummary.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Card, Stack } from '@openedx/paragon';
@@ -8,17 +8,23 @@ import InviteModalSummaryEmptyState from './InviteModalSummaryEmptyState';
 import InviteModalSummaryLearnerList from './InviteModalSummaryLearnerList';
 import InviteModalSummaryErrorState from './InviteModalSummaryErrorState';
 import InviteModalSummaryDuplicate from './InviteModalSummaryDuplicate';
+import { LearnerEmailsValidityReport } from '../cards/data';
+
+type InviteModalSummaryProps = {
+  memberInviteMetadata: LearnerEmailsValidityReport
+  isGroupInvite: boolean,
+};
 
 const InviteModalSummary = ({
   memberInviteMetadata,
   isGroupInvite,
-}) => {
+}: InviteModalSummaryProps) => {
   const {
     isValidInput,
-    lowerCasedEmails,
+    validatedEmails,
     duplicateEmails,
   } = memberInviteMetadata;
-  const renderCard = (contents, showErrorHighlight) => (
+  const renderCard = (contents, showErrorHighlight = false): ReactElement => (
     <Stack gap={2.5} className="mb-4">
       <Card
         className={classNames(
@@ -33,11 +39,11 @@ const InviteModalSummary = ({
     </Stack>
   );
 
-  const hasLearnerEmails = lowerCasedEmails?.length > 0;
-  let cardSections = [];
+  const hasLearnerEmails = validatedEmails?.length > 0;
+  let cardSections = [] as ReactElement[];
   if (hasLearnerEmails) {
     cardSections = cardSections.concat(
-      renderCard(<InviteModalSummaryLearnerList learnerEmails={lowerCasedEmails} />),
+      renderCard(<InviteModalSummaryLearnerList learnerEmails={validatedEmails} />),
     );
   }
 
@@ -55,7 +61,7 @@ const InviteModalSummary = ({
 
   let summaryHeading = 'Summary';
   if (hasLearnerEmails) {
-    summaryHeading = `${summaryHeading} (${lowerCasedEmails.length})`;
+    summaryHeading = `${summaryHeading} (${validatedEmails.length})`;
   }
   return (
     <>
@@ -69,7 +75,7 @@ const InviteModalSummary = ({
 InviteModalSummary.propTypes = {
   memberInviteMetadata: PropTypes.shape({
     isValidInput: PropTypes.bool,
-    lowerCasedEmails: PropTypes.arrayOf(PropTypes.string),
+    validatedEmails: PropTypes.arrayOf(PropTypes.string),
     duplicateEmails: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,
   isGroupInvite: PropTypes.bool,

--- a/src/components/learner-credit-management/invite-modal/InviteSummaryCount.tsx
+++ b/src/components/learner-credit-management/invite-modal/InviteSummaryCount.tsx
@@ -1,23 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Card } from '@openedx/paragon';
+import { LearnerEmailsValidityReport } from '../cards/data';
 
-const InviteSummaryCount = ({ memberInviteMetadata }) => (
+type InviteSummaryCountProps = {
+  memberInviteMetadata: LearnerEmailsValidityReport
+};
+
+const InviteSummaryCount = ({ memberInviteMetadata }: InviteSummaryCountProps) => (
   <Card className="mt-2 d-flex px-3 py-2 rounded-0 shadow-none">
     <Card.Footer className="p-0 justify-content-between" orientation="horizontal">
       <span>
         Total members to add
       </span>
-      <span>{memberInviteMetadata.lowerCasedEmails.length}</span>
+      <span>{memberInviteMetadata?.validatedEmails?.length}</span>
     </Card.Footer>
   </Card>
 );
 
 InviteSummaryCount.propTypes = {
   memberInviteMetadata: PropTypes.shape({
-    isValidInput: PropTypes.bool,
-    lowerCasedEmails: PropTypes.arrayOf(PropTypes.string),
-    duplicateEmails: PropTypes.arrayOf(PropTypes.string),
+    validatedEmails: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -690,7 +690,7 @@ function removeStringsFromListCaseInsensitive(list, stringsToRemove) {
   // Create lookup of lowercased -> original strings
   const lowercaseLookup = fromPairs(lowercasePairs);
   // Use lowercased list with lowercased removal strings to perform an efficient set difference operation
-  const lowercaseList = list.map(pair => pair[0]);
+  const lowercaseList = lowercasePairs.map(pair => pair[0]);
   const lowercaseToRemove = stringsToRemove.map(str => str.toLowerCase());
   const removedLowercase = removeStringsFromList(lowercaseList, lowercaseToRemove);
   // Return set difference mapped back to original strings

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,6 +6,7 @@ import isArray from 'lodash/isArray';
 import mergeWith from 'lodash/mergeWith';
 import isNumber from 'lodash/isNumber';
 import isString from 'lodash/isString';
+import fromPairs from 'lodash/fromPairs';
 import isEmail from 'validator/lib/isEmail';
 import isEmpty from 'validator/lib/isEmpty';
 import isNumeric from 'validator/lib/isNumeric';
@@ -663,7 +664,7 @@ function splitAndTrim(separator, str) {
 }
 
 /**
- *
+ * Remove strings from a list, matching in a case-sensitive manner
  * @param {Array<string>} list
  *  List of strings to remove from
  * @param {Array<string>} stringsToRemove
@@ -673,6 +674,22 @@ function splitAndTrim(separator, str) {
 function removeStringsFromList(list, stringsToRemove) {
   const removalSet = new Set([...stringsToRemove]);
   return list.filter((item) => !removalSet.has(item));
+}
+
+/**
+ * Remove strings from a list, matching in a case-insensitive manner
+ * @param {Array<string>} list
+ *  List of strings to remove from
+ * @param {Array<string>} stringsToRemove
+ *  Strings that should be removed from list
+ * @returns {Array<string>}
+ */
+function removeStringsFromListCaseInsensitive(list, stringsToRemove) {
+  const lowercaseMap = fromPairs(list.map(str => [str.toLowerCase(), str]));
+  const lowercaseList = list.map(str => str.toLowerCase());
+  const lowercaseToRemove = stringsToRemove.map(str => str.toLowerCase());
+  const removedLowercase = removeStringsFromList(lowercaseList, lowercaseToRemove);
+  return removedLowercase.map(str => lowercaseMap[str]);
 }
 
 export {
@@ -726,4 +743,5 @@ export {
   downloadCsv,
   splitAndTrim,
   removeStringsFromList,
+  removeStringsFromListCaseInsensitive,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,6 +7,7 @@ import mergeWith from 'lodash/mergeWith';
 import isNumber from 'lodash/isNumber';
 import isString from 'lodash/isString';
 import fromPairs from 'lodash/fromPairs';
+import without from 'lodash/without';
 import isEmail from 'validator/lib/isEmail';
 import isEmpty from 'validator/lib/isEmpty';
 import isNumeric from 'validator/lib/isNumeric';
@@ -672,8 +673,7 @@ function splitAndTrim(separator, str) {
  * @returns {Array<string>}
  */
 function removeStringsFromList(list, stringsToRemove) {
-  const removalSet = new Set([...stringsToRemove]);
-  return list.filter((item) => !removalSet.has(item));
+  return without(list, ...stringsToRemove);
 }
 
 /**
@@ -692,9 +692,9 @@ function removeStringsFromListCaseInsensitive(list, stringsToRemove) {
   // Use lowercased list with lowercased removal strings to perform an efficient set difference operation
   const lowercaseList = lowercasePairs.map(pair => pair[0]);
   const lowercaseToRemove = stringsToRemove.map(str => str.toLowerCase());
-  const removedLowercase = removeStringsFromList(lowercaseList, lowercaseToRemove);
+  const remainingLowercase = removeStringsFromList(lowercaseList, lowercaseToRemove);
   // Return set difference mapped back to original strings
-  return removedLowercase.map(str => lowercaseLookup[str]);
+  return remainingLowercase.map(str => lowercaseLookup[str]);
 }
 
 export {

--- a/src/utils.js
+++ b/src/utils.js
@@ -685,11 +685,16 @@ function removeStringsFromList(list, stringsToRemove) {
  * @returns {Array<string>}
  */
 function removeStringsFromListCaseInsensitive(list, stringsToRemove) {
-  const lowercaseMap = fromPairs(list.map(str => [str.toLowerCase(), str]));
-  const lowercaseList = list.map(str => str.toLowerCase());
+  // Create lowercased versions of original strings
+  const lowercasePairs = list.map(str => [str.toLowerCase(), str]);
+  // Create lookup of lowercased -> original strings
+  const lowercaseLookup = fromPairs(lowercasePairs);
+  // Use lowercased list with lowercased removal strings to perform an efficient set difference operation
+  const lowercaseList = list.map(pair => pair[0]);
   const lowercaseToRemove = stringsToRemove.map(str => str.toLowerCase());
   const removedLowercase = removeStringsFromList(lowercaseList, lowercaseToRemove);
-  return removedLowercase.map(str => lowercaseMap[str]);
+  // Return set difference mapped back to original strings
+  return removedLowercase.map(str => lowercaseLookup[str]);
 }
 
 export {

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -18,6 +18,7 @@ import {
   downloadCsv,
   splitAndTrim,
   removeStringsFromList,
+  removeStringsFromListCaseInsensitive,
 } from './utils';
 
 jest.mock('@edx/frontend-platform/logging', () => ({
@@ -224,6 +225,13 @@ describe('utils', () => {
       const list = ['a', 'b', 'c', 'd'];
       const remove = ['b', 'd'];
       expect(removeStringsFromList(list, remove)).toEqual(['a', 'c']);
+    });
+  });
+  describe('removeStringsFromListCaseInsensitive', () => {
+    it('should remove strings from list in a case insensitive way', () => {
+      const list = ['a', 'b', 'c', 'd', 'E'];
+      const remove = ['B', 'd', 'e'];
+      expect(removeStringsFromListCaseInsensitive(list, remove)).toEqual(['a', 'c']);
     });
   });
 });

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -229,9 +229,9 @@ describe('utils', () => {
   });
   describe('removeStringsFromListCaseInsensitive', () => {
     it('should remove strings from list in a case insensitive way', () => {
-      const list = ['a', 'b', 'c', 'd', 'E'];
-      const remove = ['B', 'd', 'e'];
-      expect(removeStringsFromListCaseInsensitive(list, remove)).toEqual(['a', 'c']);
+      const list = ['ab', 'bc', 'cd', 'de', 'Ef'];
+      const remove = ['Bc', 'de', 'eF'];
+      expect(removeStringsFromListCaseInsensitive(list, remove)).toEqual(['ab', 'cd']);
     });
   });
 });


### PR DESCRIPTION
[Jira Ticket](https://2u-internal.atlassian.net/browse/ENT-10244)

Fix for issue where attempting to click and add a member whose email address does not have all lowercase letters will result in adding the user to the summary, but:
- The checkbox is not checked
- Clicking checkbox again will add the user multiple times, creating duplicate user errors instead of removing the user

## Testing Instructions
- Go to the admin-portal repo and run `npm run start:stage`
- Navigate to https://localhost.stage.edx.org:1991/aj-test-co/admin/people-management
- Click 'Create group'
- Navigate to second page and you will find user that has a capitalized letter in their email address
- Click this user's checkbox and verify their (lowercased) email is added to the summary
- Click user's checkbox again and verify their email is removed from the summary

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
