### PR TITLE
feat: add empty state on activity tab for BnR budgets

### DIFF
--- a/src/components/InviteLearnersModal/inviteLearnerModal.test.jsx
+++ b/src/components/InviteLearnersModal/inviteLearnerModal.test.jsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+
+import InviteLearnersModal from './index';
+
+jest.mock('redux-form', () => ({
+  reduxForm: () => (Component) => {
+    const MockedComponent = (props) => (
+      <Component
+        handleSubmit={(fn) => fn}
+        submitting={false}
+        submitSucceeded={false}
+        submitFailed={false}
+        initialize={jest.fn()}
+        {...props}
+      />
+    );
+    return MockedComponent;
+  },
+  Field: function MockedField({ component: Component, ...props }) {
+    return <Component {...props} input={{}} meta={{}} />;
+  },
+  SubmissionError: class SubmissionError extends Error {
+    constructor(errors) {
+      super();
+      this.errors = errors;
+    }
+  },
+}));
+
+jest.mock('../../data/validation/email', () => ({
+  extractSalesforceIds: jest.fn(),
+  returnValidatedEmails: jest.fn(() => ['test@example.com']),
+  validateEmailAddrTemplateForm: jest.fn(),
+}));
+
+jest.mock('../../utils', () => ({
+  normalizeFileUpload: jest.fn(),
+}));
+
+jest.mock('@edx/frontend-platform/utils', () => ({
+  camelCaseObject: jest.fn((obj) => obj),
+}));
+
+jest.mock('./emailTemplate', () => ({
+  __esModule: true,
+  default: {
+    greeting: 'Test Greeting',
+    body: 'Test Body',
+    closing: jest.fn(() => 'Test Closing'),
+  },
+}));
+
+const defaultProps = {
+  handleSubmit: jest.fn((fn) => fn),
+  submitting: false,
+  submitSucceeded: false,
+  submitFailed: false,
+  error: null,
+  initialize: jest.fn(),
+
+  onClose: jest.fn(),
+  onSuccess: jest.fn(),
+  addLicensesForUsers: jest.fn(() => Promise.resolve({ data: {} })),
+  subscriptionUUID: 'test-subscription-uuid',
+  availableSubscriptionCount: 10,
+  contactEmail: 'test@example.com',
+};
+
+const InviteLearnersModalWrapper = (props = {}) => (
+  <IntlProvider locale="en">
+    <InviteLearnersModal {...defaultProps} {...props} />
+  </IntlProvider>
+);
+
+describe('InviteLearnersModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders without crashing and displays key elements', () => {
+    render(<InviteLearnersModalWrapper />);
+
+    expect(screen.getByRole('heading', { name: 'Invite learners' })).toBeInTheDocument();
+
+    expect(screen.getByText(/Unassigned licenses: 10/)).toBeInTheDocument();
+
+    expect(screen.getByTestId('add-user-heading')).toBeInTheDocument();
+    expect(screen.getByTestId('add-user-heading')).toHaveTextContent('Add Users');
+
+    expect(screen.getByText('Email Address')).toBeInTheDocument();
+    expect(screen.getByText('Upload Email Addresses')).toBeInTheDocument();
+    expect(screen.getByText('Email Template')).toBeInTheDocument();
+    expect(screen.getByText('Customize Greeting')).toBeInTheDocument();
+    expect(screen.getByText('Body')).toBeInTheDocument();
+    expect(screen.getByText('Customize Closing')).toBeInTheDocument();
+
+    // Check buttons
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /invite learners/i })).toBeInTheDocument();
+  });
+
+  it('renders error message when submitFailed is true and error exists', () => {
+    const errorProps = {
+      submitFailed: true,
+      error: ['Test error message'],
+    };
+
+    render(<InviteLearnersModalWrapper {...errorProps} />);
+
+    expect(screen.getByText('Unable to subscribe users')).toBeInTheDocument();
+    expect(screen.getByText('Test error message')).toBeInTheDocument();
+  });
+
+  it('renders multiple error messages as a list', () => {
+    const errorProps = {
+      submitFailed: true,
+      error: ['First error', 'Second error'],
+    };
+
+    render(<InviteLearnersModalWrapper {...errorProps} />);
+
+    expect(screen.getByText('Unable to subscribe users')).toBeInTheDocument();
+    expect(screen.getByText('First error')).toBeInTheDocument();
+    expect(screen.getByText('Second error')).toBeInTheDocument();
+  });
+
+  it('shows spinner when submitting', () => {
+    const submittingProps = {
+      submitting: true,
+    };
+
+    render(<InviteLearnersModalWrapper {...submittingProps} />);
+
+    // Check that spinner is present (it has a specific className)
+    const button = screen.getByRole('button', { name: /invite learners/i });
+    expect(button).toBeDisabled();
+  });
+
+  it('initializes with default email template values', () => {
+    const initializeMock = jest.fn();
+    const initProps = {
+      initialize: initializeMock,
+    };
+
+    render(<InviteLearnersModalWrapper {...initProps} />);
+
+    expect(initializeMock).toHaveBeenCalledWith({
+      'email-template-greeting': 'Test Greeting',
+      'email-template-body': 'Test Body',
+      'email-template-closing': 'Test Closing',
+    });
+  });
+
+  it('calls onClose when modal should close', () => {
+    const onCloseMock = jest.fn();
+    const successProps = {
+      onClose: onCloseMock,
+      submitSucceeded: true,
+    };
+
+    // Render with submitSucceeded false first
+    const { rerender } = render(<InviteLearnersModalWrapper onClose={onCloseMock} />);
+
+    // Then rerender with submitSucceeded true to trigger componentDidUpdate
+    rerender(<InviteLearnersModalWrapper {...successProps} />);
+
+    expect(onCloseMock).toHaveBeenCalled();
+  });
+});

