### PR TITLE
fix: unskip a few tests, update redux-mock-store imports

### DIFF
--- a/src/components/Admin/AIAnalyticsSummary.test.jsx
+++ b/src/components/Admin/AIAnalyticsSummary.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { MemoryRouter } from 'react-router-dom';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import thunk from 'redux-thunk';

--- a/src/components/Admin/Admin.test.jsx
+++ b/src/components/Admin/Admin.test.jsx
@@ -4,7 +4,7 @@ import renderer from 'react-test-renderer';
 import { render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/Admin/SubscriptionDetails.test.jsx
+++ b/src/components/Admin/SubscriptionDetails.test.jsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import userEvent from '@testing-library/user-event';
 import { SubscriptionDetailContext } from '../subscriptions/SubscriptionDetailContextProvider';
 import SubscriptionDetails from './SubscriptionDetails';

--- a/src/components/Admin/licenses/LicenseAllocationHeader.test.jsx
+++ b/src/components/Admin/licenses/LicenseAllocationHeader.test.jsx
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 import renderer from 'react-test-renderer';
 import { MemoryRouter } from 'react-router-dom';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import LicenseAllocationHeader from './LicenseAllocationHeader';
 import { SubscriptionDetailContext } from '../../subscriptions/SubscriptionDetailContextProvider';
 import { SubsidyRequestsContext } from '../../subsidy-requests';

--- a/src/components/Admin/licenses/LicenseManagementTable/index.test.jsx
+++ b/src/components/Admin/licenses/LicenseManagementTable/index.test.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { render, screen } from '@testing-library/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/extend-expect';
+
 import {
   MockSubscriptionContext,
   generateSubscriptionPlan,
@@ -72,11 +74,12 @@ const usersSetup = (
   ]);
   return refreshFunctions;
 };
