### PR TITLE
fix: modify bulk revoke logic

### DIFF
--- a/src/components/subscriptions/licenses/LicenseManagementModals/LicenseManagementRemindModal.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementModals/LicenseManagementRemindModal.jsx
@@ -108,10 +108,7 @@ const LicenseManagementRemindModal = ({
       } else {
         // If the UI happened to render bulk actions without any state set for the table or just a filter is set
         // with no selected items.
-        logError(`Unable to remind license(s) based on table state,
-        remindAllUsers: ${remindAllUsers},
-        userEmailsToRevoke: ${userEmailsToRemind},
-        filters: ${activeFilters}`);
+        logError('Unable to remind license(s) based on table state. No licenses selected for reminder');
         throw new Error('Unable to remind license(s) based on table state');
       }
 

--- a/src/components/subscriptions/licenses/LicenseManagementModals/LicenseManagementRemindModal.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementModals/LicenseManagementRemindModal.jsx
@@ -1,15 +1,9 @@
-import React, { useState, useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import dayjs from 'dayjs';
 import {
-  Alert,
-  StatefulButton,
-  ModalDialog,
-  ActionRow,
-  Spinner,
-  Form,
-  Hyperlink,
+  ActionRow, Alert, Form, Hyperlink, ModalDialog, Spinner, StatefulButton,
 } from '@openedx/paragon';
 import { logError } from '@edx/frontend-platform/logging';
 
@@ -112,7 +106,13 @@ const LicenseManagementRemindModal = ({
       if (userEmailsToRemind.length > 0) {
         options.user_emails = userEmailsToRemind;
       } else {
-        options.filters = transformedFilters;
+        // If the UI happened to render bulk actions without any state set for the table or just a filter is set
+        // with no selected items.
+        logError(`Unable to remind license(s) based on table state,
+        remindAllUsers: ${remindAllUsers},
+        userEmailsToRevoke: ${userEmailsToRemind},
+        filters: ${activeFilters}`);
+        throw new Error('Unable to remind license(s) based on table state');
       }
 
       return LicenseManagerApiService.licenseBulkRemind(subscription.uuid, options);

--- a/src/components/subscriptions/licenses/LicenseManagementModals/LicenseManagementRevokeModal.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementModals/LicenseManagementRevokeModal.jsx
@@ -3,17 +3,9 @@ import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
 
 import {
-  Alert,
-  StatefulButton,
-  ModalDialog,
-  ActionRow,
-  Hyperlink,
-  Icon,
-  Spinner,
+  ActionRow, Alert, Hyperlink, Icon, ModalDialog, Spinner, StatefulButton,
 } from '@openedx/paragon';
-import {
-  RemoveCircle,
-} from '@openedx/paragon/icons';
+import { RemoveCircle } from '@openedx/paragon/icons';
 import { logError } from '@edx/frontend-platform/logging';
 
 import { useRequestState } from './LicenseManagementModalHook';
@@ -100,7 +92,6 @@ const LicenseManagementRevokeModal = ({
     setRequestState({ ...initialRequestState, loading: true });
     const makeRequest = async () => {
       const filtersPresent = activeFilters.length > 0;
-
       // If all users are selected and there are no filters, hit revoke-all endpoint
       if (revokeAllUsers && !filtersPresent) {
         return LicenseManagerApiService.licenseRevokeAll(subscription.uuid);
@@ -110,9 +101,9 @@ const LicenseManagementRevokeModal = ({
       const userEmailsToRevoke = usersToRevoke.map((user) => user.email);
 
       const options = {};
-      if (userEmailsToRevoke.length > 0) {
+      if (userEmailsToRevoke.length > 0 && !revokeAllUsers && !filtersPresent) {
         options.user_emails = userEmailsToRevoke;
-      } else {
+      } else if (filtersPresent) {
         options.filters = transformFiltersForRequest(activeFilters);
       }
       try {

--- a/src/components/subscriptions/licenses/LicenseManagementModals/LicenseManagementRevokeModal.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementModals/LicenseManagementRevokeModal.jsx
@@ -128,16 +128,12 @@ const LicenseManagementRevokeModal = ({
       }
       // If all users not selected, then hit bulk-revoke with the emails loaded into the UI
       const userEmailsToRevoke = usersToRevoke.map((user) => user.email);
-
       if (userEmailsToRevoke.length > 0) {
         options.user_emails = userEmailsToRevoke;
       } else {
         // If the UI happened to render bulk actions without any state set for the table or just a filter is set
         // with no selected items.
-        logError(`Unable to revoke license(s) based on table state,
-        revokeAllUsers: ${revokeAllUsers},
-        userEmailsToRevoke: ${userEmailsToRevoke},
-        filters: ${activeFilters}`);
+        logError('Unable to revoke license(s) based on table state. No licenses selected for revocation');
         throw new Error('Unable to revoke license(s) based on table state');
       }
       return bulkRevokeUsers(options);

--- a/src/components/subscriptions/licenses/LicenseManagementModals/tests/LicenseManagementRemindModal.test.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementModals/tests/LicenseManagementRemindModal.test.jsx
@@ -110,12 +110,12 @@ describe('<LicenseManagementRemindModal />', () => {
 
       const button = screen.getByText('Remind (1)');
       await act(async () => { userEvent.click(button); });
-      expect(onSubmitMock).toBeCalledTimes(1);
-      expect(onSuccessMock).toBeCalledTimes(1);
+      expect(onSubmitMock).toHaveBeenCalledTimes(1);
+      expect(onSuccessMock).toHaveBeenCalledTimes(1);
 
       expect(screen.queryByText('Remind (1)')).toBeFalsy();
       expect(screen.queryByText('Done')).toBeTruthy();
-      expect(logError).toBeCalledTimes(0);
+      expect(logError).toHaveBeenCalledTimes(0);
     });
 
     it('displays alert if licenseRemind has error', async () => {
@@ -128,13 +128,13 @@ describe('<LicenseManagementRemindModal />', () => {
 
       const button = screen.getByText('Remind (1)');
       await act(async () => { userEvent.click(button); });
-      expect(onSubmitMock).toBeCalledTimes(1);
-      expect(onSuccessMock).toBeCalledTimes(0);
+      expect(onSubmitMock).toHaveBeenCalledTimes(1);
+      expect(onSuccessMock).toHaveBeenCalledTimes(0);
 
       await waitFor(() => {
         expect(screen.getByRole('alert')).toBeTruthy();
       });
-      expect(logError).toBeCalledTimes(1);
+      expect(logError).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/components/subscriptions/licenses/LicenseManagementModals/tests/LicenseManagementRevokeModal.test.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementModals/tests/LicenseManagementRevokeModal.test.jsx
@@ -122,8 +122,8 @@ describe('<LicenseManagementRevokeModal />', () => {
 
       const button = screen.getByText('Revoke (1)');
       await act(async () => { userEvent.click(button); });
-      expect(onSubmitMock).toBeCalledTimes(1);
-      expect(onSuccessMock).toBeCalledTimes(0);
+      expect(onSubmitMock).toHaveBeenCalledTimes(1);
+      expect(onSuccessMock).toHaveBeenCalledTimes(0);
 
       await waitFor(() => {
         expect(screen.getByRole('alert')).toBeTruthy();
@@ -145,8 +145,8 @@ describe('<LicenseManagementRevokeModal />', () => {
         render(<LicenseManagementRevokeModalWrapper {...props} />);
         await act(async () => { userEvent.click(screen.getByText('Revoke (1)')); });
 
-        expect(onSuccessMock).toBeCalledTimes(1);
-        expect(logError).not.toBeCalled();
+        expect(onSuccessMock).toHaveBeenCalledTimes(1);
+        expect(logError).toHaveBeenCalledTimes(0);
       });
 
       it('handles 400 error response correctly', async () => {
@@ -156,8 +156,8 @@ describe('<LicenseManagementRevokeModal />', () => {
         render(<LicenseManagementRevokeModalWrapper {...props} />);
         await act(async () => { userEvent.click(screen.getByText('Revoke (1)')); });
 
-        expect(onSuccessMock).not.toBeCalled();
-        expect(logError).toBeCalledTimes(1);
+        expect(onSuccessMock).toHaveBeenCalledTimes(0);
+        expect(logError).toHaveBeenCalledTimes(1);
       });
 
       it('handles 404 error response correctly', async () => {
@@ -167,8 +167,8 @@ describe('<LicenseManagementRevokeModal />', () => {
         render(<LicenseManagementRevokeModalWrapper {...props} />);
         await act(async () => { userEvent.click(screen.getByText('Revoke (1)')); });
 
-        expect(onSuccessMock).not.toBeCalled();
-        expect(logError).toBeCalledTimes(1);
+        expect(onSuccessMock).toHaveBeenCalledTimes(0);
+        expect(logError).toHaveBeenCalledTimes(1);
       });
 
       it('handles 207 partial success with only 404 errors correctly', async () => {
@@ -183,8 +183,8 @@ describe('<LicenseManagementRevokeModal />', () => {
         render(<LicenseManagementRevokeModalWrapper {...props} />);
         await act(async () => { userEvent.click(screen.getByText('Revoke (1)')); });
 
-        expect(onSuccessMock).toBeCalledTimes(1);
-        expect(logError).not.toBeCalled();
+        expect(onSuccessMock).toHaveBeenCalledTimes(1);
+        expect(logError).toHaveBeenCalledTimes(0);
       });
 
       it('handles 207 partial success with mixed errors correctly', async () => {
@@ -206,8 +206,8 @@ describe('<LicenseManagementRevokeModal />', () => {
         render(<LicenseManagementRevokeModalWrapper {...props} />);
         await act(async () => { userEvent.click(screen.getByText('Revoke (1)')); });
 
-        expect(onSuccessMock).not.toBeCalled();
-        expect(logError).toBeCalledTimes(1);
+        expect(onSuccessMock).toHaveBeenCalledTimes(0);
+        expect(logError).toHaveBeenCalledTimes(1);
       });
 
       it('handles 207 partial success with 404 errors and successful revocations correctly', async () => {
@@ -229,9 +229,9 @@ describe('<LicenseManagementRevokeModal />', () => {
         render(<LicenseManagementRevokeModalWrapper {...props} />);
         await act(async () => { userEvent.click(screen.getByText('Revoke (1)')); });
 
-        expect(onSuccessMock).toBeCalledTimes(1);
+        expect(onSuccessMock).toHaveBeenCalledTimes(1);
         expect(onSuccessMock).toHaveBeenCalledWith(mockPartialSuccess207WithMixed404AndSuccess.data);
-        expect(logError).not.toBeCalled();
+        expect(logError).toHaveBeenCalledTimes(0);
       });
     });
 
@@ -245,12 +245,12 @@ describe('<LicenseManagementRevokeModal />', () => {
 
       const button = screen.getByText('Revoke all');
       await act(async () => { userEvent.click(button); });
-      expect(onSubmitMock).toBeCalledTimes(1);
+      expect(onSubmitMock).toHaveBeenCalledTimes(1);
 
       await waitFor(() => {
         expect(screen.getByRole('alert')).toBeTruthy();
       });
-      expect(logError).toBeCalledTimes(1);
+      expect(logError).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -313,6 +313,7 @@ describe('<LicenseManagementRevokeModal />', () => {
       const props = {
         ...basicProps,
         revokeAllUsers: true,
+        usersToRevoke: [sampleUser],
         totalToRevoke: null,
         activeFilters: [{
           name: 'statusBadge',


### PR DESCRIPTION
Updated logic behind the bulk revoke logic when selecting all items within a table with filters enabled. We modify to logic to correctly fall into the codepath of passing filters as options to the bulk revoke logic. 

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
