### PR TITLE
fix: resolve erroneous start label by memoizing `now`

### DIFF
--- a/src/components/learner-credit-management/assignment-modal/NewAssignmentModalDropdown.jsx
+++ b/src/components/learner-credit-management/assignment-modal/NewAssignmentModalDropdown.jsx
@@ -2,7 +2,7 @@ import { defineMessages, useIntl } from '@edx/frontend-platform/i18n';
 import { Dropdown, Skeleton, Stack } from '@openedx/paragon';
 import dayjs from 'dayjs';
 import PropTypes from 'prop-types';
-import { useState } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import classNames from 'classnames';
 import { SHORT_MONTH_DATE_FORMAT } from '../data';
 
@@ -44,7 +44,8 @@ const NewAssignmentModalDropdown = ({
     }
     return true;
   };
-  const startLabel = ({ start }) => (dayjs(start).isBefore(dayjs()) ? 'Started' : 'Starts');
+  const now = useMemo(() => dayjs(), []);
+  const getStartLabel = useCallback((start) => (dayjs(start).isBefore(now) ? 'Started' : 'Starts'), [now]);
   return (
     <Dropdown
       onSelect={(eventKey, event) => {
@@ -77,7 +78,7 @@ const NewAssignmentModalDropdown = ({
             >
               <Stack>
                 {intl.formatMessage(messages.startDate, {
-                  startLabel: startLabel(courseRun),
+                  startLabel: getStartLabel(courseRun.start),
                   startDate: dayjs(courseRun.start).format(SHORT_MONTH_DATE_FORMAT),
                 })}
                 <span className={classNames('small', { 'text-muted': getDropdownItemClassName(courseRun) })}>


### PR DESCRIPTION
Ticket: https://2u-internal.atlassian.net/browse/ENT-10376

Memoizes `dayjs()` with `useMemo` and `getStartLabel` with `useCallback` to ensure its stable between re-renders to prevent "Starts" switching to "Started" on a re-render (e.g., on click) in button text, and vice versa.

See below for examples.

## Before

https://github.com/user-attachments/assets/cad20f22-ed58-4892-9426-d0ae88776063

## After

https://github.com/user-attachments/assets/c3924f5b-e9b4-47b0-883b-c790daa3599f

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
