### PR TITLE
ENT-10281: Added a new card component for admin portal.

### DIFF
--- a/src/components/AdminV2/AdminCards.jsx
+++ b/src/components/AdminV2/AdminCards.jsx
@@ -6,7 +6,7 @@ import {
   Award, Check, Groups, RemoveRedEye,
 } from '@openedx/paragon/icons';
 
-import NumberCard from '../NumberCard';
+import NumberCard from './cards/NumberCard';
 
 class AdminCards extends React.Component {
   constructor(props) {

--- a/src/components/AdminV2/AnalyticsOverview.jsx
+++ b/src/components/AdminV2/AnalyticsOverview.jsx
@@ -4,7 +4,7 @@ import { FormattedMessage } from '@edx/frontend-platform/i18n';
 
 import AIAnalyticsSummary from './AIAnalyticsSummary';
 import AIAnalyticsSummarySkeleton from './AIAnalyticsSummarySkeleton';
-import AdminCards from '../../containers/AdminCards';
+import AdminCards from '../../containers/AdminCardsV2';
 import AdminCardsSkeleton from './AdminCardsSkeleton';
 
 const AnalyticsOverview = ({

--- a/src/components/AdminV2/cards/NumberCard/DetailsAction.jsx
+++ b/src/components/AdminV2/cards/NumberCard/DetailsAction.jsx
@@ -1,0 +1,41 @@
+import { Link, useLocation, useParams } from 'react-router-dom';
+import { Icon, Spinner } from '@openedx/paragon';
+import classNames from 'classnames';
+import { ArrowDownward } from '@openedx/paragon/icons';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { removeTrailingSlash } from '../../../../utils';
+
+const DetailsAction = ({
+  slug, label, isLoading, onClick,
+}) => {
+  const location = useLocation();
+  const { actionSlug } = useParams();
+  const slugIndex = location?.pathname.lastIndexOf('/');
+  const truncatedURL = location?.pathname.substring(0, slugIndex);
+
+  return (
+    <Link
+      key={label}
+      to={actionSlug ? `${truncatedURL}/${slug}` : `${removeTrailingSlash(location?.pathname)}/${slug}`}
+      onClick={onClick}
+    >
+      <div
+        className={classNames('p-2 d-flex align-items-center justify-content-between', { 'bg-primary-100': slug === actionSlug })}
+      >
+        <span className="label">{label}</span>
+        <Icon src={ArrowDownward} />
+        {isLoading && <Spinner animation="border" className="ml-2" variant="primary" size="sm" />}
+      </div>
+    </Link>
+  );
+};
+
+DetailsAction.propTypes = {
+  slug: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  isLoading: PropTypes.bool.isRequired,
+  onClick: PropTypes.func.isRequired,
+};
+
+export default DetailsAction;

--- a/src/components/AdminV2/cards/NumberCard/DetailsAction.test.jsx
+++ b/src/components/AdminV2/cards/NumberCard/DetailsAction.test.jsx
@@ -1,0 +1,32 @@
+import { MemoryRouter } from 'react-router-dom';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { screen, render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import DetailsAction from './DetailsAction';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: jest.fn().mockReturnValue({ pathname: '/admin' }),
+}));
+
+const DetailsActionWrapper = () => (
+  <MemoryRouter>
+    <IntlProvider locale="en">
+      <DetailsAction
+        slug="action-slug"
+        label="Action Label"
+        isLoading={false}
+        onClick={() => {}}
+      />
+    </IntlProvider>
+  </MemoryRouter>
+);
+
+describe('<NumberCard /> ', () => {
+  it('renders correctly', () => {
+    render(
+      <DetailsActionWrapper />,
+    );
+    expect(screen.getByText('Action Label')).toBeInTheDocument();
+  });
+});

--- a/src/components/AdminV2/cards/NumberCard/NumberCard.test.jsx
+++ b/src/components/AdminV2/cards/NumberCard/NumberCard.test.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { Groups } from '@openedx/paragon/icons';
+import { screen, render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+
+import NumberCard from './index';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: jest.fn().mockReturnValue({ pathname: '/admin' }),
+}));
+
+const NumberCardWrapper = () => (
+  <MemoryRouter>
+    <IntlProvider locale="en">
+      <NumberCard
+        title={10}
+        description="This describes the data!"
+        icon={Groups}
+        detailActions={
+          [{
+            label: 'Action 1',
+            slug: 'action-1',
+            isLoading: false,
+          }, {
+            label: 'Action 2',
+            slug: 'action-2',
+            isLoading: false,
+          }]
+        }
+      />
+    </IntlProvider>
+  </MemoryRouter>
+);
+
+describe('<NumberCard />', () => {
+  it('without detail actions', () => {
+    render(
+      <NumberCardWrapper />,
+    );
+    expect(screen.getByText('This describes the data!')).toBeInTheDocument();
+    expect(screen.getByText('Details')).toBeInTheDocument();
+  });
+});

