### PR TITLE
fix: prevent access to catalog tab in LCM for expired/retired budgets

### DIFF
--- a/src/components/EnterpriseSubsidiesContext/data/hooks.js
+++ b/src/components/EnterpriseSubsidiesContext/data/hooks.js
@@ -12,9 +12,8 @@ import LicenseManagerApiService from '../../../data/services/LicenseManagerAPISe
 import SubsidyApiService from '../../../data/services/EnterpriseSubsidyApiService';
 import { BUDGET_TYPES } from '../../EnterpriseApp/data/constants';
 import EnterpriseAccessApiService from '../../../data/services/EnterpriseAccessApiService';
-import { learnerCreditManagementQueryKeys } from '../../learner-credit-management/data';
+import { learnerCreditManagementQueryKeys, isBudgetRetiredOrExpired, getBudgetStatus } from '../../learner-credit-management/data';
 import { isAssignableSubsidyAccessPolicyType } from '../../../utils';
-import { isBudgetRetiredOrExpired, getBudgetStatus } from '../../learner-credit-management/data/utils';
 
 dayjs.extend(isBetween);
 

--- a/src/components/EnterpriseSubsidiesContext/data/hooks.js
+++ b/src/components/EnterpriseSubsidiesContext/data/hooks.js
@@ -124,7 +124,6 @@ export const useEnterpriseBudgets = ({
       enterpriseId,
       enablePortalLearnerCreditManagementScreen,
     }),
-    ...queryOptions,
     select: (data) => {
       if (!data?.budgets) {
         return data;
@@ -146,10 +145,16 @@ export const useEnterpriseBudgets = ({
         return budget;
       });
 
-      return {
+      const transformedData = {
         ...data,
         budgets: updatedBudgets,
       };
+
+      if (queryOptions.select) {
+        return queryOptions.select(transformedData);
+      }
+
+      return transformedData;
     },
   });
 };