-// TODO: Fix
-describe.skip('<LicenseManagementTable />', () => {
+
+describe('<LicenseManagementTable />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
+
   it('renders the license management table', async () => {
     const user = userEvent.setup();
     usersSetup();
@@ -84,7 +87,12 @@ describe.skip('<LicenseManagementTable />', () => {
 
     // Revoke a license
     await user.click(screen.getByRole('button', { name: 'Revoke license' })); // Click on the revoke license button
-    await user.click(screen.getByRole('button', { name: 'Revoke License' })); // Confirm license revocation
+
+    const revokeModal = await screen.findByRole('dialog');
+    expect(revokeModal).toBeInTheDocument();
+    const revokeConfirmButton = screen.getByRole('button', { name: 'Revoke (1)' });
+    expect(revokeConfirmButton).toBeInTheDocument();
+    await user.click(revokeConfirmButton); // Confirm license revocation
 
     // Check Pagination
     await user.click(screen.getByRole('button', { name: 'Next, Page 2' }));

--- a/src/components/AdvanceAnalyticsV2/tests/AnalyticsV2Page.test.jsx
+++ b/src/components/AdvanceAnalyticsV2/tests/AnalyticsV2Page.test.jsx
@@ -4,7 +4,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import '@testing-library/jest-dom/extend-expect';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { Provider } from 'react-redux';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { BrowserRouter as Router } from 'react-router-dom';
 import AnalyticsV2Page from '../AnalyticsV2Page';

--- a/src/components/BudgetExpiryAlertAndModal/data/index.test.jsx
+++ b/src/components/BudgetExpiryAlertAndModal/data/index.test.jsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import { renderWithRouter } from '@edx/frontend-enterprise-utils';

--- a/src/components/BulkEnrollmentPage/CourseSearchResults.test.jsx
+++ b/src/components/BulkEnrollmentPage/CourseSearchResults.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import userEvent from '@testing-library/user-event';
 import thunk from 'redux-thunk';
 import {

--- a/src/components/BulkEnrollmentPage/stepper/AddCoursesStep.test.tsx
+++ b/src/components/BulkEnrollmentPage/stepper/AddCoursesStep.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import React, { useMemo } from 'react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { Provider } from 'react-redux';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import algoliasearch from 'algoliasearch/lite';
 import userEvent from '@testing-library/user-event';

--- a/src/components/BulkEnrollmentPage/stepper/ReviewStepCourseList.test.tsx
+++ b/src/components/BulkEnrollmentPage/stepper/ReviewStepCourseList.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { screen, render, renderHook } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import algoliasearch from 'algoliasearch/lite';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/CodeAssignmentModal/CodeAssignmentModal.test.jsx
+++ b/src/components/CodeAssignmentModal/CodeAssignmentModal.test.jsx
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { MemoryRouter } from 'react-router-dom';
 import remindEmailTemplate from './emailTemplate';

--- a/src/components/CodeManagement/tests/CodeManagementRoutes.test.jsx
+++ b/src/components/CodeManagement/tests/CodeManagementRoutes.test.jsx
@@ -6,7 +6,7 @@ import {
   screen,
   render,
 } from '@testing-library/react';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import CodeManagementRoutes from '../CodeManagementRoutes';

--- a/src/components/CodeManagement/tests/CouponCodeTabs.test.jsx
+++ b/src/components/CodeManagement/tests/CouponCodeTabs.test.jsx
@@ -8,7 +8,7 @@ import {
   render,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/CodeManagement/tests/ManageCodesTab.test.jsx
+++ b/src/components/CodeManagement/tests/ManageCodesTab.test.jsx
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 import PropTypes from 'prop-types';
 import { MemoryRouter } from 'react-router-dom';
 import { userEvent } from '@testing-library/user-event';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';

--- a/src/components/CodeManagement/tests/ManageRequestsTab.test.jsx
+++ b/src/components/CodeManagement/tests/ManageRequestsTab.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import dayjs from 'dayjs';
 import userEvent from '@testing-library/user-event';
 import {

--- a/src/components/CodeReminderModal/CodeReminderModal.test.jsx
+++ b/src/components/CodeReminderModal/CodeReminderModal.test.jsx
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux';
 import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { MemoryRouter } from 'react-router-dom';
 import remindEmailTemplate from './emailTemplate';

--- a/src/components/CodeRevokeModal/CodeRevokeModal.test.jsx
+++ b/src/components/CodeRevokeModal/CodeRevokeModal.test.jsx
@@ -6,7 +6,7 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 
 import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { MemoryRouter } from 'react-router-dom';
 import remindEmailTemplate from './emailTemplate';

--- a/src/components/CodeSearchResults/CodeSearchResults.test.jsx
+++ b/src/components/CodeSearchResults/CodeSearchResults.test.jsx
@@ -7,7 +7,7 @@ import { MemoryRouter } from 'react-router-dom';
 import {
   fireEvent, render, screen, waitFor,
 } from '@testing-library/react';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 

--- a/src/components/CompletedLearnersTable/CompletedLearnersTable.test.jsx
+++ b/src/components/CompletedLearnersTable/CompletedLearnersTable.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import renderer from 'react-test-renderer';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 

--- a/src/components/ContentHighlights/CatalogVisibility/tests/ContentHighlightCatalogVisibilityAlert.test.jsx
+++ b/src/components/ContentHighlights/CatalogVisibility/tests/ContentHighlightCatalogVisibilityAlert.test.jsx
@@ -4,7 +4,7 @@ import { renderWithRouter, sendEnterpriseTrackEvent } from '@edx/frontend-enterp
 import React, { useState } from 'react';
 import thunk from 'redux-thunk';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { camelCaseObject } from '@edx/frontend-platform';
 import userEvent from '@testing-library/user-event';

--- a/src/components/ContentHighlights/CatalogVisibility/tests/ContentHighlightCatalogVisibilityRadioInput.test.jsx
+++ b/src/components/ContentHighlights/CatalogVisibility/tests/ContentHighlightCatalogVisibilityRadioInput.test.jsx
@@ -4,7 +4,7 @@ import { renderWithRouter, sendEnterpriseTrackEvent } from '@edx/frontend-enterp
 import React, { useState } from 'react';
 import thunk from 'redux-thunk';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { camelCaseObject } from '@edx/frontend-platform';
 import userEvent from '@testing-library/user-event';

--- a/src/components/ContentHighlights/HighlightStepper/tests/ContentConfirmContentCard.test.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/tests/ContentConfirmContentCard.test.jsx
@@ -5,7 +5,7 @@ import '@testing-library/jest-dom/extend-expect';
 import algoliasearch from 'algoliasearch/lite';
 import { Provider } from 'react-redux';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { renderWithRouter, sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import ContentConfirmContentCard from '../ContentConfirmContentCard';
 import { testCourseData, testCourseAggregation, FOOTER_TEXT_BY_CONTENT_TYPE } from '../../data/constants';

--- a/src/components/ContentHighlights/HighlightStepper/tests/ContentHighlightStepper.test.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/tests/ContentHighlightStepper.test.jsx
@@ -6,7 +6,7 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 import algoliasearch from 'algoliasearch/lite';
 import thunk from 'redux-thunk';
 import { renderWithRouter, sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { ContentHighlightsContext } from '../../ContentHighlightsContext';
 import {

--- a/src/components/ContentHighlights/HighlightStepper/tests/HighlightStepperConfirmContent.test.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/tests/HighlightStepperConfirmContent.test.jsx
@@ -3,7 +3,7 @@ import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import algoliasearch from 'algoliasearch/lite';
 import { renderWithRouter } from '@edx/frontend-enterprise-utils';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/ContentHighlights/HighlightStepper/tests/HighlightStepperSelectContentSearch.test.jsx
+++ b/src/components/ContentHighlights/HighlightStepper/tests/HighlightStepperSelectContentSearch.test.jsx
@@ -3,7 +3,7 @@ import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import algoliasearch from 'algoliasearch/lite';
 import { renderWithRouter, sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/ContentHighlights/tests/ContentHighlightCardItem.test.jsx
+++ b/src/components/ContentHighlights/tests/ContentHighlightCardItem.test.jsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 import { Provider } from 'react-redux';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import thunk from 'redux-thunk';
 import { camelCaseObject } from '@edx/frontend-platform';

--- a/src/components/ContentHighlights/tests/ContentHighlightSet.test.jsx
+++ b/src/components/ContentHighlights/tests/ContentHighlightSet.test.jsx
@@ -1,7 +1,7 @@
 import algoliasearch from 'algoliasearch/lite';
 import React, { useState } from 'react';
 import '@testing-library/jest-dom/extend-expect';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import Router, { Route } from 'react-router-dom';

--- a/src/components/ContentHighlights/tests/ContentHighlightSetCard.test.jsx
+++ b/src/components/ContentHighlights/tests/ContentHighlightSetCard.test.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { Provider } from 'react-redux';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { renderWithRouter, sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import algoliasearch from 'algoliasearch/lite';

--- a/src/components/ContentHighlights/tests/ContentHighlights.test.tsx
+++ b/src/components/ContentHighlights/tests/ContentHighlights.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { Provider } from 'react-redux';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { renderWithRouter } from '@edx/frontend-enterprise-utils';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';

--- a/src/components/ContentHighlights/tests/ContentHighlightsCardItemsContainer.test.jsx
+++ b/src/components/ContentHighlights/tests/ContentHighlightsCardItemsContainer.test.jsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 import { Provider } from 'react-redux';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { camelCaseObject } from '@edx/frontend-platform';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/ContentHighlights/tests/ContentHighlightsDashboard.test.jsx
+++ b/src/components/ContentHighlights/tests/ContentHighlightsDashboard.test.jsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { Provider } from 'react-redux';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { renderWithRouter, sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import algoliasearch from 'algoliasearch/lite';

--- a/src/components/ContentHighlights/tests/CurrentContentHighlights.test.jsx
+++ b/src/components/ContentHighlights/tests/CurrentContentHighlights.test.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { Provider } from 'react-redux';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { renderWithRouter } from '@edx/frontend-enterprise-utils';
 import algoliasearch from 'algoliasearch/lite';

--- a/src/components/ContentHighlights/tests/DeleteArchivedCourses.test.jsx
+++ b/src/components/ContentHighlights/tests/DeleteArchivedCourses.test.jsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import userEvent from '@testing-library/user-event';
 
 import { Provider } from 'react-redux';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { camelCaseObject } from '@edx/frontend-platform';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/ContentHighlights/tests/DeleteHighlightSet.test.jsx
+++ b/src/components/ContentHighlights/tests/DeleteHighlightSet.test.jsx
@@ -6,7 +6,7 @@ import { logError } from '@edx/frontend-platform/logging';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { Provider } from 'react-redux';
 import { Routes, Route, MemoryRouter } from 'react-router-dom';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 

--- a/src/components/ContentHighlights/tests/HighlightSetSection.test.jsx
+++ b/src/components/ContentHighlights/tests/HighlightSetSection.test.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { Provider } from 'react-redux';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import thunk from 'redux-thunk';
 import { renderWithRouter, sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';

--- a/src/components/Coupon/Coupon.test.jsx
+++ b/src/components/Coupon/Coupon.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import renderer from 'react-test-renderer';
 import thunk from 'redux-thunk';
 import { MemoryRouter } from 'react-router-dom';

--- a/src/components/CouponDetails/index.test.jsx
+++ b/src/components/CouponDetails/index.test.jsx
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { MemoryRouter } from 'react-router-dom';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import userEvent from '@testing-library/user-event';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/EmailTemplateForm/EmailTemplateForm.test.jsx
+++ b/src/components/EmailTemplateForm/EmailTemplateForm.test.jsx
@@ -4,7 +4,7 @@ import { reduxForm } from 'redux-form';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 
 import { screen, render } from '@testing-library/react';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import '@testing-library/jest-dom/extend-expect';
 import { MemoryRouter } from 'react-router';

--- a/src/components/EnrolledLearnersForInactiveCoursesTable/EnrolledLearnersForInactiveCoursesTable.test.jsx
+++ b/src/components/EnrolledLearnersForInactiveCoursesTable/EnrolledLearnersForInactiveCoursesTable.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import renderer from 'react-test-renderer';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';

--- a/src/components/EnrolledLearnersTable/EnrolledLearnersTable.test.jsx
+++ b/src/components/EnrolledLearnersTable/EnrolledLearnersTable.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import renderer from 'react-test-renderer';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 

--- a/src/components/EnrollmentsTable/EnrollmentsTable.test.jsx
+++ b/src/components/EnrollmentsTable/EnrollmentsTable.test.jsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { BrowserRouter } from 'react-router-dom';
 import renderer from 'react-test-renderer';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/Hero/Hero.test.jsx
+++ b/src/components/Hero/Hero.test.jsx
@@ -2,7 +2,7 @@ import {
   render, screen,
 } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import { Provider } from 'react-redux';

--- a/src/components/LearnerActivityTable/LearnerActivityTable.test.jsx
+++ b/src/components/LearnerActivityTable/LearnerActivityTable.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import renderer from 'react-test-renderer';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import '@testing-library/jest-dom';

--- a/src/components/NewFeatureAlertBrowseAndRequest/NewFeatureAlertBrowseAndRequest.test.jsx
+++ b/src/components/NewFeatureAlertBrowseAndRequest/NewFeatureAlertBrowseAndRequest.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import {
   screen,

--- a/src/components/PastWeekPassedLearnersTable/PastWeekPassedLearnersTable.test.jsx
+++ b/src/components/PastWeekPassedLearnersTable/PastWeekPassedLearnersTable.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import renderer from 'react-test-renderer';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/PeopleManagement/tests/AddMembersModal.test.jsx
+++ b/src/components/PeopleManagement/tests/AddMembersModal.test.jsx
@@ -4,7 +4,7 @@ import {
 } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 import { QueryClientProvider, useQueryClient } from '@tanstack/react-query';

--- a/src/components/PeopleManagement/tests/CreateGroupModal.test.jsx
+++ b/src/components/PeopleManagement/tests/CreateGroupModal.test.jsx
@@ -4,7 +4,7 @@ import {
 } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';

--- a/src/components/PeopleManagement/tests/DownloadCsvButton.test.jsx
+++ b/src/components/PeopleManagement/tests/DownloadCsvButton.test.jsx
@@ -4,7 +4,7 @@ import { logError } from '@edx/frontend-platform/logging';
 import {
   render, screen,
 } from '@testing-library/react';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 

--- a/src/components/PeopleManagement/tests/DownloadCsvIconButton.test.jsx
+++ b/src/components/PeopleManagement/tests/DownloadCsvIconButton.test.jsx
@@ -4,7 +4,7 @@ import { logError } from '@edx/frontend-platform/logging';
 import {
   act, fireEvent, render, screen, waitFor,
 } from '@testing-library/react';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 

--- a/src/components/PeopleManagement/tests/GroupDetailPage.test.jsx
+++ b/src/components/PeopleManagement/tests/GroupDetailPage.test.jsx
@@ -3,7 +3,7 @@ import {
 } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import thunk from 'redux-thunk';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import userEvent from '@testing-library/user-event';
 import { QueryClientProvider, useQueryClient } from '@tanstack/react-query';

--- a/src/components/PeopleManagement/tests/LearnerDetailPage.test.jsx
+++ b/src/components/PeopleManagement/tests/LearnerDetailPage.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter, useParams } from 'react-router-dom';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import '@testing-library/jest-dom';

--- a/src/components/PeopleManagement/tests/PeopleManagementPage.test.jsx
+++ b/src/components/PeopleManagement/tests/PeopleManagementPage.test.jsx
@@ -3,7 +3,7 @@ import {
 } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import thunk from 'redux-thunk';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';

--- a/src/components/ProductTours/tests/ProductTours.test.jsx
+++ b/src/components/ProductTours/tests/ProductTours.test.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import { Provider } from 'react-redux';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import {
   screen,

--- a/src/components/RegisteredLearnersTable/RegisteredLearnersTable.test.jsx
+++ b/src/components/RegisteredLearnersTable/RegisteredLearnersTable.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import renderer from 'react-test-renderer';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 

--- a/src/components/ReportingConfig/ReportingConfigForm.test.jsx
+++ b/src/components/ReportingConfig/ReportingConfigForm.test.jsx
@@ -126,7 +126,6 @@ const availableCatalogs = [{
 const createConfig = jest.fn();
 const updateConfig = () => { };
 
-// TODO: Fix it.skips
 describe('<ReportingConfigForm />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -220,11 +219,12 @@ describe('<ReportingConfigForm />', () => {
     expect(container.querySelector('input#hourOfDay')).toHaveAttribute('class', 'form-control is-invalid');
   });
 
-  it.skip('Does not submit if sftp fields are empty and deliveryMethod is sftp', async () => {
+  it('Does not submit if sftp fields are empty and deliveryMethod is sftp', async () => {
+    const user = userEvent.setup();
     const config = { ...defaultConfig };
     config.deliveryMethod = 'sftp';
     config.sftpPort = undefined;
-    const { container } = render((
+    render((
       <IntlProvider locale="en">
         <ReportingConfigForm
           config={config}
@@ -236,17 +236,18 @@ describe('<ReportingConfigForm />', () => {
         />
       </IntlProvider>
     ));
-    container.querySelectorAll('.form-control').forEach(input => fireEvent.blur(input));
+
+    const submitButton = screen.getByRole('button', { name: 'Submit' });
+    await user.click(submitButton);
+
     // sftpPort
-    expect(await screen.findByText('Required for all frequency types')).toBeInTheDocument();
+    expect(await screen.findByText('Required. Must be a valid port')).toBeInTheDocument();
     // sftpUsername
     expect(await screen.findByText('Required. Username cannot be blank')).toBeInTheDocument();
     // sftpHostname
     expect(await screen.findByText('Required. Hostname cannot be blank')).toBeInTheDocument();
     // sftpFilePath
     expect(await screen.findByText('Required. File path cannot be blank')).toBeInTheDocument();
-    // encryptedSftpPassword
-    expect(await screen.findByText('Required. Password must not be blank')).toBeInTheDocument();
   });
   it('Does not let you select a new value for data type if it uses the old progress_v1', () => {
     const configWithOldDataType = {
@@ -409,7 +410,7 @@ describe('<ReportingConfigForm />', () => {
     const updatedCheckboxInstance = screen.queryByTestId('includeDateCheckbox');
     expect(updatedCheckboxInstance.checked).toEqual(true);
   });
-  it.skip("should update enableCompression state when the 'Enable Compression' checkbox is clicked", async () => {
+  it("should update enableCompression state when the 'Enable Compression' checkbox is clicked", async () => {
     const user = userEvent.setup();
     render((
       <IntlProvider locale="en">
@@ -424,12 +425,12 @@ describe('<ReportingConfigForm />', () => {
       </IntlProvider>
     ));
 
-    const instance = screen.findByTestId('compressionCheckbox');
+    const instance = await screen.findByTestId('compressionCheckbox');
     expect(instance.checked).toEqual(true);
     const checkBoxInput = screen.getByTestId('compressionCheckbox');
     await user.click(checkBoxInput);
 
-    const updatedInstance = screen.findByTestId('compressionCheckbox');
+    const updatedInstance = await screen.findByTestId('compressionCheckbox');
     expect(updatedInstance.checked).toEqual(false);
   });
 });

--- a/src/components/ReportingConfig/index.test.jsx
+++ b/src/components/ReportingConfig/index.test.jsx
@@ -174,7 +174,7 @@ describe('<ReportingConfig />', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
-  it.skip('calls deleteConfig function on button click', async () => {
+  it('calls deleteConfig function on button click', async () => {
     const user = userEvent.setup();
     render(
       <IntlProvider locale="en">
@@ -188,7 +188,7 @@ describe('<ReportingConfig />', () => {
     });
 
     // Find the collapsible component and set its "isOpen" prop to true
-    const collapsibleTrigger = screen.getByTestId('collapsible-trigger-reporting-config');
+    const collapsibleTrigger = screen.getByRole('button', { name: 'Report Type: csv Delivery Method: email Frequency: monthly' });
     await user.click(collapsibleTrigger);
     // Find the delete button using its data-testid and simulate a click event
     const deleteButton = await screen.findByTestId('deleteConfigButton');

--- a/src/components/Sidebar/IconLink.test.jsx
+++ b/src/components/Sidebar/IconLink.test.jsx
@@ -7,7 +7,7 @@ import { Icon } from '@openedx/paragon';
 import { School } from '@openedx/paragon/icons';
 import { MemoryRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import IconLink from './IconLink';
 

--- a/src/components/SubsidyRequestManagementTable/tests/CourseTitleCell.test.jsx
+++ b/src/components/SubsidyRequestManagementTable/tests/CourseTitleCell.test.jsx
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 import { screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import userEvent from '@testing-library/user-event';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/algolia-search/withAlgoliaSearch.test.tsx
+++ b/src/components/algolia-search/withAlgoliaSearch.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import configureMockStore from 'redux-mock-store';
+import configureMockStore, { MockStore } from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import type { ThunkDispatch } from 'redux-thunk';

--- a/src/components/algolia-search/withAlgoliaSearch.test.tsx
+++ b/src/components/algolia-search/withAlgoliaSearch.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import { legacy_configureStore as configureMockStore, MockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import type { ThunkDispatch } from 'redux-thunk';

--- a/src/components/learner-credit-management/cards/tests/CourseCard.test.jsx
+++ b/src/components/learner-credit-management/cards/tests/CourseCard.test.jsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { QueryClientProvider, useQueryClient } from '@tanstack/react-query';
 import { getConfig } from '@edx/frontend-platform';
 import { AppContext } from '@edx/frontend-platform/react';

--- a/src/components/learner-credit-management/invite-modal/tests/InviteMemberModal.test.jsx
+++ b/src/components/learner-credit-management/invite-modal/tests/InviteMemberModal.test.jsx
@@ -4,7 +4,7 @@ import {
 } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
 import { QueryClientProvider } from '@tanstack/react-query';

--- a/src/components/learner-credit-management/members-tab/tests/MembersTab.test.jsx
+++ b/src/components/learner-credit-management/members-tab/tests/MembersTab.test.jsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/learner-credit-management/search/tests/CatalogSearch.test.tsx
+++ b/src/components/learner-credit-management/search/tests/CatalogSearch.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import '@testing-library/jest-dom/extend-expect';
 import {
   SEARCH_FACET_FILTERS,

--- a/src/components/learner-credit-management/search/tests/CatalogSearchResults.test.jsx
+++ b/src/components/learner-credit-management/search/tests/CatalogSearchResults.test.jsx
@@ -3,7 +3,7 @@ import { screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { SearchContext } from '@edx/frontend-enterprise-catalog-search';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { renderWithRouter } from '@edx/frontend-enterprise-utils';

--- a/src/components/learner-credit-management/tests/BudgetCard.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetCard.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import dayjs from 'dayjs';
 import {
   screen,

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -4,7 +4,7 @@ import { useParams } from 'react-router-dom';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/learner-credit-management/tests/BudgetDetailPageWrapper.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPageWrapper.test.jsx
@@ -2,7 +2,7 @@ import { useContext } from 'react';
 import { Button } from '@openedx/paragon';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/learner-credit-management/tests/EmailAddressTableCell.test.jsx
+++ b/src/components/learner-credit-management/tests/EmailAddressTableCell.test.jsx
@@ -5,7 +5,7 @@ import {
   waitFor,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/learner-credit-management/tests/LearnerCreditAllocationTable.test.jsx
+++ b/src/components/learner-credit-management/tests/LearnerCreditAllocationTable.test.jsx
@@ -5,7 +5,7 @@ import {
 } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 
 import LearnerCreditAllocationTable from '../LearnerCreditAllocationTable';
 

--- a/src/components/learner-credit-management/tests/MultipleBudgetsPage.test.jsx
+++ b/src/components/learner-credit-management/tests/MultipleBudgetsPage.test.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { QueryClientProvider } from '@tanstack/react-query';
 import thunk from 'redux-thunk';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import {
   screen,
   render,

--- a/src/components/settings/SettingsAccessTab/tests/TestUtils.jsx
+++ b/src/components/settings/SettingsAccessTab/tests/TestUtils.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import { Provider } from 'react-redux';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import PropTypes from 'prop-types';
 import { EnterpriseSubsidiesContext } from '../../../EnterpriseSubsidiesContext';
 

--- a/src/components/settings/SettingsAppearanceTab/tests/SettingsAppearanceTab.test.jsx
+++ b/src/components/settings/SettingsAppearanceTab/tests/SettingsAppearanceTab.test.jsx
@@ -3,7 +3,7 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import { Provider } from 'react-redux';

--- a/src/components/settings/SettingsLMSTab/ErrorReporting/tests/SyncHistory.test.jsx
+++ b/src/components/settings/SettingsLMSTab/ErrorReporting/tests/SyncHistory.test.jsx
@@ -3,7 +3,7 @@ import {
   cleanup, screen, waitFor, waitForElementToBeRemoved,
 } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';

--- a/src/components/settings/SettingsLMSTab/tests/AuthorizationsConfigs.test.tsx
+++ b/src/components/settings/SettingsLMSTab/tests/AuthorizationsConfigs.test.tsx
@@ -4,7 +4,7 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/settings/SettingsLMSTab/tests/LmsConfigPage.test.jsx
+++ b/src/components/settings/SettingsLMSTab/tests/LmsConfigPage.test.jsx
@@ -4,7 +4,7 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/settings/SettingsSSOTab/tests/ExistingSSOConfigs.test.jsx
+++ b/src/components/settings/SettingsSSOTab/tests/ExistingSSOConfigs.test.jsx
@@ -4,7 +4,7 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom/extend-expect';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/components/settings/SettingsSSOTab/tests/SSOConfigPage.test.jsx
+++ b/src/components/settings/SettingsSSOTab/tests/SSOConfigPage.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 

--- a/src/components/settings/SettingsSSOTab/tests/SettingsSSOTab.test.jsx
+++ b/src/components/settings/SettingsSSOTab/tests/SettingsSSOTab.test.jsx
@@ -4,7 +4,7 @@ import {
 import userEvent from '@testing-library/user-event';
 import { QueryClientProvider } from '@tanstack/react-query';
 import '@testing-library/jest-dom/extend-expect';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 

--- a/src/components/settings/SettingsSSOTab/testutils.js
+++ b/src/components/settings/SettingsSSOTab/testutils.js
@@ -1,4 +1,4 @@
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 const enterpriseId = 'an-enterprise';

--- a/src/components/settings/tests/SettingsPage.test.jsx
+++ b/src/components/settings/tests/SettingsPage.test.jsx
@@ -4,7 +4,7 @@ import {
   render,
 } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 
 import { MemoryRouter, Route, Routes } from 'react-router-dom';

--- a/src/components/settings/tests/SettingsTabs.test.jsx
+++ b/src/components/settings/tests/SettingsTabs.test.jsx
@@ -7,7 +7,7 @@ import {
   render,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import SettingsTabs from '../SettingsTabs';

--- a/src/components/subscriptions/licenses/LicenseManagementModals/tests/LicenseManagementRemindModal.test.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementModals/tests/LicenseManagementRemindModal.test.jsx
@@ -4,7 +4,7 @@ import {
   act, cleanup, render, screen, waitFor,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { logError } from '@edx/frontend-platform/logging';
 

--- a/src/components/subscriptions/licenses/LicenseManagementTable/bulk-actions/EnrollBulkAction.test.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/bulk-actions/EnrollBulkAction.test.jsx
@@ -4,7 +4,7 @@ import {
   render,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import '@testing-library/jest-dom/extend-expect';
 

--- a/src/components/subscriptions/licenses/LicenseManagementTable/bulk-actions/RemindBulkAction.test.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/bulk-actions/RemindBulkAction.test.jsx
@@ -4,7 +4,7 @@ import {
   render,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import dayjs from 'dayjs';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/subscriptions/licenses/LicenseManagementTable/bulk-actions/RevokeBulkAction.test.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/bulk-actions/RevokeBulkAction.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import dayjs from 'dayjs';
 import '@testing-library/jest-dom/extend-expect';

--- a/src/components/subscriptions/licenses/LicenseManagementTable/tests/LicenseManagementTableActionColumn.test.jsx
+++ b/src/components/subscriptions/licenses/LicenseManagementTable/tests/LicenseManagementTableActionColumn.test.jsx
@@ -4,7 +4,7 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import dayjs from 'dayjs';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 

--- a/src/components/subscriptions/tests/MultipleSubscriptionsPage.test.jsx
+++ b/src/components/subscriptions/tests/MultipleSubscriptionsPage.test.jsx
@@ -5,7 +5,7 @@ import {
 } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { Provider } from 'react-redux';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 

--- a/src/components/subscriptions/tests/SubscriptionRoutes.test.jsx
+++ b/src/components/subscriptions/tests/SubscriptionRoutes.test.jsx
@@ -6,7 +6,7 @@ import {
   screen,
   render,
 } from '@testing-library/react';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import SubscriptionRoutes from '../SubscriptionRoutes';

--- a/src/components/subscriptions/tests/SubscriptionSubsidyRequests.test.jsx
+++ b/src/components/subscriptions/tests/SubscriptionSubsidyRequests.test.jsx
@@ -7,7 +7,7 @@ import {
   render,
   cleanup,
 } from '@testing-library/react';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import '@testing-library/jest-dom/extend-expect';
 import userEvent from '@testing-library/user-event';

--- a/src/components/subscriptions/tests/SubscriptionTabs.test.jsx
+++ b/src/components/subscriptions/tests/SubscriptionTabs.test.jsx
@@ -8,7 +8,7 @@ import {
   render,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { Routes, Route, MemoryRouter } from 'react-router-dom';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 

--- a/src/components/subscriptions/tests/TestUtilities.jsx
+++ b/src/components/subscriptions/tests/TestUtilities.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { createMemoryHistory } from 'history';
 import dayjs from 'dayjs';

--- a/src/containers/AdminPage/AdminPage.test.jsx
+++ b/src/containers/AdminPage/AdminPage.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';

--- a/src/containers/CodeAssignmentModal/CodeAssignmentModal.test.jsx
+++ b/src/containers/CodeAssignmentModal/CodeAssignmentModal.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import PropTypes from 'prop-types';
 import { MemoryRouter } from 'react-router-dom';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { last } from 'lodash-es';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/containers/CodeReminderModal/CodeReminderModal.test.jsx
+++ b/src/containers/CodeReminderModal/CodeReminderModal.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import PropTypes from 'prop-types';
 import { MemoryRouter } from 'react-router-dom';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { last } from 'lodash-es';

--- a/src/containers/CodeRevokeModal/CodeRevokeModal.test.jsx
+++ b/src/containers/CodeRevokeModal/CodeRevokeModal.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import PropTypes from 'prop-types';
 import { MemoryRouter } from 'react-router-dom';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { last } from 'lodash-es';

--- a/src/containers/CouponDetails/CouponDetails.test.jsx
+++ b/src/containers/CouponDetails/CouponDetails.test.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import userEvent from '@testing-library/user-event';
 import { within } from '@testing-library/dom';
 import { MemoryRouter } from 'react-router-dom';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { render, screen } from '@testing-library/react';
 

--- a/src/containers/DownloadCsvButton/DownloadCsvButton.test.jsx
+++ b/src/containers/DownloadCsvButton/DownloadCsvButton.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';

--- a/src/containers/EnterpriseApp/EnterpriseApp.test.jsx
+++ b/src/containers/EnterpriseApp/EnterpriseApp.test.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import PropTypes from 'prop-types';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { render, screen, waitFor } from '@testing-library/react';
 import { breakpoints } from '@openedx/paragon';

--- a/src/containers/EnterpriseIndexPage/EnterpriseIndexPage.test.jsx
+++ b/src/containers/EnterpriseIndexPage/EnterpriseIndexPage.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { render } from '@testing-library/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/containers/Footer/Footer.test.jsx
+++ b/src/containers/Footer/Footer.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import renderer from 'react-test-renderer';
 import { MemoryRouter } from 'react-router-dom';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { configuration } from '../../config';

--- a/src/containers/Header/Header.test.jsx
+++ b/src/containers/Header/Header.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { MemoryRouter } from 'react-router-dom';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import { render, screen } from '@testing-library/react';

--- a/src/containers/InviteLearnersModal/InviteLearnersModal.test.jsx
+++ b/src/containers/InviteLearnersModal/InviteLearnersModal.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import PropTypes from 'prop-types';
 import { MemoryRouter } from 'react-router-dom';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { render, screen } from '@testing-library/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';

--- a/src/containers/SaveTemplateButton/SaveTemplateButton.test.jsx
+++ b/src/containers/SaveTemplateButton/SaveTemplateButton.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { MemoryRouter } from 'react-router-dom';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import { userEvent } from '@testing-library/user-event';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';

--- a/src/containers/Sidebar/Sidebar.test.jsx
+++ b/src/containers/Sidebar/Sidebar.test.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import renderer from 'react-test-renderer';
 import { MemoryRouter } from 'react-router-dom';

--- a/src/containers/SidebarToggle/SidebarToggle.test.jsx
+++ b/src/containers/SidebarToggle/SidebarToggle.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import '@testing-library/jest-dom';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';

--- a/src/data/actions/dashboardAnalytics.test.js
+++ b/src/data/actions/dashboardAnalytics.test.js
@@ -1,4 +1,4 @@
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { axiosMock } from '../../setupTest';
 import {

--- a/src/data/actions/emailTemplate.test.js
+++ b/src/data/actions/emailTemplate.test.js
@@ -1,4 +1,4 @@
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import EcommerceApiService from '../services/EcommerceApiService';

--- a/src/data/actions/enterpriseGroups.test.js
+++ b/src/data/actions/enterpriseGroups.test.js
@@ -1,4 +1,4 @@
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { fetchEnterpriseGroups, clearEnterpriseGroups } from './enterpriseGroups';
 import { getAllFlexEnterpriseGroups } from '../../components/learner-credit-management/data/hooks/useAllFlexEnterpriseGroups';

--- a/src/data/actions/portalConfiguration.test.js
+++ b/src/data/actions/portalConfiguration.test.js
@@ -1,4 +1,4 @@
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { camelCaseObject } from '@edx/frontend-platform/utils';
 

--- a/src/data/actions/sidebar.test.js
+++ b/src/data/actions/sidebar.test.js
@@ -1,4 +1,4 @@
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import {

--- a/src/data/actions/table.test.js
+++ b/src/data/actions/table.test.js
@@ -1,4 +1,4 @@
-import { legacy_configureStore as configureMockStore } from 'redux-mock-store';
+import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import { paginateTable, sortTable } from './table';


### PR DESCRIPTION
# Description

1. Unskips some (not all) tests that were skipped in the parent PR: https://github.com/openedx/frontend-app-admin-portal/pull/1506
2. Updates imports for `redux-mock-store` to not use a legacy named export.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