--- a/src/components/learner-credit-management/BudgetDetailActivityTabContents.jsx
+++ b/src/components/learner-credit-management/BudgetDetailActivityTabContents.jsx
@@ -10,6 +10,7 @@ import { BudgetDetailPageContext } from './BudgetDetailPageWrapper';
 import { useBudgetDetailActivityOverview, useBudgetId, useSubsidyAccessPolicy } from './data';
 import NoAssignableBudgetActivity from './empty-state/NoAssignableBudgetActivity';
 import NoBnEBudgetActivity from './empty-state/NoBnEBudgetActivity';
+import NoBnRBudgetActivity from './empty-state/NoBnRBudgetActivity';
 
 const BudgetDetailActivityTabContents = ({ enterpriseUUID, enterpriseFeatures, appliesToAllContexts }) => {
   const isTopDownAssignmentEnabled = enterpriseFeatures.topDownAssignmentRealTimeLcm;
@@ -42,6 +43,14 @@ const BudgetDetailActivityTabContents = ({ enterpriseUUID, enterpriseFeatures, a
 
   // If enterprise groups is turned on, it's learner credit NOT enterprise offers w/ no spend
   const renderBnEActivity = isEnterpriseGroupsEnabled && (enterpriseOfferId == null) && !hasSpentTransactions;
+
+  const hasApprovedBnrRequests = budgetActivityOverview.approvedBnrRequests?.count > 0;
+
+  if (subsidyAccessPolicy?.bnrEnabled && !hasApprovedBnrRequests && !hasSpentTransactions) {
+    // If we don't have a request in approved state and there are no spent transactions,
+    // that means requests table and spent table both are empty.
+    return <NoBnRBudgetActivity />;
+  }
 
   if (!isTopDownAssignmentEnabled || !subsidyAccessPolicy?.isAssignable) {
     if (isEnterpriseGroupsEnabled) {

--- a/src/components/learner-credit-management/BudgetDetailPageOverviewAvailability.jsx
+++ b/src/components/learner-credit-management/BudgetDetailPageOverviewAvailability.jsx
@@ -54,6 +54,7 @@ const BudgetActions = ({
   });
 
   const enterpriseHasActiveBudget = budgets?.length > 0;
+  const isBnREnabled = subsidyAccessPolicy?.bnrEnabled;
 
   const trackEventMetadata = {};
   if (subsidyAccessPolicy) {
@@ -182,6 +183,38 @@ const BudgetActions = ({
               description="Contact support button on retired budget detail page overview"
             />
           </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (isBnREnabled) {
+    return (
+      <div className="h-100 d-flex align-items-center pt-4 pt-lg-0">
+        <div>
+          <h3>
+            <FormattedMessage
+              id="lcm.budget.detail.page.overview.budget.actions.manage.edx.for.organization"
+              defaultMessage="Manage edX for your organization"
+              description="Title for the budget actions section on the budget detail page overview"
+            />
+          </h3>
+          <p>
+            <FormattedMessage
+              id="lcm.budget.detail.page.overview.budget.actions.all.people.browse.and.request"
+              defaultMessage="All people in your organization can browse the catalog and make requests to enroll."
+              description="Description which tells that user can browse the catalog and request to enroll"
+            />
+          </p>
+          <Link to={`/${enterpriseSlug}/admin/settings/access`}>
+            <Button variant="outline-primary">
+              <FormattedMessage
+                id="lcm.budget.detail.page.overview.budget.actions.configure.access.general"
+                defaultMessage="Configure access"
+                description="Configure access button on the budget detail page overview"
+              />
+            </Button>
+          </Link>
         </div>
       </div>
     );

--- a/src/components/learner-credit-management/BudgetOverviewContent.jsx
+++ b/src/components/learner-credit-management/BudgetOverviewContent.jsx
@@ -76,6 +76,7 @@ const BudgetOverviewContent = ({
           badgeVariant={badgeVariant}
           status={status}
           isAssignable={isAssignable}
+          isBnREnabled={subsidyAccessPolicy?.bnrEnabled}
           term={term}
           date={date}
           policy={subsidyAccessPolicy}

--- a/src/components/learner-credit-management/BudgetStatusSubtitle.jsx
+++ b/src/components/learner-credit-management/BudgetStatusSubtitle.jsx
@@ -13,7 +13,7 @@ import {
 } from './data';
 
 const BudgetStatusSubtitle = ({
-  badgeVariant, status, isAssignable, term, date, policy, enterpriseUUID, isRetired,
+  badgeVariant, status, isAssignable, term, date, policy, enterpriseUUID, isRetired, isBnREnabled,
 }) => {
   const { data: enterpriseGroup } = useEnterpriseGroup(policy);
   const customGroup = !isEmpty(policy?.groupAssociations) && !enterpriseGroup?.appliesToAllContexts;
@@ -73,6 +73,21 @@ const BudgetStatusSubtitle = ({
       }),
       icon: <Icon size="xs" src={Groups} className="ml-1 d-inline-flex" svgAttrs={{ transform: 'translate(0,2)' }} />,
     },
+    browseAndRequest: {
+      enrollmentType:
+      intl.formatMessage({
+        id: 'lcm.budget.detail.page.overview.enroll.browse.and.request',
+        defaultMessage: 'Browse & Request',
+        description: 'Enrollment type for browse and request budgets',
+      }),
+      popoverText:
+      intl.formatMessage({
+        id: 'lcm.budget.detail.page.overview.enroll.browse.and.request.popover',
+        defaultMessage: 'Available to all people in your organization',
+        description: 'Popover text for for browse and request budgets',
+      }),
+      icon: <Icon size="xs" src={Groups} className="ml-1 d-inline-flex" svgAttrs={{ transform: 'translate(0,2)' }} />,
+    },
   };
   let budgetTypeToRender;
 
@@ -80,6 +95,8 @@ const BudgetStatusSubtitle = ({
     budgetTypeToRender = budgetType.lms;
   } else if (customGroup) {
     budgetTypeToRender = budgetType.groupsBrowseAndEnroll;
+  } else if (isBnREnabled) {
+    budgetTypeToRender = budgetType.browseAndRequest;
   } else if (isAssignable) {
     budgetTypeToRender = budgetType.assignable;
   } else {
@@ -125,6 +142,7 @@ BudgetStatusSubtitle.propTypes = {
   badgeVariant: PropTypes.string.isRequired,
   status: PropTypes.string.isRequired,
   isAssignable: PropTypes.bool.isRequired,
+  isBnREnabled: PropTypes.bool,
   term: PropTypes.string,
   date: PropTypes.string,
   policy: PropTypes.shape({
@@ -132,6 +150,10 @@ BudgetStatusSubtitle.propTypes = {
   }),
   enterpriseUUID: PropTypes.string.isRequired,
   isRetired: PropTypes.bool.isRequired,
+};
+
+BudgetStatusSubtitle.defaultProps = {
+  isBnREnabled: false,
 };
 
 export default BudgetStatusSubtitle;

--- a/src/components/learner-credit-management/data/constants.js
+++ b/src/components/learner-credit-management/data/constants.js
@@ -142,3 +142,5 @@ export const LEARNER_CREDIT_ROUTE = '/:enterpriseSlug/admin/:enterpriseAppPage/:
 // The `restriction_type` metadata key for course runs may have this value,
 // indicating that the run is restricted.
 export const ENTERPRISE_RESTRICTION_TYPE = 'custom-b2b-enterprise';
+
+export const APPROVED_REQUEST_TYPE = 'approved';

--- a/src/components/learner-credit-management/empty-state/NoBnRBudgetActivity.jsx
+++ b/src/components/learner-credit-management/empty-state/NoBnRBudgetActivity.jsx
@@ -6,24 +6,50 @@ import {
 } from '@openedx/paragon';
 import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import {
   useIsLargeOrGreater,
 } from '../data';
 import findCourse from '../assets/reading.svg';
 import inviteLearners from '../assets/phoneScroll.svg';
 import approveRequest from '../assets/wallet.svg';
+import messages from './messages';
 
-const FindCourseIllustration = (props) => (
-  <img data-testid="find-course-illustration" src={findCourse} alt="" {...props} />
-);
+const FindCourseIllustration = (props) => {
+  const intl = useIntl();
+  return (
+    <img
+      data-testid="find-course-illustration"
+      src={findCourse}
+      alt={intl.formatMessage(messages.findCourseIllustrationAlt)}
+      {...props}
+    />
+  );
+};
 
-const InviteLearnerIllustration = (props) => (
-  <img data-testid="invite-learner-illustration" src={inviteLearners} alt="" {...props} />
-);
+const InviteLearnerIllustration = (props) => {
+  const intl = useIntl();
+  return (
+    <img
+      data-testid="invite-learner-illustration"
+      src={inviteLearners}
+      alt={intl.formatMessage(messages.inviteLearnerIllustrationAlt)}
+      {...props}
+    />
+  );
+};
 
-const ApproveRequestIllustration = (props) => (
-  <img data-testid="approve-request-illustration" src={approveRequest} alt="" {...props} />
-);
+const ApproveRequestIllustration = (props) => {
+  const intl = useIntl();
+  return (
+    <img
+      data-testid="approve-request-illustration"
+      src={approveRequest}
+      alt={intl.formatMessage(messages.approveRequestIllustrationAlt)}
+      {...props}
+    />
+  );
+};
 
 const NoBnRBudgetActivity = ({ enterpriseSlug }) => {
   const isLargeOrGreater = useIsLargeOrGreater();
@@ -32,7 +58,9 @@ const NoBnRBudgetActivity = ({ enterpriseSlug }) => {
     <Card className="mb-4">
       <Card.Section className={classNames('text-center', { 'bg-light-300': isLargeOrGreater })}>
         <h3 className={classNames({ 'mb-4.5': isLargeOrGreater })}>
-          No budget activity yet? Invite learners to browse the catalog and request content!
+          <FormattedMessage
+            {...messages.noBudgetActivityTitle}
+          />
         </h3>
         {isLargeOrGreater && (
           <Row>
@@ -53,34 +81,55 @@ const NoBnRBudgetActivity = ({ enterpriseSlug }) => {
           <Col className="mb-5 mb-lg-0">
             {!isLargeOrGreater && <InviteLearnerIllustration className="mb-5" />}
             <h4>
-              <span className="d-block text-brand mb-2">01</span>
-              Invite learners
+              <span className="d-block text-brand mb-2">
+                <FormattedMessage
+                  {...messages.stepOne}
+                />
+              </span>
+              <FormattedMessage
+                {...messages.inviteLearners}
+              />
             </h4>
             <span>
-              Use the Settings tab in this budget to select the authentication
-              method that will allow learners to access the catalog.
+              <FormattedMessage
+                {...messages.inviteLearnersDescription}
+              />
             </span>
           </Col>
           <Col className="mb-5 mb-lg-0">
             {!isLargeOrGreater && <FindCourseIllustration className="mb-5" />}
             <h4>
-              <span className="d-block text-brand mb-2">02</span>
-              Learners find the right course
+              <span className="d-block text-brand mb-2">
+                <FormattedMessage
+                  {...messages.stepTwo}
+                />
+              </span>
+              <FormattedMessage
+                {...messages.learnersFind}
+              />
             </h4>
             <span>
-              Learners can then browse the catalog associated with this budget
-              and request a course that aligns with their interests.
+              <FormattedMessage
+                {...messages.learnersFindDescription}
+              />
             </span>
           </Col>
           <Col className="mb-5 mb-lg-0">
             {!isLargeOrGreater && <ApproveRequestIllustration className="mb-5" />}
             <h4>
-              <span className="d-block text-brand mb-2">03</span>
-              Approve requests
+              <span className="d-block text-brand mb-2">
+                <FormattedMessage
+                  {...messages.stepThree}
+                />
+              </span>
+              <FormattedMessage
+                {...messages.approveRequests}
+              />
             </h4>
             <span>
-              Once approved, the total cost of the requested course will be deducted
-              from your budget, and you can track your spending right here!
+              <FormattedMessage
+                {...messages.approveRequestsDescription}
+              />
             </span>
           </Col>
         </Row>
@@ -90,7 +139,9 @@ const NoBnRBudgetActivity = ({ enterpriseSlug }) => {
               as={Link}
               to={`/${enterpriseSlug}/admin/settings/access`}
             >
-              Get started
+              <FormattedMessage
+                {...messages.getStarted}
+              />
             </Button>
           </Col>
         </Row>

--- a/src/components/learner-credit-management/empty-state/NoBnRBudgetActivity.jsx
+++ b/src/components/learner-credit-management/empty-state/NoBnRBudgetActivity.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import {
+  Button, Card, Col, Row,
+} from '@openedx/paragon';
+import { Link } from 'react-router-dom';
+import { connect } from 'react-redux';
+import {
+  useIsLargeOrGreater,
+} from '../data';
+import findCourse from '../assets/reading.svg';
+import inviteLearners from '../assets/phoneScroll.svg';
+import approveRequest from '../assets/wallet.svg';
+
+const FindCourseIllustration = (props) => (
+  <img data-testid="find-course-illustration" src={findCourse} alt="" {...props} />
+);
+
+const InviteLearnerIllustration = (props) => (
+  <img data-testid="invite-learner-illustration" src={inviteLearners} alt="" {...props} />
+);
+
+const ApproveRequestIllustration = (props) => (
+  <img data-testid="approve-request-illustration" src={approveRequest} alt="" {...props} />
+);
+
+const NoBnRBudgetActivity = ({ enterpriseSlug }) => {
+  const isLargeOrGreater = useIsLargeOrGreater();
+
+  return (
+    <Card className="mb-4">
+      <Card.Section className={classNames('text-center', { 'bg-light-300': isLargeOrGreater })}>
+        <h3 className={classNames({ 'mb-4.5': isLargeOrGreater })}>
+          No budget activity yet? Invite learners to browse the catalog and request content!
+        </h3>
+        {isLargeOrGreater && (
+          <Row>
+            <Col>
+              <InviteLearnerIllustration />
+            </Col>
+            <Col>
+              <FindCourseIllustration />
+            </Col>
+            <Col>
+              <ApproveRequestIllustration />
+            </Col>
+          </Row>
+        )}
+      </Card.Section>
+      <Card.Section className="text-center">
+        <Row className={classNames({ 'mb-5': isLargeOrGreater })}>
+          <Col className="mb-5 mb-lg-0">
+            {!isLargeOrGreater && <InviteLearnerIllustration className="mb-5" />}
+            <h4>
+              <span className="d-block text-brand mb-2">01</span>
+              Invite learners
+            </h4>
+            <span>
+              Use the Settings tab in this budget to select the authentication
+              method that will allow learners to access the catalog.
+            </span>
+          </Col>
+          <Col className="mb-5 mb-lg-0">
+            {!isLargeOrGreater && <FindCourseIllustration className="mb-5" />}
+            <h4>
+              <span className="d-block text-brand mb-2">02</span>
+              Learners find the right course
+            </h4>
+            <span>
+              Learners can then browse the catalog associated with this budget
+              and request a course that aligns with their interests.
+            </span>
+          </Col>
+          <Col className="mb-5 mb-lg-0">
+            {!isLargeOrGreater && <ApproveRequestIllustration className="mb-5" />}
+            <h4>
+              <span className="d-block text-brand mb-2">03</span>
+              Approve requests
+            </h4>
+            <span>
+              Once approved, the total cost of the requested course will be deducted
+              from your budget, and you can track your spending right here!
+            </span>
+          </Col>
+        </Row>
+        <Row>
+          <Col>
+            <Button
+              as={Link}
+              to={`/${enterpriseSlug}/admin/settings/access`}
+            >
+              Get started
+            </Button>
+          </Col>
+        </Row>
+      </Card.Section>
+    </Card>
+  );
+};
+
+NoBnRBudgetActivity.propTypes = {
+  enterpriseSlug: PropTypes.string.isRequired,
+};
+
+const mapStateToProps = state => ({
+  enterpriseSlug: state.portalConfiguration.enterpriseSlug,
+});
+
+export default connect(mapStateToProps)(NoBnRBudgetActivity);

--- a/src/components/learner-credit-management/empty-state/messages.js
+++ b/src/components/learner-credit-management/empty-state/messages.js
@@ -1,0 +1,76 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  noBudgetActivityTitle: {
+    id: 'learner.credit.management.empty.state.no.budget.activity.title',
+    defaultMessage: 'No budget activity yet? Invite learners to browse the catalog and request content!',
+    description: 'Title for the no budget activity empty state',
+  },
+  inviteLearners: {
+    id: 'learner.credit.management.empty.state.invite.learners',
+    defaultMessage: 'Invite learners',
+    description: 'Title for the invite learners section',
+  },
+  stepOne: {
+    id: 'learner.credit.management.empty.state.step.one',
+    defaultMessage: '01',
+    description: 'Step number for invite learners',
+  },
+  inviteLearnersDescription: {
+    id: 'learner.credit.management.empty.state.invite.learners.description',
+    defaultMessage: 'Use the Settings tab in this budget to select the authentication method that will allow learners to access the catalog.',
+    description: 'Description for the invite learners section',
+  },
+  learnersFind: {
+    id: 'learner.credit.management.empty.state.learners.find',
+    defaultMessage: 'Learners find the right course',
+    description: 'Title for the learners find section',
+  },
+  stepTwo: {
+    id: 'learner.credit.management.empty.state.step.two',
+    defaultMessage: '02',
+    description: 'Step number for learners find course',
+  },
+  learnersFindDescription: {
+    id: 'learner.credit.management.empty.state.learners.find.description',
+    defaultMessage: 'Learners can then browse the catalog associated with this budget and request a course that aligns with their interests.',
+    description: 'Description for the learners find section',
+  },
+  approveRequests: {
+    id: 'learner.credit.management.empty.state.approve.requests',
+    defaultMessage: 'Approve requests',
+    description: 'Title for the approve requests section',
+  },
+  stepThree: {
+    id: 'learner.credit.management.empty.state.step.three',
+    defaultMessage: '03',
+    description: 'Step number for approve requests',
+  },
+  approveRequestsDescription: {
+    id: 'learner.credit.management.empty.state.approve.requests.description',
+    defaultMessage: 'Once approved, the total cost of the requested course will be deducted from your budget, and you can track your spending right here!',
+    description: 'Description for the approve requests section',
+  },
+  getStarted: {
+    id: 'learner.credit.management.empty.state.get.started',
+    defaultMessage: 'Get started',
+    description: 'Button text to get started with the process',
+  },
+  findCourseIllustrationAlt: {
+    id: 'learner.credit.management.empty.state.find.course.illustration.alt',
+    defaultMessage: 'Find course illustration',
+    description: 'Alt text for find course illustration',
+  },
+  inviteLearnerIllustrationAlt: {
+    id: 'learner.credit.management.empty.state.invite.learner.illustration.alt',
+    defaultMessage: 'Invite learner illustration',
+    description: 'Alt text for invite learner illustration',
+  },
+  approveRequestIllustrationAlt: {
+    id: 'learner.credit.management.empty.state.approve.request.illustration.alt',
+    defaultMessage: 'Approve request illustration',
+    description: 'Alt text for approve request illustration',
+  },
+});
+
+export default messages;

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -2686,4 +2686,63 @@ describe('<BudgetDetailPage />', () => {
       'Failure to enroll by the enrollment deadline will release funds back into the budget',
     )).toBeTruthy());
   });
+
+  it('renders Browse & Request budget type when bnrEnabled is true', () => {
+    useParams.mockReturnValue({
+      enterpriseSlug: 'test-enterprise-slug',
+      enterpriseAppPage: 'test-enterprise-page',
+      budgetId: 'a52e6548-649f-4576-b73f-c5c2bee25e9c',
+      activeTabKey: 'activity',
+    });
+
+    useSubsidyAccessPolicy.mockReturnValue({
+      isInitialLoading: false,
+      data: {
+        ...mockAssignableSubsidyAccessPolicy,
+        bnrEnabled: true,
+        isAssignable: false,
+      },
+    });
+
+    useEnterpriseCustomer.mockReturnValue({
+      data: {
+        uuid: 'test-customer-uuid',
+        activeIntegrations: [],
+      },
+    });
+
+    useEnterpriseGroup.mockReturnValue({
+      data: {
+        appliesToAllContexts: true,
+        enterpriseCustomer: 'test-customer-uuid',
+        name: 'test-name',
+        uuid: 'test-uuid',
+      },
+    });
+
+    useEnterpriseGroupLearners.mockReturnValue({
+      data: {
+        count: 0,
+        currentPage: 1,
+        next: null,
+        numPages: 1,
+        results: [],
+      },
+    });
+
+    useBudgetDetailActivityOverview.mockReturnValue({
+      isLoading: false,
+      data: mockEmptyStateBudgetDetailActivityOverview,
+    });
+
+    useBudgetRedemptions.mockReturnValue({
+      isLoading: false,
+      budgetRedemptions: mockEmptyBudgetRedemptions,
+      fetchBudgetRedemptions: jest.fn(),
+    });
+
+    renderWithRouter(<BudgetDetailPageWrapper />);
+
+    expect(screen.getByText('Browse & Request', { exact: false })).toBeInTheDocument();
+  });
 });

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -706,6 +706,60 @@ describe('<BudgetDetailPage />', () => {
     expect(screen.getByText('Get started', { selector: 'a' })).toBeInTheDocument();
   });
 
+  it.each([
+    { isLargeViewport: true },
+    { isLargeViewport: false },
+  ])('displays learner credit bnr budget activity overview empty state', async ({ isLargeViewport }) => {
+    useIsLargeOrGreater.mockReturnValue(isLargeViewport);
+    useParams.mockReturnValue({
+      enterpriseSlug: 'test-enterprise-slug',
+      enterpriseAppPage: 'test-enterprise-page',
+      budgetId: 'a52e6548-649f-4576-b73f-c5c2bee25e9d',
+      activeTabKey: 'activity',
+    });
+    useSubsidyAccessPolicy.mockReturnValue({
+      isInitialLoading: false,
+      data: {
+        ...mockPerLearnerSpendLimitSubsidyAccessPolicy,
+        bnrEnabled: true,
+      },
+    });
+    useEnterpriseGroupLearners.mockReturnValue({
+      data: {
+        count: 0,
+        currentPage: 1,
+        next: null,
+        numPages: 1,
+        results: [],
+      },
+    });
+    useEnterpriseGroup.mockReturnValue({
+      data: {
+        appliesToAllContexts: false,
+      },
+    });
+    useBudgetDetailActivityOverview.mockReturnValue({
+      isLoading: false,
+      data: mockEmptyStateBudgetDetailActivityOverview,
+    });
+    useBudgetRedemptions.mockReturnValue({
+      isLoading: false,
+      budgetRedemptions: mockEmptyBudgetRedemptions,
+      fetchBudgetRedemptions: jest.fn(),
+    });
+    useEnterpriseRemovedGroupMembers.mockReturnValue({
+      isRemovedMembersLoading: false,
+      removedGroupMembersCount: 0,
+    });
+    renderWithRouter(<BudgetDetailPageWrapper />);
+
+    // Overview empty state (no content assignments)
+    expect(screen.getByText('No budget activity yet? Invite learners to browse the catalog and request content!')).toBeInTheDocument();
+    const illustrationTestIds = ['find-course-illustration', 'invite-learner-illustration', 'approve-request-illustration'];
+    illustrationTestIds.forEach(testId => expect(screen.getByTestId(testId)).toBeInTheDocument());
+    expect(screen.getByText('Get started', { selector: 'a' })).toBeInTheDocument();
+  });
+
   it('still render bne zero state if there are members but no spend', async () => {
     useParams.mockReturnValue({
       enterpriseSlug: 'test-enterprise-slug',


### PR DESCRIPTION
**Ticket:** [ENT-10295](https://2u-internal.atlassian.net/jira/software/c/projects/ENT/boards/868?selectedIssue=ENT-10295)
**Description:** Added an empty state for BnR enabled learner credit budgets. The empty state is dependent on `bnrEnabled` flag on `SubsidyAccessPolicy`, `hasApprovedBnrRequests`, and `hasSpentTransactions` variable.

Other than that,
- I've changed the top left subtitle to `Browse & Request`.
- I've also added the `configure access` button and the relevant text to match the design.

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [x] Ensure to have UX team confirm screenshots

<img width="1610" alt="image" src="https://github.com/user-attachments/assets/5f7ad38f-e9b9-4476-8238-147576fae443" />

<img width="1610" alt="image" src="https://github.com/user-attachments/assets/76f68278-4c39-4e42-b75d-21c443624bba" />
