### PR TITLE
feat: Enabled group functionality for groups.

### DIFF
--- a/src/components/AdvanceAnalyticsV2/AnalyticsV2Page.jsx
+++ b/src/components/AdvanceAnalyticsV2/AnalyticsV2Page.jsx
@@ -15,15 +15,19 @@ import Leaderboard from './tabs/Leaderboard';
 import Skills from './tabs/Skills';
 import { useEnterpriseAnalyticsAggregatesData } from './data/hooks';
 import { GRANULARITY, CALCULATION } from './data/constants';
+import { DEFAULT_GROUP } from './constants';
 import { formatTimestamp } from '../../utils';
+import { useAllFlexEnterpriseGroups } from '../learner-credit-management/data';
 
 const AnalyticsV2Page = ({ enterpriseId }) => {
   const [activeTab, setActiveTab] = useState('enrollments');
   const [granularity, setGranularity] = useState(GRANULARITY.WEEKLY);
   const [calculation, setCalculation] = useState('Total');
+  const [groupUUID, setGroupUUID] = useState('');
   const [startDate, setStartDate] = useState();
   const [endDate, setEndDate] = useState();
   const intl = useIntl();
+  const { data: groups, isLoading: isGroupsLoading } = useAllFlexEnterpriseGroups(enterpriseId);
 
   const PAGE_TITLE = intl.formatMessage({
     id: 'analytics.page.title',
@@ -93,13 +97,46 @@ const AnalyticsV2Page = ({ enterpriseId }) => {
               />
             </Form.Group>
           </div>
+          <div className="col" data-testid="group-select">
+            <Form.Group>
+              <Form.Label>
+                <FormattedMessage
+                  id="advance.analytics.filter.date.group"
+                  defaultMessage="Group"
+                  description="Advance analytics group filter label"
+                />
+              </Form.Label>
+              <Form.Control
+                as="select"
+                value={groupUUID}
+                onChange={(e) => setGroupUUID(e.target.value)}
+                disabled={isGroupsLoading || groups === undefined || groups.length === 0}
+              >
+                <option value={DEFAULT_GROUP}>
+                  {intl.formatMessage({
+                    id: 'adminPortal.analytics.filter.group.all',
+                    defaultMessage: 'All Groups',
+                    description: 'Label for the all groups option in the group filter dropdown in the admin portal analytics.',
+                  })}
+                </option>
+                {groups?.map(grp => (
+                  <option
+                    value={grp.uuid}
+                    key={grp.uuid}
+                  >
+                    {grp.name}
+                  </option>
+                ))}
+              </Form.Control>
+            </Form.Group>
+          </div>
           <div className="col" data-testid="granularity-select">
             <Form.Group>
               <Form.Label>
                 <FormattedMessage
                   id="advance.analytics.filter.date.granularity"
                   defaultMessage="Date granularity"
-                  description="Advance analytics Date granularity filter label"
+                  description="Advance analytics data granularity filter label"
                 />
               </Form.Label>
               <Form.Control
@@ -216,6 +253,7 @@ const AnalyticsV2Page = ({ enterpriseId }) => {
                 endDate={endDate || currentDate}
                 granularity={granularity}
                 calculation={calculation}
+                groupUUID={groupUUID}
                 enterpriseId={enterpriseId}
               />
             </Tab>
@@ -232,6 +270,7 @@ const AnalyticsV2Page = ({ enterpriseId }) => {
                 endDate={endDate || currentDate}
                 enterpriseId={enterpriseId}
                 granularity={granularity}
+                groupUUID={groupUUID}
                 calculation={calculation}
               />
             </Tab>
@@ -248,6 +287,7 @@ const AnalyticsV2Page = ({ enterpriseId }) => {
                 endDate={endDate || currentDate}
                 granularity={granularity}
                 calculation={calculation}
+                groupUUID={groupUUID}
                 enterpriseId={enterpriseId}
               />
             </Tab>

--- a/src/components/AdvanceAnalyticsV2/constants.js
+++ b/src/components/AdvanceAnalyticsV2/constants.js
@@ -1,0 +1,2 @@
+// Default group for the analytics. For now, it will be an empty string.
+export const DEFAULT_GROUP = '';

--- a/src/components/AdvanceAnalyticsV2/data/hooks/index.js
+++ b/src/components/AdvanceAnalyticsV2/data/hooks/index.js
@@ -15,12 +15,13 @@ export const useEnterpriseAnalyticsData = ({
   endDate,
   granularity = undefined,
   calculation = undefined,
+  groupUUID = undefined,
   currentPage = undefined,
   pageSize = undefined,
   queryOptions = {},
 }) => {
   const requestOptions = {
-    startDate, endDate, granularity, calculation, page: currentPage, pageSize,
+    startDate, endDate, granularity, calculation, page: currentPage, pageSize, groupUUID,
   };
   return useQuery({
     queryKey: advanceAnalyticsQueryKeys[key](enterpriseCustomerUUID, requestOptions),

--- a/src/components/AdvanceAnalyticsV2/data/hooks/useEnterpriseCompletionsData.js
+++ b/src/components/AdvanceAnalyticsV2/data/hooks/useEnterpriseCompletionsData.js
@@ -43,7 +43,7 @@ const applyDataTransformations = (response, granularity, calculation, allowedEnr
 };
 
 /**
-  Fetches enterprise completion data.
+ Fetches enterprise completion data.
 
  *  @param {String} enterpriseCustomerUUID - UUID of the enterprise customer.
  *  @param {Date} startDate - Start date for the data.
@@ -51,6 +51,7 @@ const applyDataTransformations = (response, granularity, calculation, allowedEnr
  *  @param {OpUnitType} granularity - Granularity of the data. e.g. `day`, `week`, `month`, `quarter`, `year`.
  *  @param {String} calculation - Calculation to apply on the data. e.g.
  *    `total`, `running_total`, `moving_average_3_periods`, `moving_average_7_periods`.
+ *  @param groupUUID - UUID of the group.
  *  @param {object} queryOptions - Additional options for the query.
  */
 const useEnterpriseCompletionsData = ({
@@ -59,9 +60,10 @@ const useEnterpriseCompletionsData = ({
   endDate,
   granularity = undefined,
   calculation = undefined,
+  groupUUID = undefined,
   queryOptions = {},
 }) => {
-  const requestOptions = { startDate, endDate };
+  const requestOptions = { startDate, endDate, groupUUID };
   const response = useQuery({
     queryKey: generateKey('completions', enterpriseCustomerUUID, requestOptions),
     queryFn: () => EnterpriseDataApiService.fetchAdminAnalyticsData(

--- a/src/components/AdvanceAnalyticsV2/data/hooks/useEnterpriseEngagementData.js
+++ b/src/components/AdvanceAnalyticsV2/data/hooks/useEnterpriseEngagementData.js
@@ -43,7 +43,7 @@ const applyDataTransformations = (response, granularity, calculation, allowedEnr
 };
 
 /**
-  Fetches enterprise engagement data.
+ Fetches enterprise engagement data.
 
  *  @param {String} enterpriseCustomerUUID - UUID of the enterprise customer.
  *  @param {Date} startDate - Start date for the data.
@@ -51,6 +51,7 @@ const applyDataTransformations = (response, granularity, calculation, allowedEnr
  *  @param {OpUnitType} granularity - Granularity of the data. e.g. `day`, `week`, `month`, `quarter`, `year`.
  *  @param {String} calculation - Calculation to apply on the data. e.g.
  *    `total`, `running_total`, `moving_average_3_periods`, `moving_average_7_periods`.
+ *  @param groupUUID - UUID of the group.
  *  @param {object} queryOptions - Additional options for the query.
  */
 const useEnterpriseEngagementData = ({
@@ -59,9 +60,10 @@ const useEnterpriseEngagementData = ({
   endDate,
   granularity = undefined,
   calculation = undefined,
+  groupUUID = undefined,
   queryOptions = {},
 }) => {
-  const requestOptions = { startDate, endDate };
+  const requestOptions = { startDate, endDate, groupUUID };
   const response = useQuery({
     queryKey: generateKey('engagements', enterpriseCustomerUUID, requestOptions),
     queryFn: () => EnterpriseDataApiService.fetchAdminAnalyticsData(

--- a/src/components/AdvanceAnalyticsV2/data/hooks/useEnterpriseEnrollmentsData.js
+++ b/src/components/AdvanceAnalyticsV2/data/hooks/useEnterpriseEnrollmentsData.js
@@ -43,7 +43,7 @@ const applyDataTransformations = (response, granularity, calculation, allowedEnr
 };
 
 /**
-  Fetches enterprise enrollments data.
+ Fetches enterprise enrollments data.
 
  *  @param {String} enterpriseCustomerUUID - UUID of the enterprise customer.
  *  @param {Date} startDate - Start date for the data.
@@ -51,6 +51,7 @@ const applyDataTransformations = (response, granularity, calculation, allowedEnr
  *  @param {OpUnitType} granularity - Granularity of the data. e.g. `day`, `week`, `month`, `quarter`, `year`.
  *  @param {String} calculation - Calculation to apply on the data. e.g.
  *    `total`, `running_total`, `moving_average_3_periods`, `moving_average_7_periods`.
+ *  @param groupUUID - UUID of the group.
  *  @param {Number} currentPage - Current page number.
  *  @param {Number} pageSize - Number of items per page.
  *  @param {object} queryOptions - Additional options for the query.
@@ -61,12 +62,13 @@ const useEnterpriseEnrollmentsData = ({
   endDate,
   granularity = undefined,
   calculation = undefined,
+  groupUUID = undefined,
   currentPage = undefined,
   pageSize = undefined,
   queryOptions = {},
 }) => {
   const requestOptions = {
-    startDate, endDate, page: currentPage, pageSize,
+    startDate, endDate, page: currentPage, pageSize, groupUUID,
   };
   const response = useQuery({
     queryKey: generateKey('enrollments', enterpriseCustomerUUID, requestOptions),

--- a/src/components/AdvanceAnalyticsV2/tabs/AnalyticsTable.jsx
+++ b/src/components/AdvanceAnalyticsV2/tabs/AnalyticsTable.jsx
@@ -18,6 +18,7 @@ const AnalyticsTable = ({
   startDate,
   endDate,
   enterpriseId,
+  groupUUID,
 }) => {
   const intl = useIntl();
   const [currentPage, setCurrentPage] = useState(0);
@@ -30,6 +31,7 @@ const AnalyticsTable = ({
     key: analyticsDataTableKeys[name],
     startDate,
     endDate,
+    groupUUID,
     // pages index from 1 in backend, frontend components index from 0
     currentPage: currentPage + 1,
     pageSize,
@@ -41,6 +43,7 @@ const AnalyticsTable = ({
     {
       start_date: startDate,
       end_date: endDate,
+      groupUUID,
     },
   );
 
@@ -103,6 +106,10 @@ const AnalyticsTable = ({
   );
 };
 
+AnalyticsTable.defaultProps = {
+  groupUUID: undefined,
+};
+
 AnalyticsTable.propTypes = {
   name: PropTypes.string.isRequired,
   tableColumns: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
@@ -111,6 +118,7 @@ AnalyticsTable.propTypes = {
   enterpriseId: PropTypes.string.isRequired,
   startDate: PropTypes.string.isRequired,
   endDate: PropTypes.string.isRequired,
+  groupUUID: PropTypes.string,
 };
 
 export default AnalyticsTable;

--- a/src/components/AdvanceAnalyticsV2/tabs/Completions.jsx
+++ b/src/components/AdvanceAnalyticsV2/tabs/Completions.jsx
@@ -11,7 +11,7 @@ import DownloadCSVButton from '../DownloadCSVButton';
 import { constructChartHoverTemplate, modifyDataToIntroduceEnrollTypeCount } from '../data/utils';
 
 const Completions = ({
-  startDate, endDate, granularity, calculation, enterpriseId,
+  startDate, endDate, granularity, calculation, enterpriseId, groupUUID,
 }) => {
   const intl = useIntl();
 
@@ -24,6 +24,7 @@ const Completions = ({
     endDate,
     granularity,
     calculation,
+    groupUUID,
   });
 
   const completionsOverTimeForCSV = useMemo(() => {
@@ -221,6 +222,7 @@ const Completions = ({
           startDate={startDate}
           endDate={endDate}
           enterpriseId={enterpriseId}
+          groupUUID={groupUUID}
           enableCSVDownload
           tableColumns={[
             {
@@ -269,5 +271,6 @@ Completions.propTypes = {
   endDate: PropTypes.string.isRequired,
   granularity: PropTypes.string.isRequired,
   calculation: PropTypes.string.isRequired,
+  groupUUID: PropTypes.string.isRequired,
 };
 export default Completions;

--- a/src/components/AdvanceAnalyticsV2/tabs/Engagements.jsx
+++ b/src/components/AdvanceAnalyticsV2/tabs/Engagements.jsx
@@ -11,7 +11,7 @@ import DownloadCSVButton from '../DownloadCSVButton';
 import { constructChartHoverTemplate, modifyDataToIntroduceEnrollTypeCount } from '../data/utils';
 
 const Engagements = ({
-  startDate, endDate, granularity, calculation, enterpriseId,
+  startDate, endDate, granularity, calculation, enterpriseId, groupUUID,
 }) => {
   const intl = useIntl();
   const {
@@ -23,6 +23,7 @@ const Engagements = ({
     endDate,
     granularity,
     calculation,
+    groupUUID,
   });
 
   const engagementOverTimeForCSV = useMemo(() => {
@@ -220,6 +221,7 @@ const Engagements = ({
           startDate={startDate}
           endDate={endDate}
           enterpriseId={enterpriseId}
+          groupUUID={groupUUID}
           enableCSVDownload
           tableColumns={[
             {
@@ -278,5 +280,6 @@ Engagements.propTypes = {
   enterpriseId: PropTypes.string.isRequired,
   granularity: PropTypes.string.isRequired,
   calculation: PropTypes.string.isRequired,
+  groupUUID: PropTypes.string.isRequired,
 };
 export default Engagements;

--- a/src/components/AdvanceAnalyticsV2/tabs/Enrollments.jsx
+++ b/src/components/AdvanceAnalyticsV2/tabs/Enrollments.jsx
@@ -14,7 +14,7 @@ import { modifyDataToIntroduceEnrollTypeCount, constructChartHoverTemplate } fro
 dayjs.extend(utc);
 
 const Enrollments = ({
-  startDate, endDate, granularity, calculation, enterpriseId,
+  startDate, endDate, granularity, calculation, enterpriseId, groupUUID,
 }) => {
   const intl = useIntl();
   const {
@@ -25,6 +25,7 @@ const Enrollments = ({
     endDate,
     granularity,
     calculation,
+    groupUUID,
   });
   const enrollmentsOverTimeForCSV = useMemo(() => {
     const enrollmentsOverTime = modifyDataToIntroduceEnrollTypeCount(
@@ -215,6 +216,7 @@ const Enrollments = ({
           startDate={startDate}
           endDate={endDate}
           enterpriseId={enterpriseId}
+          groupUUID={groupUUID}
           enableCSVDownload
           tableColumns={[
             {
@@ -273,6 +275,7 @@ Enrollments.propTypes = {
   endDate: PropTypes.string.isRequired,
   granularity: PropTypes.string.isRequired,
   calculation: PropTypes.string.isRequired,
+  groupUUID: PropTypes.string.isRequired,
 };
 
 export default Enrollments;

--- a/src/components/learner-credit-management/data/hooks/useAllFlexEnterpriseGroups.js
+++ b/src/components/learner-credit-management/data/hooks/useAllFlexEnterpriseGroups.js
@@ -12,8 +12,7 @@ import { fetchPaginatedData } from '../../../../data/services/apiServiceUtils';
  */
 export const getAllFlexEnterpriseGroups = async ({ enterpriseId }) => {
   const { results } = await fetchPaginatedData(`${LmsApiService.enterpriseGroupListUrl}?enterprise_uuids=${enterpriseId}`);
-  const flexGroups = results.filter(result => result.groupType === 'flex');
-  return flexGroups;
+  return results.filter(result => result.groupType === 'flex');
 };
 
 const useAllFlexEnterpriseGroups = (enterpriseId, { queryOptions } = {}) => useQuery({


### PR DESCRIPTION
__Jira Ticket:__ [ENT-10130](https://2u-internal.atlassian.net/browse/ENT-10130)

__Description:__
Add a new single select drop down menu to display a list of groups for admin analytics, this will be enabled for enrollments, engagements and completions data only and will not have any affect on skills and leaderboard data. The list can be fetched from enterprise API endpoint [edx-enterprise/enterprise/api/v1/urls.py at master · openedx/edx-enterprise](https://github.com/openedx/edx-enterprise/blob/master/enterprise/api/v1/urls.py#L85) When a user make a selection then we need to pass in the selected group’s uuid via group_uuid named parameter in API calls to the backend.

# Screenshot
<img width="1512" alt="Screenshot 2025-05-05 at 12 09 34 PM" src="https://github.com/user-attachments/assets/35da2949-fa8f-4be4-ad9f-6a356ee95dee" />