--- a/src/components/AdminV2/cards/NumberCard/index.jsx
+++ b/src/components/AdminV2/cards/NumberCard/index.jsx
@@ -4,20 +4,18 @@ import {
   Icon, Card, Collapsible,
 } from '@openedx/paragon';
 
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import DetailsAction from './DetailsAction';
 
 const NumberCard = ({
   title, icon, description, detailActions,
 }) => {
-  const handleDetailsActionClick = (event) => {
+  const handleDetailsActionClick = () => {
     const element = document.getElementById('learner-progress-report');
-    if (event) {
-      event.target.click();
-    }
     if (element) {
-      setTimeout(() => {
+      requestAnimationFrame(() => {
         element.scrollIntoView({ behavior: 'smooth' });
-      }, 0);
+      });
     }
   };
 
@@ -37,10 +35,15 @@ const NumberCard = ({
       <Card.Section>
         <Collapsible
           styling="basic"
-          title="Details"
+          title={(
+            <FormattedMessage
+              id="adminPortal.cards.collapsible.details"
+              defaultMessage="Details"
+            />
+          )}
         >
           {
-            detailActions && detailActions.map(action => (
+            detailActions?.map(action => (
               <DetailsAction
                 slug={action.slug}
                 label={action.label}

--- a/src/components/AdminV2/cards/NumberCard/index.jsx
+++ b/src/components/AdminV2/cards/NumberCard/index.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Icon, Card, Collapsible,
+} from '@openedx/paragon';
+
+import DetailsAction from './DetailsAction';
+
+const NumberCard = ({
+  title, icon, description, detailActions,
+}) => {
+  const handleDetailsActionClick = (event) => {
+    const element = document.getElementById('learner-progress-report');
+    if (event) {
+      event.target.click();
+    }
+    if (element) {
+      setTimeout(() => {
+        element.scrollIntoView({ behavior: 'smooth' });
+      }, 0);
+    }
+  };
+
+  return (
+    <Card>
+      <Card.Header
+        title={(
+          <div className="d-flex align-items-center justify-content-between">
+            <h2 className="h2">
+              {typeof title === 'number' ? title.toLocaleString() : title}
+            </h2>
+            {icon && <Icon src={icon} />}
+          </div>
+        )}
+        subtitle={description}
+      />
+      <Card.Section>
+        <Collapsible
+          styling="basic"
+          title="Details"
+        >
+          {
+            detailActions && detailActions.map(action => (
+              <DetailsAction
+                slug={action.slug}
+                label={action.label}
+                isLoading={action.isLoading}
+                key={action.label}
+                onClick={handleDetailsActionClick}
+              />
+            ))
+          }
+        </Collapsible>
+      </Card.Section>
+    </Card>
+  );
+};
+
+NumberCard.defaultProps = {
+  icon: null,
+  detailActions: null,
+};
+
+NumberCard.propTypes = {
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  description: PropTypes.string.isRequired,
+  icon: PropTypes.func,
+  detailActions: PropTypes.arrayOf(PropTypes.shape({
+    slug: PropTypes.string,
+    label: PropTypes.string,
+    isLoading: PropTypes.bool,
+  })),
+};
+
+export default NumberCard;

--- a/src/components/AdminV2/tests/Admin.test.jsx
+++ b/src/components/AdminV2/tests/Admin.test.jsx
@@ -281,7 +281,7 @@ describe('<Admin />', () => {
       });
 
       it('renders collapsible cards', () => {
-        const { container } = render(
+        render(
           <AdminWrapper
             {...baseProps}
           />,
@@ -289,7 +289,7 @@ describe('<Admin />', () => {
         expect(screen.getByRole('main')).toHaveClass('learner-progress-report');
         expect(screen.getByRole('heading', { name: 'Learner Progress Report' })).toBeInTheDocument();
         expect(screen.getByText('Full report')).toBeInTheDocument();
-        expect(container.querySelector('.card-footer')).toBeInTheDocument();
+        expect(screen.getByText('total number of learners registered')).toBeInTheDocument();
       });
     });
 
@@ -350,10 +350,10 @@ describe('<Admin />', () => {
           },
         };
 
-        const { container } = render(<AdminWrapper {...baseProps} insights={insights} />);
+        render(<AdminWrapper {...baseProps} insights={insights} />);
 
         expect(screen.getByRole('heading', { name: 'Learner Progress Report' })).toBeInTheDocument();
-        expect(container.querySelector('.number-card')).toBeInTheDocument();
+        expect(screen.getByText('total number of learners registered')).toBeInTheDocument();
       });
 
       it('renders skeleton when loading is true', () => {

--- a/src/components/AdminV2/tests/AdminCards.test.jsx
+++ b/src/components/AdminV2/tests/AdminCards.test.jsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { BrowserRouter } from 'react-router-dom';
 import AdminCards from '../AdminCards';
-import NumberCard from '../../NumberCard';
+import NumberCard from '../cards/NumberCard';
 
 jest.mock('@openedx/paragon/icons', () => ({
   Award: function Award() { return <span data-testid="icon-award" />; },

--- a/src/containers/AdminCardsV2/index.jsx
+++ b/src/containers/AdminCardsV2/index.jsx
@@ -1,0 +1,12 @@
+import { connect } from 'react-redux';
+
+import AdminCards from '../../components/AdminV2/AdminCards';
+
+const mapStateToProps = state => ({
+  activeLearners: state.dashboardAnalytics.active_learners,
+  enrolledLearners: state.dashboardAnalytics.enrolled_learners,
+  numberOfUsers: state.dashboardAnalytics.number_of_users,
+  courseCompletions: state.dashboardAnalytics.course_completions,
+});
+
+export default connect(mapStateToProps)(AdminCards);


### PR DESCRIPTION
__Jira Ticket:__ [ENT-10240](https://2u-internal.atlassian.net/browse/ENT-10281)

__Description:__
This PR adds a new component to use for showing the cards at the top section of Learner Progress Report.

<img width="1449" alt="Screenshot 2025-04-21 at 12 08 16 PM" src="https://github.com/user-attachments/assets/fcfcfa48-249b-47a6-a52f-de7642108bb2" />


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
