### PR TITLE
feat: display toast when non-org group members can't be invited

### DIFF
--- a/src/components/PeopleManagement/CreateGroupModal.tsx
+++ b/src/components/PeopleManagement/CreateGroupModal.tsx
@@ -17,12 +17,21 @@ import CreateGroupModalContent from './CreateGroupModalContent';
 import EVENT_NAMES from '../../eventTracking';
 import { learnerCreditManagementQueryKeys } from '../learner-credit-management/data';
 import { useValidatedEmailsContext } from './data/ValidatedEmailsContext';
+import { checkForInviteErrors, GroupErrorType } from './utils';
+
+export type CreateGroupModalProps = {
+  isModalOpen: boolean,
+  closeModal: () => void,
+  enterpriseUUID: string,
+  onInviteError: (errorType: GroupErrorType) => void
+};
 
 const CreateGroupModal = ({
   isModalOpen,
   closeModal,
   enterpriseUUID,
-}) => {
+  onInviteError,
+}: CreateGroupModalProps) => {
   const intl = useIntl();
   const {
     validatedEmails: learnerEmails,
@@ -34,6 +43,7 @@ const CreateGroupModal = ({
   const [groupName, setGroupName] = useState('');
   const [canCreateGroup, setCanCreateGroup] = useState(false);
   const [isSystemErrorModalOpen, openSystemErrorModal, closeSystemErrorModal] = useToggle(false);
+
   const handleCloseCreateGroupModal = () => {
     closeModal();
     setCreateButtonState('default');
@@ -88,7 +98,18 @@ const CreateGroupModal = ({
       const requestBody = snakeCaseObject({
         learnerEmails,
       });
-      await LmsApiService.inviteEnterpriseLearnersToGroup(groupCreationResponse.data.uuid, requestBody);
+      const { data: inviteResponse } = await LmsApiService.inviteEnterpriseLearnersToGroup(
+        groupCreationResponse.data.uuid,
+        requestBody,
+      );
+      const { hasErrors, errorType } = checkForInviteErrors(inviteResponse);
+      if (hasErrors) {
+        onInviteError(errorType);
+        sendEnterpriseTrackEvent(
+          enterpriseUUID,
+          EVENT_NAMES.PEOPLE_MANAGEMENT.ADD_LEARNER_ERROR_NOT_IN_ORG,
+        );
+      }
       queryClient.invalidateQueries({
         queryKey: learnerCreditManagementQueryKeys.group(enterpriseUUID),
       });

--- a/src/components/PeopleManagement/GroupDetailPage/GroupDetailPage.jsx
+++ b/src/components/PeopleManagement/GroupDetailPage/GroupDetailPage.jsx
@@ -19,6 +19,7 @@ import AddMembersModal from '../AddMembersModal/AddMembersModal';
 import { makePlural } from '../../../utils';
 import EVENT_NAMES from '../../../eventTracking';
 import ValidatedEmailsContextProvider from '../data/ValidatedEmailsContextProvider';
+import GroupInviteErrorToast from '../GroupInviteErrorToast';
 
 const GroupDetailPage = ({ enterpriseUUID }) => {
   const intl = useIntl();
@@ -29,6 +30,8 @@ const GroupDetailPage = ({ enterpriseUUID }) => {
   const [isLoading, setIsLoading] = useState(true);
   const [groupName, setGroupName] = useState(enterpriseGroup?.name);
   const [isAddMembersModalOpen, openAddMembersModal, closeAddMembersModal] = useToggle(false);
+  const [isGroupInviteErrorModalOpen, openGroupInviteErrorModal, closeGroupInviteErrorModal] = useToggle(false);
+  const [groupInviteError, setGroupInviteError] = useState('');
   const {
     isLoading: isTableLoading,
     enterpriseGroupLearnersTableData,
@@ -48,6 +51,11 @@ const GroupDetailPage = ({ enterpriseUUID }) => {
     }
   }, [enterpriseGroup]);
 
+  const handleInviteError = (errorType) => {
+    setGroupInviteError(errorType);
+    openGroupInviteErrorModal();
+  };
+
   const tooltipContent = (
     <FormattedMessage
       id="adminPortal.peopleManagement.groupDetail.deleteGroup.icon"
@@ -60,6 +68,11 @@ const GroupDetailPage = ({ enterpriseUUID }) => {
     <div className="pt-4 pl-4">
       {!isLoading ? (
         <>
+          <GroupInviteErrorToast
+            isOpen={isGroupInviteErrorModalOpen}
+            errorType={groupInviteError}
+            closeToast={closeGroupInviteErrorModal}
+          />
           <DeleteGroupModal
             group={enterpriseGroup}
             isOpen={isDeleteModalOpen}
@@ -175,6 +188,7 @@ const GroupDetailPage = ({ enterpriseUUID }) => {
           groupName={groupName}
           isModalOpen={isAddMembersModalOpen}
           closeModal={closeAddMembersModal}
+          onInviteError={handleInviteError}
         />
       </ValidatedEmailsContextProvider>
     </div>

--- a/src/components/PeopleManagement/GroupInviteErrorToast.tsx
+++ b/src/components/PeopleManagement/GroupInviteErrorToast.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { Toast } from '@openedx/paragon';
+import { ERROR_LEARNER_NOT_IN_ORG } from './constants';
+import { GroupErrorType } from './utils';
+
+type GroupErrorToastProps = {
+  isOpen: boolean,
+  errorType: GroupErrorType,
+  closeToast: () => void,
+};
+
+const GroupInviteErrorToast = ({ isOpen, errorType, closeToast }: GroupErrorToastProps) => {
+  const intl = useIntl();
+
+  const generateErrorText = () => {
+    let text = '';
+    if (errorType === ERROR_LEARNER_NOT_IN_ORG) {
+      text = 'Looks like some learners aren\'t linked to your organization. '
+        + 'Please make sure they are associated with a subsidy before adding them to a group.';
+    }
+    return intl.formatMessage({
+      id: 'admin.portal.people.management.group.error.toast',
+      defaultMessage: text,
+      description: 'Toast text indicating failure to add group members who are not part of the org.',
+    });
+  };
+
+  const toastText = generateErrorText();
+
+  return (
+    <Toast onClose={closeToast} show={isOpen}>{toastText}</Toast>
+  );
+};
+
+GroupInviteErrorToast.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  errorType: PropTypes.string.isRequired,
+  closeToast: PropTypes.func.isRequired,
+};
+
+export default GroupInviteErrorToast;

--- a/src/components/PeopleManagement/GroupInviteErrorToast.tsx
+++ b/src/components/PeopleManagement/GroupInviteErrorToast.tsx
@@ -30,7 +30,17 @@ const GroupInviteErrorToast = ({ isOpen, errorType, closeToast }: GroupErrorToas
   const toastText = generateErrorText();
 
   return (
-    <Toast onClose={closeToast} show={isOpen}>{toastText}</Toast>
+    <Toast
+      onClose={closeToast}
+      show={isOpen}
+      delay={10000}
+      action={{
+        label: 'Help',
+        href: 'https://enterprise-support.edx.org/s/article/Why-can-t-I-invite-certain-learners-to-a-group',
+      }}
+    >
+      {toastText}
+    </Toast>
   );
 };
 

--- a/src/components/PeopleManagement/constants.js
+++ b/src/components/PeopleManagement/constants.js
@@ -51,3 +51,5 @@ export const ASSIGNMENT_TYPES = {
   EXPIRING: 'expiring',
   REVERSED: 'reversed',
 };
+
+export const ERROR_LEARNER_NOT_IN_ORG = 'learner_not_in_org';

--- a/src/components/PeopleManagement/index.jsx
+++ b/src/components/PeopleManagement/index.jsx
@@ -19,6 +19,7 @@ import GroupCardGrid from './GroupCardGrid';
 import PeopleManagementTable from './PeopleManagementTable';
 import EVENT_NAMES from '../../eventTracking';
 import ValidatedEmailsContextProvider from './data/ValidatedEmailsContextProvider';
+import GroupInviteErrorToast from './GroupInviteErrorToast';
 
 const PeopleManagementPage = ({ enterpriseId }) => {
   const intl = useIntl();
@@ -34,6 +35,9 @@ const PeopleManagementPage = ({ enterpriseId }) => {
     defaultMessage: 'Group deleted',
     description: 'Toast text after a user has deleted a group.',
   });
+
+  const [isGroupInviteErrorModalOpen, openGroupInviteErrorModal, closeGroupInviteErrorModal] = useToggle(false);
+  const [groupInviteError, setGroupInviteError] = useState('');
 
   const { enterpriseSubsidyTypes } = useContext(EnterpriseSubsidiesContext);
   const { data, isLoading: isGroupsLoading } = useAllFlexEnterpriseGroups(enterpriseId);
@@ -76,6 +80,11 @@ const PeopleManagementPage = ({ enterpriseId }) => {
     }
   }
 
+  const handleInviteError = (errorType) => {
+    setGroupInviteError(errorType);
+    openGroupInviteErrorModal();
+  };
+
   const handleOnClickCreateGroup = () => {
     openModal();
     sendEnterpriseTrackEvent(
@@ -91,6 +100,11 @@ const PeopleManagementPage = ({ enterpriseId }) => {
       <Toast onClose={closeToast} show={isToastOpen}>
         {toastText}
       </Toast>
+      <GroupInviteErrorToast
+        isOpen={isGroupInviteErrorModalOpen}
+        errorType={groupInviteError}
+        closeToast={closeGroupInviteErrorModal}
+      />
       <div className="mx-3 mt-4">
         <ActionRow className="mb-4">
           <span className="flex-column">
@@ -131,6 +145,7 @@ const PeopleManagementPage = ({ enterpriseId }) => {
               isModalOpen={isModalOpen}
               openModel={openModal}
               closeModal={closeModal}
+              onInviteError={handleInviteError}
             />
           </ValidatedEmailsContextProvider>
         </ActionRow>

--- a/src/components/PeopleManagement/tests/CreateGroupModal.test.jsx
+++ b/src/components/PeopleManagement/tests/CreateGroupModal.test.jsx
@@ -367,7 +367,7 @@ describe('<CreateGroupModal />', () => {
     expect(screen.queryByText("Members can't be invited as entered.")).not.toBeInTheDocument();
     expect(screen.queryByText('iamnotanemail is not a valid email.')).not.toBeInTheDocument();
   });
-  it('shows error toast when invitees not part of org', async () => {
+  it('callback for error toast triggered when invitees not part of org', async () => {
     const mockGroupData = { uuid: 'test-uuid' };
     LmsApiService.createEnterpriseGroup.mockResolvedValue({ status: 201, data: mockGroupData });
 

--- a/src/components/PeopleManagement/tests/GroupInviteErrorToast.test.jsx
+++ b/src/components/PeopleManagement/tests/GroupInviteErrorToast.test.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { render, screen } from '@testing-library/react';
+
+import '@testing-library/jest-dom/extend-expect';
+
+import GroupInviteErrorToast from '../GroupInviteErrorToast';
+import { ERROR_LEARNER_NOT_IN_ORG } from '../constants';
+
+const DEFAULT_PROPS = {
+  isOpen: true,
+  errorType: ERROR_LEARNER_NOT_IN_ORG,
+  closeToast: jest.fn,
+};
+
+const GroupInviteErrorToastWrapper = props => (
+  <IntlProvider locale="en">
+    <GroupInviteErrorToast {...props} />
+  </IntlProvider>
+);
+
+describe('DownloadCSVButton', () => {
+  it('renders unlinked learner errors.', async () => {
+    render(<GroupInviteErrorToastWrapper {...DEFAULT_PROPS} />);
+    const expectedMsg = 'Looks like some learners aren’t linked to your organization. '
+      + 'Please make sure they are associated with a subsidy before adding them to a group.';
+
+    // Validate button text
+    expect(screen.getByText(expectedMsg)).toBeInTheDocument();
+  });
+});

--- a/src/components/PeopleManagement/tests/GroupInviteErrorToast.test.jsx
+++ b/src/components/PeopleManagement/tests/GroupInviteErrorToast.test.jsx
@@ -22,7 +22,7 @@ const GroupInviteErrorToastWrapper = props => (
 describe('DownloadCSVButton', () => {
   it('renders unlinked learner errors.', async () => {
     render(<GroupInviteErrorToastWrapper {...DEFAULT_PROPS} />);
-    const expectedMsg = 'Looks like some learners aren’t linked to your organization. '
+    const expectedMsg = 'Looks like some learners aren\'t linked to your organization. '
       + 'Please make sure they are associated with a subsidy before adding them to a group.';
 
     // Validate button text

--- a/src/components/PeopleManagement/utils.ts
+++ b/src/components/PeopleManagement/utils.ts
@@ -1,7 +1,8 @@
 import dayjs from 'dayjs';
 import { logError } from '@edx/frontend-platform/logging';
-import { ASSIGNMENT_TYPES, MAX_INITIAL_LEARNER_EMAILS_DISPLAYED_COUNT } from './constants';
+import { ASSIGNMENT_TYPES, ERROR_LEARNER_NOT_IN_ORG, MAX_INITIAL_LEARNER_EMAILS_DISPLAYED_COUNT } from './constants';
 import { ROUTE_NAMES } from '../EnterpriseApp/data/constants';
+import { GroupInviteSummary } from '../../data/services/LmsApiService';
 
 /**
  * Formats provided dates for display
@@ -223,4 +224,29 @@ export const isEmail = (email: string): boolean => {
     return false;
   }
   return !!email.match(/^[^\s@]+@[^\s@]+\.[^\s@]+$/);
+};
+
+export type GroupErrorType = typeof ERROR_LEARNER_NOT_IN_ORG | '';
+
+export type InviteErrorSummary = {
+  hasErrors: boolean,
+  errorType: GroupErrorType
+};
+
+/**
+ * Checks for error indicators in response from LmsApiService.inviteEnterpriseLearnersToGroup
+ *
+ * @param {GroupInviteSummary} inviteResponse - Response from LmsApiService.inviteEnterpriseLearnersToGroup
+ * @returns {InviteErrorSummary}
+ */
+export const checkForInviteErrors = (inviteResponse: GroupInviteSummary): InviteErrorSummary => {
+  let errorType: GroupErrorType = '';
+  if (inviteResponse?.non_org_rejected) {
+    // If any learners were not invited because they were not part of the org
+    errorType = ERROR_LEARNER_NOT_IN_ORG;
+  }
+  return {
+    errorType,
+    hasErrors: !!errorType,
+  };
 };

--- a/src/data/services/LmsApiService.ts
+++ b/src/data/services/LmsApiService.ts
@@ -22,10 +22,18 @@ export type EnterpriseGroupMembershipArgs = {
   enterpriseUuid: string,
 };
 
+export type GroupInviteSummary = {
+  records_processed: number,
+  new_learners: number,
+  existing_learners: number,
+  non_org_rejected: number,
+};
+
 export type EnterpriseGroupResponse = Promise<AxiosResponse<EnterpriseGroup>>;
 export type EnterpriseGroupListResponse = Promise<AxiosResponse<PaginatedCurrentPage<EnterpriseGroup>>>;
 export type EnterpriseLearnersListResponse = Promise<AxiosResponse<PaginatedCurrentPage<EnterpriseLearner>>>;
 export type EnterpriseGroupMembershipResponse = Promise<AxiosResponse<PaginatedCurrentPage<EnterpriseGroupMembership>>>;
+export type EnterpriseGroupInviteResponse = Promise<AxiosResponse<GroupInviteSummary>>;
 
 export type FetchEnterpriseLearnerDataArgs = { enterpriseCustomer?: string, userId?: string, username?: string };
 
@@ -526,7 +534,7 @@ class LmsApiService {
     return response;
   };
 
-  static inviteEnterpriseLearnersToGroup = async (groupUuid: string, formData) => {
+  static inviteEnterpriseLearnersToGroup = async (groupUuid: string, formData) : EnterpriseGroupInviteResponse => {
     const assignLearnerEndpoint = `${LmsApiService.enterpriseGroupListUrl}${groupUuid}/assign_learners/`;
     return LmsApiService.apiClient().post(assignLearnerEndpoint, formData);
   };

--- a/src/eventTracking.js
+++ b/src/eventTracking.js
@@ -32,6 +32,7 @@ const PEOPLE_MANAGEMENT_EVENTS = {
   GROUP_CREATE_WITH_UPLOAD_CSV: `${GROUPS_PEOPLE_MANAGEMENT_PREFIX}.create_group_modal.csv_upload`,
   GROUP_CREATE_WITH_LIST_SELECTION: `${GROUPS_PEOPLE_MANAGEMENT_PREFIX}.create_group_modal.list_selection`,
   GROUP_CREATE_WITH_CSV_AND_LIST: `${GROUPS_PEOPLE_MANAGEMENT_PREFIX}.create_group_modal.csv_upload_and_list_selection`,
+  ADD_LEARNER_ERROR_NOT_IN_ORG: `${GROUPS_PEOPLE_MANAGEMENT_PREFIX}.error.learner_not_in_org`,
 };
 // learner-progress-report
 const LEARNER_PROGRESS_REPORT_EVENTS = {


### PR DESCRIPTION
[Jira Ticket](https://2u-internal.atlassian.net/browse/ENT-10243)


https://github.com/user-attachments/assets/c7266bcc-c440-43d4-bfec-330b6e2769d5


This change adds an error toast after an attempt to invite non-org learners to a flex group fails on the backend.

## Testing Instructions
- In Admin Portal, create a new flex Group, populating via csv file that includes at least one learner email from outside the enterprise customer org
- Verify Toast appears with error message

## Testing Instructions

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