--- a/src/components/EnterpriseSubsidiesContext/data/tests/hooks.test.jsx
+++ b/src/components/EnterpriseSubsidiesContext/data/tests/hooks.test.jsx
@@ -247,6 +247,9 @@ describe('useEnterpriseBudgets', () => {
         isCurrent: true,
         source: BUDGET_TYPES.policy,
         isAssignable: false,
+        isRetired: undefined,
+        isRetiredOrExpired: false,
+        retiredAt: undefined,
         aggregates: {
           available: 700,
           spent: 200,

--- a/src/components/EnterpriseSubsidiesContext/data/tests/hooks.test.jsx
+++ b/src/components/EnterpriseSubsidiesContext/data/tests/hooks.test.jsx
@@ -2,6 +2,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { logError } from '@edx/frontend-platform/logging';
 import dayjs from 'dayjs';
 import { QueryClientProvider } from '@tanstack/react-query';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 
 import { useCoupons, useCustomerAgreement, useEnterpriseBudgets } from '../hooks';
 import EcommerceApiService from '../../../../data/services/EcommerceApiService';
@@ -31,7 +32,9 @@ const TEST_ENTERPRISE_UUID = 'test-enterprise-uuid';
 describe('useEnterpriseBudgets', () => {
   const wrapper = ({ children }) => (
     <QueryClientProvider client={queryClient()}>
-      {children}
+      <IntlProvider locale="en">
+        {children}
+      </IntlProvider>
     </QueryClientProvider>
   );
 

--- a/src/components/EnterpriseSubsidiesContext/data/tests/hooks.test.jsx
+++ b/src/components/EnterpriseSubsidiesContext/data/tests/hooks.test.jsx
@@ -210,6 +210,7 @@ describe('useEnterpriseBudgets', () => {
           amountRedeemedUsd: 200,
           amountAllocatedUsd: 100,
         },
+        retired: false,
       },
     ];
     fetchEnterpriseOffersSpy.mockResolvedValue({
@@ -247,7 +248,7 @@ describe('useEnterpriseBudgets', () => {
         isCurrent: true,
         source: BUDGET_TYPES.policy,
         isAssignable: false,
-        isRetired: undefined,
+        isRetired: false,
         isRetiredOrExpired: false,
         retiredAt: undefined,
         aggregates: {

--- a/src/components/EnterpriseSubsidiesContext/data/tests/hooks.test.jsx
+++ b/src/components/EnterpriseSubsidiesContext/data/tests/hooks.test.jsx
@@ -211,6 +211,7 @@ describe('useEnterpriseBudgets', () => {
           amountAllocatedUsd: 100,
         },
         retired: false,
+        retiredAt: '2025-06-25T19:56:09Z',
       },
     ];
     fetchEnterpriseOffersSpy.mockResolvedValue({
@@ -250,7 +251,7 @@ describe('useEnterpriseBudgets', () => {
         isAssignable: false,
         isRetired: false,
         isRetiredOrExpired: false,
-        retiredAt: undefined,
+        retiredAt: '2025-06-25T19:56:09Z',
         aggregates: {
           available: 700,
           spent: 200,

--- a/src/components/learner-credit-management/AssignmentAmountTableCell.jsx
+++ b/src/components/learner-credit-management/AssignmentAmountTableCell.jsx
@@ -1,22 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useIntl } from '@edx/frontend-platform/i18n';
 import {
-  formatPrice, getBudgetStatus, useBudgetId, useSubsidyAccessPolicy,
+  formatPrice, useBudgetId, useSubsidyAccessPolicy,
 } from './data';
-import { BUDGET_STATUSES } from '../EnterpriseApp/data/constants';
 
 const AssignmentAmountTableCell = ({ row }) => {
-  const intl = useIntl();
   const { subsidyAccessPolicyId } = useBudgetId();
   const { data: subsidyAccessPolicy } = useSubsidyAccessPolicy(subsidyAccessPolicyId);
-  const { status } = getBudgetStatus({
-    intl,
-    startDateStr: subsidyAccessPolicy.subsidyActiveDatetime,
-    endDateStr: subsidyAccessPolicy.subsidyExpirationDatetime,
-    isBudgetRetired: subsidyAccessPolicy.retired,
-  });
-  const shouldStrikeoutPrice = [BUDGET_STATUSES.expired, BUDGET_STATUSES.retired].includes(status);
+  const shouldStrikeoutPrice = subsidyAccessPolicy?.isRetiredOrExpired;
 
   if (shouldStrikeoutPrice) {
     return (

--- a/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
+++ b/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
@@ -28,7 +28,6 @@ const AssignmentStatusTableCell = ({ enterpriseId, row }) => {
   const {
     subsidyUuid, assignmentConfiguration, isSubsidyActive, isAssignable, catalogUuid, aggregates,
   } = subsidyAccessPolicy;
-  const budgetStatusesWithIncompleteAssignments = subsidyAccessPolicy?.isRetiredOrExpired;
   const sharedTrackEventMetadata = {
     learnerState,
     subsidyUuid,
@@ -74,8 +73,8 @@ const AssignmentStatusTableCell = ({ enterpriseId, row }) => {
     return null;
   }
 
-  // Always display "Incomplete assignment" status chip for retired budgets
-  if (budgetStatusesWithIncompleteAssignments) {
+  // Always display "Incomplete assignment" status chip for retired/expired budgets
+  if (subsidyAccessPolicy?.isRetiredOrExpired) {
     return (
       <IncompleteAssignment trackEvent={sendGenericTrackEvent} />
     );

--- a/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
+++ b/src/components/learner-credit-management/AssignmentStatusTableCell.jsx
@@ -2,7 +2,6 @@ import { Chip } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { connect } from 'react-redux';
-import { useIntl } from '@edx/frontend-platform/i18n';
 import FailedBadEmail from './assignments-status-chips/FailedBadEmail';
 import FailedCancellation from './assignments-status-chips/FailedCancellation';
 import FailedRedemption from './assignments-status-chips/FailedRedemption';
@@ -12,15 +11,12 @@ import NotifyingLearner from './assignments-status-chips/NotifyingLearner';
 import WaitingForLearner from './assignments-status-chips/WaitingForLearner';
 import { capitalizeFirstLetter } from '../../utils';
 import {
-  getBudgetStatus,
   useBudgetId,
   useSubsidyAccessPolicy,
 } from './data';
 import IncompleteAssignment from './assignments-status-chips/IncompleteAssignment';
-import { BUDGET_STATUSES } from '../EnterpriseApp/data/constants';
 
 const AssignmentStatusTableCell = ({ enterpriseId, row }) => {
-  const intl = useIntl();
   const { original } = row;
   const {
     learnerEmail,
@@ -29,16 +25,10 @@ const AssignmentStatusTableCell = ({ enterpriseId, row }) => {
   } = original;
   const { subsidyAccessPolicyId } = useBudgetId();
   const { data: subsidyAccessPolicy } = useSubsidyAccessPolicy(subsidyAccessPolicyId);
-  const { status } = getBudgetStatus({
-    intl,
-    startDateStr: subsidyAccessPolicy.subsidyActiveDatetime,
-    endDateStr: subsidyAccessPolicy.subsidyExpirationDatetime,
-    isBudgetRetired: subsidyAccessPolicy.retired,
-  });
   const {
     subsidyUuid, assignmentConfiguration, isSubsidyActive, isAssignable, catalogUuid, aggregates,
   } = subsidyAccessPolicy;
-  const budgetStatusesWithIncompleteAssignments = [BUDGET_STATUSES.expired, BUDGET_STATUSES.retired];
+  const budgetStatusesWithIncompleteAssignments = subsidyAccessPolicy?.isRetiredOrExpired;
   const sharedTrackEventMetadata = {
     learnerState,
     subsidyUuid,
@@ -85,7 +75,7 @@ const AssignmentStatusTableCell = ({ enterpriseId, row }) => {
   }
 
   // Always display "Incomplete assignment" status chip for retired budgets
-  if (budgetStatusesWithIncompleteAssignments.includes(status)) {
+  if (budgetStatusesWithIncompleteAssignments) {
     return (
       <IncompleteAssignment trackEvent={sendGenericTrackEvent} />
     );

--- a/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
+++ b/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
@@ -10,14 +10,13 @@ import AssignmentAmountTableCell from './AssignmentAmountTableCell';
 import AssignmentRowActionTableCell from './AssignmentRowActionTableCell';
 import AssignmentTableRemindAction from './AssignmentTableRemind';
 import AssignmentTableCancelAction from './AssignmentTableCancel';
-import {
-  DEFAULT_PAGE, PAGE_SIZE,
-} from './data';
 import AssignmentRecentActionTableCell from './AssignmentRecentActionTableCell';
 import AssignmentsTableRefreshAction from './AssignmentsTableRefreshAction';
 import AssignmentEnrollByDateCell from './AssignmentEnrollByDateCell';
 import AssignmentEnrollByDateHeader from './AssignmentEnrollByDateHeader';
-import { useBudgetId, useSubsidyAccessPolicy } from './data';
+import {
+  DEFAULT_PAGE, PAGE_SIZE, useBudgetId, useSubsidyAccessPolicy,
+} from './data';
 
 const FilterStatus = (rest) => <DataTable.FilterStatus showFilteredFields={false} {...rest} />;
 

--- a/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
+++ b/src/components/learner-credit-management/BudgetAssignmentsTable.jsx
@@ -17,7 +17,7 @@ import AssignmentRecentActionTableCell from './AssignmentRecentActionTableCell';
 import AssignmentsTableRefreshAction from './AssignmentsTableRefreshAction';
 import AssignmentEnrollByDateCell from './AssignmentEnrollByDateCell';
 import AssignmentEnrollByDateHeader from './AssignmentEnrollByDateHeader';
-import { BUDGET_STATUSES } from '../EnterpriseApp/data/constants';
+import { useBudgetId, useSubsidyAccessPolicy } from './data';
 
 const FilterStatus = (rest) => <DataTable.FilterStatus showFilteredFields={false} {...rest} />;
 
@@ -46,9 +46,10 @@ const BudgetAssignmentsTable = ({
   isLoading,
   tableData,
   fetchTableData,
-  status,
 }) => {
   const intl = useIntl();
+  const { subsidyAccessPolicyId } = useBudgetId();
+  const { data: subsidyAccessPolicy } = useSubsidyAccessPolicy(subsidyAccessPolicyId);
   const statusFilterChoices = tableData.learnerStateCounts
     .filter(({ learnerState }) => !!getLearnerStateDisplayName(learnerState))
     .map(({ learnerState, count }) => ({
@@ -56,7 +57,7 @@ const BudgetAssignmentsTable = ({
       number: count,
       value: learnerState,
     }));
-  const isRetiredOrExpired = [BUDGET_STATUSES.retired, BUDGET_STATUSES.expired].includes(status);
+  const isRetiredOrExpired = subsidyAccessPolicy?.isRetiredOrExpired;
 
   const budgetAssignmentsTableData = (() => {
     if (isRetiredOrExpired) {
@@ -183,7 +184,6 @@ BudgetAssignmentsTable.propTypes = {
     numPages: PropTypes.number.isRequired,
   }).isRequired,
   fetchTableData: PropTypes.func.isRequired,
-  status: PropTypes.string.isRequired,
 };
 
 export default BudgetAssignmentsTable;

--- a/src/components/learner-credit-management/BudgetDetail.jsx
+++ b/src/components/learner-credit-management/BudgetDetail.jsx
@@ -4,13 +4,14 @@ import { ProgressBar, Stack } from '@openedx/paragon';
 
 import { formatPrice } from './data';
 import { BUDGET_STATUSES } from '../EnterpriseApp/data/constants';
+import { isBudgetRetiredOrExpired } from './data/utils';
 
 const BudgetDetail = ({
   available, utilized, limit, status,
 }) => {
   const currentProgressBarLimit = (available / limit) * 100;
 
-  if (status === BUDGET_STATUSES.expired || status === BUDGET_STATUSES.retired) {
+  if (isBudgetRetiredOrExpired(status)) {
     return (
       <Stack className="border border-light-400 p-4">
         <h4>Spent</h4>

--- a/src/components/learner-credit-management/BudgetDetailAssignments.jsx
+++ b/src/components/learner-credit-management/BudgetDetailAssignments.jsx
@@ -15,6 +15,7 @@ import {
   useSubsidyAccessPolicy,
 } from './data';
 import { BUDGET_STATUSES } from '../EnterpriseApp/data/constants';
+import { isBudgetRetiredOrExpired } from './data/utils';
 
 const BudgetDetailAssignmentsHeader = ({
   status,
@@ -34,7 +35,7 @@ const BudgetDetailAssignmentsHeader = ({
     }
   }, [navigate, location, locationState]);
 
-  if ([BUDGET_STATUSES.retired, BUDGET_STATUSES.expired].includes(status)) {
+  if (isBudgetRetiredOrExpired(status)) {
     return (
       <>
         <h3 className="mb-3" ref={assignedHeadingRef}>
@@ -136,7 +137,7 @@ const BudgetDetailAssignments = ({
 
   if (!hasContentAssignments
     && hasSpentTransactions
-    && ![BUDGET_STATUSES.retired, BUDGET_STATUSES.expired].includes(status)) {
+    && !isBudgetRetiredOrExpired(status)) {
     return (
       <AssignMoreCoursesEmptyStateMinimal />
     );
@@ -149,7 +150,6 @@ const BudgetDetailAssignments = ({
         isLoading={isLoading}
         tableData={contentAssignments}
         fetchTableData={fetchContentAssignments}
-        status={status}
       />
     </section>
   );

--- a/src/components/learner-credit-management/BudgetDetailAssignments.jsx
+++ b/src/components/learner-credit-management/BudgetDetailAssignments.jsx
@@ -134,7 +134,9 @@ const BudgetDetailAssignments = ({
     return null;
   }
 
-  if (!hasContentAssignments && hasSpentTransactions) {
+  if (!hasContentAssignments
+    && hasSpentTransactions
+    && ![BUDGET_STATUSES.retired, BUDGET_STATUSES.expired].includes(status)) {
     return (
       <AssignMoreCoursesEmptyStateMinimal />
     );

--- a/src/components/learner-credit-management/BudgetDetailTabsAndRoutes.jsx
+++ b/src/components/learner-credit-management/BudgetDetailTabsAndRoutes.jsx
@@ -13,7 +13,8 @@ import {
   BUDGET_DETAIL_REQUESTS_TAB,
 } from './data/constants';
 import { getBudgetStatus, useBudgetDetailTabs, useBudgetId } from './data';
-import { BUDGET_STATUSES, ROUTE_NAMES } from '../EnterpriseApp/data/constants';
+import { ROUTE_NAMES } from '../EnterpriseApp/data/constants';
+import { isBudgetRetiredOrExpired } from './data/utils';
 import NotFoundPage from '../NotFoundPage';
 import EVENT_NAMES from '../../eventTracking';
 
@@ -111,7 +112,7 @@ const BudgetDetailTabsAndRoutes = ({
     // If viewing the catalog tab and the budget is retired or expired, redirect to the default tab
     if (
       initialTabKey === BUDGET_DETAIL_CATALOG_TAB
-      && [BUDGET_STATUSES.retired, BUDGET_STATUSES.expired].includes(budgetStatus)
+      && isBudgetRetiredOrExpired(budgetStatus)
     ) {
       navigate(`/${enterpriseSlug}/admin/${ROUTE_NAMES.learnerCredit}/${budgetId}/${DEFAULT_TAB}`);
     }

--- a/src/components/learner-credit-management/BudgetDetailTabsAndRoutes.jsx
+++ b/src/components/learner-credit-management/BudgetDetailTabsAndRoutes.jsx
@@ -108,7 +108,7 @@ const BudgetDetailTabsAndRoutes = ({
     );
     setActiveTabKey(initialTabKey);
 
-    // If the budget is retired or expired, redirect to the default tab
+    // If viewing the catalog tab and the budget is retired or expired, redirect to the default tab
     if (
       initialTabKey === BUDGET_DETAIL_CATALOG_TAB
       && [BUDGET_STATUSES.retired, BUDGET_STATUSES.expired].includes(budgetStatus)

--- a/src/components/learner-credit-management/SubBudgetCard.jsx
+++ b/src/components/learner-credit-management/SubBudgetCard.jsx
@@ -15,6 +15,7 @@ import { BUDGET_STATUSES, ROUTE_NAMES } from '../EnterpriseApp/data/constants';
 import {
   getBudgetStatus, getTranslatedBudgetStatus, getTranslatedBudgetTerm,
 } from './data';
+import { isBudgetRetiredOrExpired } from './data/utils';
 import { useEnterpriseBudgets } from '../EnterpriseSubsidiesContext/data/hooks';
 import SubBudgetCardUtilization from './SubBudgetCardUtilization';
 
@@ -93,7 +94,7 @@ const BaseSubBudgetCard = ({
       year: 'numeric',
     },
   ) : undefined;
-  const isRetiredOrExpired = [BUDGET_STATUSES.expired, BUDGET_STATUSES.retired].includes(status);
+  const isRetiredOrExpired = isBudgetRetiredOrExpired(status);
 
   const hasBudgetAggregatesSection = () => {
     const statusesWithoutAggregates = [

--- a/src/components/learner-credit-management/SubBudgetCardUtilization.jsx
+++ b/src/components/learner-credit-management/SubBudgetCardUtilization.jsx
@@ -3,7 +3,7 @@ import { Col, Skeleton, Card } from '@openedx/paragon';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import classNames from 'classnames';
 import { formatPrice } from './data';
-import { BUDGET_STATUSES } from '../EnterpriseApp/data/constants';
+import { isBudgetRetiredOrExpired } from './data/utils';
 
 const SubBudgetCardUtilization = ({
   isAssignable,
@@ -13,9 +13,7 @@ const SubBudgetCardUtilization = ({
   pending,
   spent,
 }) => {
-  const isRetiredOrExpired = (
-    status === BUDGET_STATUSES.retired || status === BUDGET_STATUSES.expired
-  );
+  const isRetiredOrExpired = isBudgetRetiredOrExpired(status);
 
   return (
     <Card.Section

--- a/src/components/learner-credit-management/data/hooks/tests/useBudgetDetailTabs.test.jsx
+++ b/src/components/learner-credit-management/data/hooks/tests/useBudgetDetailTabs.test.jsx
@@ -12,6 +12,7 @@ import { BUDGET_STATUSES } from '../../../../EnterpriseApp/data/constants';
 
 // Mock getBudgetStatus
 jest.mock('../../utils', () => ({
+  ...jest.requireActual('../../utils'),
   getBudgetStatus: jest.fn(),
 }));
 
@@ -147,6 +148,8 @@ describe('useBudgetDetailTabs', () => {
     const { result } = renderHook(() => useBudgetDetailTabs(propsWithActiveRequestsTab), { wrapper });
 
     const requestsTab = result.current.find(tab => tab.key === BUDGET_DETAIL_REQUESTS_TAB);
+    expect(requestsTab).toBeDefined();
     expect(requestsTab.props.children).toBeTruthy();
+    expect(requestsTab.props.children.type).toBe(mockProps.RequestsTabElement);
   });
 });

--- a/src/components/learner-credit-management/data/hooks/tests/useSubsidyAccessPolicy.test.jsx
+++ b/src/components/learner-credit-management/data/hooks/tests/useSubsidyAccessPolicy.test.jsx
@@ -1,5 +1,6 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 
 import useSubsidyAccessPolicy from '../useSubsidyAccessPolicy'; // Import the hook
 import EnterpriseAccessApiService from '../../../../../data/services/EnterpriseAccessApiService';
@@ -20,7 +21,9 @@ jest.mock('../../../../../data/services/EnterpriseAccessApiService', () => ({
 }));
 
 const wrapper = ({ children }) => (
-  <QueryClientProvider client={queryClient()}>{children}</QueryClientProvider>
+  <IntlProvider locale="en">
+    <QueryClientProvider client={queryClient()}>{children}</QueryClientProvider>
+  </IntlProvider>
 );
 
 describe('useSubsidyAccessPolicy', () => {
@@ -55,6 +58,7 @@ describe('useSubsidyAccessPolicy', () => {
       policyType: isAssignable ? 'AssignedLearnerCreditAccessPolicy' : 'PerLearnerCreditSpendLimitAccessPolicy',
       isAssignable,
       assignmentConfiguration: isAssignable ? mockAssignmentConfiguration : undefined,
+      isRetiredOrExpired: true,
       // Other expected properties...
     });
   });
@@ -87,6 +91,7 @@ describe('useSubsidyAccessPolicy', () => {
         policyType: 'AssignedLearnerCreditAccessPolicy',
         assignmentConfiguration: mockAssignmentConfiguration,
         isAssignable: true,
+        isRetiredOrExpired: true,
         // Other expected properties...
       },
     },

--- a/src/components/learner-credit-management/data/hooks/useBudgetDetailTabs.jsx
+++ b/src/components/learner-credit-management/data/hooks/useBudgetDetailTabs.jsx
@@ -5,8 +5,7 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 import {
   BUDGET_DETAIL_ACTIVITY_TAB, BUDGET_DETAIL_CATALOG_TAB, BUDGET_DETAIL_MEMBERS_TAB, BUDGET_DETAIL_REQUESTS_TAB,
 } from '../constants';
-import { BUDGET_STATUSES } from '../../../EnterpriseApp/data/constants';
-import { getBudgetStatus } from '../utils';
+import { getBudgetStatus, isBudgetRetiredOrExpired } from '../utils';
 
 const TAB_CLASS_NAME = 'pt-4.5';
 
@@ -30,7 +29,7 @@ export const useBudgetDetailTabs = ({
     endDateStr: subsidyAccessPolicy?.subsidyExpirationDatetime,
     isBudgetRetired: subsidyAccessPolicy?.retired,
   });
-  const isCatalogTabDisabled = [BUDGET_STATUSES.retired, BUDGET_STATUSES.expired].includes(status);
+  const isCatalogTabDisabled = isBudgetRetiredOrExpired(status);
   const showCatalog = (subsidyAccessPolicy?.groupAssociations?.length > 0 && !appliesToAllContexts)
     || (enterpriseFeatures.topDownAssignmentRealTimeLcm && !!subsidyAccessPolicy?.isAssignable);
   const isBnrEnabled = subsidyAccessPolicy?.bnrEnabled || false;

--- a/src/components/learner-credit-management/data/hooks/useBudgetId.js
+++ b/src/components/learner-credit-management/data/hooks/useBudgetId.js
@@ -1,5 +1,6 @@
+import { validate as uuidValidate } from 'uuid';
+
 import { useParams } from 'react-router-dom';
-import { isUUID } from '../utils';
 
 /**
  * Given a page route with the `:budgetId` param, returns the `budgetId` and either a
@@ -13,8 +14,8 @@ import { isUUID } from '../utils';
  */
 const useBudgetId = () => {
   const { budgetId } = useParams();
-  const enterpriseOfferId = isUUID(budgetId) ? null : budgetId;
-  const subsidyAccessPolicyId = isUUID(budgetId) ? budgetId : null;
+  const enterpriseOfferId = uuidValidate(budgetId) ? null : budgetId;
+  const subsidyAccessPolicyId = uuidValidate(budgetId) ? budgetId : null;
   return {
     budgetId,
     enterpriseOfferId,

--- a/src/components/learner-credit-management/data/hooks/useEnterpriseFlexGroups.js
+++ b/src/components/learner-credit-management/data/hooks/useEnterpriseFlexGroups.js
@@ -19,7 +19,8 @@ export const getGroupMemberEmails = async (groupUUID) => {
  * @returns A list of flex groups associated with an enterprise customer.
  */
 export const getEnterpriseFlexGroups = async ({ enterpriseId }) => {
-  const { results } = await fetchPaginatedData(LmsApiService.enterpriseGroupListUrl);
+  const groupListUrl = `${LmsApiService.enterpriseGroupListUrl}?page_size=100`;
+  const { results } = await fetchPaginatedData(groupListUrl);
   const flexGroups = results.filter(result => (
     result.enterpriseCustomer === enterpriseId && result.groupType === GROUP_TYPE_FLEX));
   return flexGroups;

--- a/src/components/learner-credit-management/data/types.ts
+++ b/src/components/learner-credit-management/data/types.ts
@@ -6,4 +6,13 @@ export type SubsidyAccessPolicy = {
   assignmentConfiguration: Record<string, string>;
   catalogUuid: string;
   groupAssociations: string[];
+  subsidyActiveDatetime: string;
+  subsidyExpirationDatetime: string;
+  retired: boolean;
+  isRetiredOrExpired?: boolean;
+  aggregates?: {
+    spendAvailableUsd: number;
+    amountRedeemedUsd: number;
+    amountAllocatedUsd: number;
+  };
 };

--- a/src/components/learner-credit-management/data/utils.js
+++ b/src/components/learner-credit-management/data/utils.js
@@ -160,9 +160,6 @@ export const getProgressBarVariant = ({ percentUtilized, remainingFunds }) => {
   return variant;
 };
 
-//  Utility function to check if the ID is a UUID
-export const isUUID = (id) => /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(id);
-
 // TODO: Abstract 'status' higher up into the component tree to simplify code
 //  Utility function to check the budget status
 export const getBudgetStatus = ({

--- a/src/components/learner-credit-management/data/utils.js
+++ b/src/components/learner-credit-management/data/utils.js
@@ -163,7 +163,7 @@ export const getProgressBarVariant = ({ percentUtilized, remainingFunds }) => {
 //  Utility function to check if the ID is a UUID
 export const isUUID = (id) => /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(id);
 
-// TODO: Abstract ‘status’ higher up into the component tree to simplify code
+// TODO: Abstract 'status' higher up into the component tree to simplify code
 //  Utility function to check the budget status
 export const getBudgetStatus = ({
   intl,
@@ -798,3 +798,12 @@ export const getAssignableCourseRuns = ({
   // Sorts by the enrollBy date. If enrollBy is equivalent, sort by start
   return assignableCourseRuns.sort(startAndEnrollBySortLogic);
 };
+
+/**
+ * Checks if a budget status is retired or expired.
+ * These states typically disable certain actions or hide UI elements.
+ *
+ * @param {string} status The budget status to check
+ * @returns {boolean} True if the budget is retired or expired, false otherwise
+ */
+export const isBudgetRetiredOrExpired = (status) => [BUDGET_STATUSES.retired, BUDGET_STATUSES.expired].includes(status);

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -2892,6 +2892,7 @@ describe('<BudgetDetailPage />', () => {
           ...mockAssignableSubsidyAccessPolicy,
           endDate: dayjs().subtract(1, 'day').format(),
           isRetired: false,
+          isRetiredOrExpired: true,
         },
       },
       {
@@ -2899,6 +2900,7 @@ describe('<BudgetDetailPage />', () => {
         mockPolicyData: {
           ...mockAssignableSubsidyAccessPolicy,
           isRetired: true,
+          isRetiredOrExpired: true,
         },
       },
     ];

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -2798,6 +2798,38 @@ describe('<BudgetDetailPage />', () => {
         expect(screen.queryByText('Assign more courses')).not.toBeInTheDocument();
       });
     });
+
+    it('should show assign more courses empty state for an active budget', async () => {
+      useParams.mockReturnValue({ budgetId: mockSubsidyAccessPolicyUUID, enterpriseSlug, enterpriseAppPage: 'learner-credit' });
+      useSubsidyAccessPolicy.mockReturnValue({
+        isLoading: false,
+        data: {
+          ...mockAssignableSubsidyAccessPolicy,
+          retired: false,
+          subsidyExpirationDatetime: dayjs().add(1, 'year').toISOString(),
+        },
+      });
+      useBudgetDetailActivityOverview.mockReturnValue({
+        isLoading: false,
+        data: mockBudgetDetailActivityOverviewWithSpend,
+      });
+      useBudgetContentAssignments.mockReturnValue({
+        isLoading: false,
+        contentAssignments: { results: [], learnerStateCounts: [] },
+      });
+      useBudgetRedemptions.mockReturnValue({
+        isLoading: false,
+        budgetRedemptions: mockEmptyBudgetRedemptions,
+        fetchBudgetRedemptions: jest.fn(),
+      });
+
+      renderWithRouter(<BudgetDetailPageWrapper />);
+      await waitFor(() => {
+        expect(screen.getByText('Assign more courses to maximize your budget.')).toBeInTheDocument();
+        expect(screen.getByText('available balance of $10,000', { exact: false })).toBeInTheDocument();
+        expect(screen.getByText('Assign courses', { selector: 'a' })).toBeInTheDocument();
+      });
+    });
   });
 
   describe('tab redirection for expired and retired budgets', () => {

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -12,7 +12,7 @@ import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { renderWithRouter, sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { act } from 'react-dom/test-utils';
-import { v4 as uuidv4 } from 'uuid';
+import { v4 as uuidv4, validate as uuidValidate } from 'uuid';
 import { faker } from '@faker-js/faker';
 import dayjs from 'dayjs';
 
@@ -250,9 +250,8 @@ describe('<BudgetDetailPage />', () => {
     // Mock useBudgetId to be dynamic based on useParams
     useBudgetId.mockImplementation(() => {
       const { budgetId } = useParams();
-      const isUUID = (id) => /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(id);
-      const enterpriseOfferId = isUUID(budgetId) ? null : budgetId;
-      const subsidyAccessPolicyId = isUUID(budgetId) ? budgetId : null;
+      const enterpriseOfferId = uuidValidate(budgetId) ? null : budgetId;
+      const subsidyAccessPolicyId = uuidValidate(budgetId) ? budgetId : null;
       return {
         budgetId,
         enterpriseOfferId,

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -1542,7 +1542,7 @@ describe('<BudgetDetailPage />', () => {
     expect(viewCourseCTA.getAttribute('href')).toEqual(`${process.env.ENTERPRISE_LEARNER_PORTAL_URL}/${enterpriseSlug}/course/${mockCourseKey}`);
   });
 
-  it.only('renders with incomplete assignments table data, when budget is retired', async () => {
+  it('renders with incomplete assignments table data, when budget is retired', async () => {
     const user = userEvent.setup();
     useParams.mockReturnValue({
       enterpriseSlug: 'test-enterprise-slug',

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -113,6 +113,10 @@ const mockEmptyStateBudgetDetailActivityOverview = {
   contentAssignments: { count: 0 },
   spentTransactions: { count: 0 },
 };
+const mockBudgetDetailActivityOverviewWithSpend = {
+  contentAssignments: { count: 0 },
+  spentTransactions: { count: 1 },
+};
 const mockEmptyBudgetRedemptions = {
   itemCount: 0,
   pageCount: 0,
@@ -2744,5 +2748,48 @@ describe('<BudgetDetailPage />', () => {
     renderWithRouter(<BudgetDetailPageWrapper />);
 
     expect(screen.getByText('Browse & Request', { exact: false })).toBeInTheDocument();
+  });
+
+  describe('when there are no assignments but there is spend', () => {
+    test.each([
+      [
+        'retired',
+        {
+          ...mockAssignableSubsidyAccessPolicy,
+          retired: true,
+        },
+      ],
+      [
+        'expired',
+        {
+          ...mockAssignableSubsidyAccessPolicy,
+          subsidyExpirationDatetime: dayjs().subtract(1, 'day').toISOString(),
+        },
+      ],
+    ])('should NOT show assign more courses empty state for a %s budget', async (status, budgetData) => {
+      useParams.mockReturnValue({ budgetId: mockSubsidyAccessPolicyUUID, enterpriseSlug, enterpriseAppPage: 'learner-credit' });
+      useSubsidyAccessPolicy.mockReturnValue({
+        isLoading: false,
+        data: budgetData,
+      });
+      useBudgetDetailActivityOverview.mockReturnValue({
+        isLoading: false,
+        data: mockBudgetDetailActivityOverviewWithSpend,
+      });
+      useBudgetContentAssignments.mockReturnValue({
+        isLoading: false,
+        contentAssignments: { results: [], learnerStateCounts: [] },
+      });
+      useBudgetRedemptions.mockReturnValue({
+        isLoading: false,
+        budgetRedemptions: mockEmptyBudgetRedemptions,
+        fetchBudgetRedemptions: jest.fn(),
+      });
+
+      renderWithRouter(<BudgetDetailPageWrapper />);
+      await waitFor(() => {
+        expect(screen.queryByText('Assign more courses')).not.toBeInTheDocument();
+      });
+    });
   });
 });

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -314,7 +314,6 @@ describe('<BudgetDetailPage />', () => {
       },
     });
 
-    // Add default mocks for hooks that are used in multiple tests
     useBudgetDetailActivityOverview.mockReturnValue({
       isLoading: false,
       data: mockEmptyStateBudgetDetailActivityOverview,


### PR DESCRIPTION
# Description

Ticket: [ENT-10462](https://2u-internal.atlassian.net/browse/ENT-10462)

* Only display the `AssignMoreCoursesEmptyStateMinimal` (if applicable) when the catalog is NOT expired and/or retired.
* If navigating to the Catalog tab's page route directly for an expired and/or retired budget, redirect to the default Activity tab's page route instead.
* Increases the `page_size` for the `enterprise_group` list API to prevent needing to traverse as many paginated API requests to retrieve group memberships.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
