### PR TITLE
feat: add pending amount on learner credit management page for BnR budgets

### DIFF
--- a/src/components/EnterpriseSubsidiesContext/data/hooks.js
+++ b/src/components/EnterpriseSubsidiesContext/data/hooks.js
@@ -77,6 +77,7 @@ async function fetchEnterpriseBudgets({
         pending: result.aggregates.amountAllocatedUsd,
       },
       isAssignable: isAssignableSubsidyAccessPolicyType(result),
+      isBnREnabled: result.bnrEnabled,
       isRetired: result.retired,
       retiredAt: result.retiredAt,
     });

--- a/src/components/learner-credit-management/BudgetCard.jsx
+++ b/src/components/learner-credit-management/BudgetCard.jsx
@@ -25,6 +25,7 @@ const BudgetCard = ({ original }) => {
     enterpriseUUID,
     id,
     isAssignable,
+    isBnREnabled,
     isRetired,
     retiredAt,
     name,
@@ -51,6 +52,7 @@ const BudgetCard = ({ original }) => {
         displayName={name}
         enterpriseSlug={enterpriseSlug}
         isAssignable={isAssignable}
+        isBnREnabled={isBnREnabled}
         isRetired={isRetired}
         retiredAt={retiredAt}
       />
@@ -108,6 +110,7 @@ BudgetCard.propTypes = {
       pending: PropTypes.number,
     }),
     isAssignable: PropTypes.bool,
+    isBnREnabled: PropTypes.bool,
     isRetired: PropTypes.bool,
     retiredAt: PropTypes.string,
     enterpriseUUID: PropTypes.string.isRequired,

--- a/src/components/learner-credit-management/SubBudgetCard.jsx
+++ b/src/components/learner-credit-management/SubBudgetCard.jsx
@@ -67,6 +67,7 @@ const BaseSubBudgetCard = ({
   enablePortalLearnerCreditManagementScreen,
   isLoading,
   isAssignable,
+  isBnREnabled,
   isRetired,
   retiredAt,
 }) => {
@@ -163,6 +164,7 @@ const BaseSubBudgetCard = ({
             <SubBudgetCardUtilization
               isFetchingBudgets={isFetchingBudgets}
               isAssignable={isAssignable}
+              isBnREnabled={isBnREnabled}
               status={status}
               available={available}
               pending={pending}
@@ -189,6 +191,7 @@ BaseSubBudgetCard.propTypes = {
   pending: PropTypes.number,
   displayName: PropTypes.string,
   isAssignable: PropTypes.bool,
+  isBnREnabled: PropTypes.bool,
   isRetired: PropTypes.bool,
   retiredAt: PropTypes.string,
 };

--- a/src/components/learner-credit-management/SubBudgetCardUtilization.jsx
+++ b/src/components/learner-credit-management/SubBudgetCardUtilization.jsx
@@ -7,6 +7,7 @@ import { isBudgetRetiredOrExpired } from './data/utils';
 
 const SubBudgetCardUtilization = ({
   isAssignable,
+  isBnREnabled,
   isFetchingBudgets,
   status,
   available,
@@ -57,6 +58,20 @@ const SubBudgetCardUtilization = ({
               </span>
             </Col>
             )}
+            {isBnREnabled && (
+            <Col xs="6" md="auto" className="mb-3 mb-md-0">
+              <div className="small font-weight-bold">
+                <FormattedMessage
+                  id="lcm.budgets.budget.card.pending"
+                  defaultMessage="Pending"
+                  description="Label for the pending balance on the budget card"
+                />
+              </div>
+              <span className="small">
+                {isFetchingBudgets ? <Skeleton /> : formatPrice(pending)}
+              </span>
+            </Col>
+            )}
           </>
         )}
         <Col xs="6" md="auto" className={classNames('mb-3 mb-md-0', { 'ml-n4.5': isRetiredOrExpired })}>
@@ -82,6 +97,7 @@ const SubBudgetCardUtilization = ({
 
 SubBudgetCardUtilization.propTypes = {
   isAssignable: PropTypes.bool,
+  isBnREnabled: PropTypes.bool,
   isFetchingBudgets: PropTypes.bool.isRequired,
   status: PropTypes.string.isRequired,
   available: PropTypes.number,


### PR DESCRIPTION
**Ticket:** [ENT-10653](https://2u-internal.atlassian.net/browse/ENT-10653)
**Description:** Added Pending amount details on learner credit management page for BnR enabled budgets.

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [x] Ensure to have UX team confirm screenshots

<img width="1670" alt="Screenshot 2025-07-09 at 9 03 24 PM" src="https://github.com/user-attachments/assets/df14eeb5-a207-4048-a404-06baad88e0f8" />

