### PR TITLE
fix: fetch requests based on policyUuid

### DIFF
--- a/src/components/learner-credit-management/data/hooks/tests/useBnrSubsidyRequests.test.jsx
+++ b/src/components/learner-credit-management/data/hooks/tests/useBnrSubsidyRequests.test.jsx
@@ -24,7 +24,15 @@ jest.mock('../../../../../data/services/EnterpriseAccessApiService', () => ({
   fetchBnrSubsidyRequests: jest.fn(),
 }));
 
+jest.mock('../useBudgetId', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    subsidyAccessPolicyId: 'test-policy-id',
+  })),
+}));
+
 const mockEnterpriseId = 'test-enterprise-id';
+const mockPolicyId = 'test-policy-id';
 const mockApiResponse = {
   data: {
     count: 2,
@@ -184,6 +192,7 @@ describe('useBnrSubsidyRequests', () => {
 
       expect(EnterpriseAccessApiService.fetchBnrSubsidyRequests).toHaveBeenCalledWith(
         mockEnterpriseId,
+        mockPolicyId,
         {
           page: 1,
           page_size: 25,
@@ -216,6 +225,7 @@ describe('useBnrSubsidyRequests', () => {
 
       expect(EnterpriseAccessApiService.fetchBnrSubsidyRequests).toHaveBeenCalledWith(
         mockEnterpriseId,
+        mockPolicyId,
         {
           page: 2,
           page_size: undefined,
@@ -244,6 +254,7 @@ describe('useBnrSubsidyRequests', () => {
 
       expect(EnterpriseAccessApiService.fetchBnrSubsidyRequests).toHaveBeenCalledWith(
         mockEnterpriseId,
+        mockPolicyId,
         {
           page: 1,
           page_size: 25,
@@ -273,6 +284,7 @@ describe('useBnrSubsidyRequests', () => {
 
       expect(EnterpriseAccessApiService.fetchBnrSubsidyRequests).toHaveBeenCalledWith(
         mockEnterpriseId,
+        mockPolicyId,
         {
           page: 1,
           page_size: 25,
@@ -402,6 +414,7 @@ describe('useBnrSubsidyRequests', () => {
 
       expect(EnterpriseAccessApiService.fetchBnrSubsidyRequests).toHaveBeenCalledWith(
         mockEnterpriseId,
+        mockPolicyId,
         {
           page: 3,
           page_size: 10,

--- a/src/components/learner-credit-management/data/hooks/useBnrSubsidyRequests.js
+++ b/src/components/learner-credit-management/data/hooks/useBnrSubsidyRequests.js
@@ -7,6 +7,7 @@ import { debounce } from 'lodash-es';
 
 import EnterpriseAccessApiService from '../../../../data/services/EnterpriseAccessApiService';
 import { REQUEST_STATUS_FILTER_CHOICES, REQUEST_TAB_VISIBLE_STATES } from '../constants';
+import useBudgetId from './useBudgetId';
 
 const initialBnrRequestsState = {
   results: [],
@@ -99,6 +100,7 @@ const useBnrSubsidyRequests = ({
   const currentArgsRef = useRef(null);
   const [isLoading, setIsLoading] = useState(true);
   const [bnrRequests, setBnrRequests] = useState(initialBnrRequestsState);
+  const { subsidyAccessPolicyId } = useBudgetId();
 
   const fetchBnrRequests = useCallback(async (args) => {
     if (!isEnabled || !enterpriseId) {
@@ -130,6 +132,7 @@ const useBnrSubsidyRequests = ({
 
       const response = await EnterpriseAccessApiService.fetchBnrSubsidyRequests(
         enterpriseId,
+        subsidyAccessPolicyId,
         options,
       );
       const data = camelCaseObject(response.data);
@@ -149,7 +152,7 @@ const useBnrSubsidyRequests = ({
       logError('Failed to fetch BNR subsidy requests', error);
       setIsLoading(false);
     }
-  }, [isEnabled, enterpriseId]);
+  }, [isEnabled, enterpriseId, subsidyAccessPolicyId]);
 
   const debouncedFetchBnrRequests = useMemo(
     () => debounce(fetchBnrRequests, 300),

--- a/src/components/learner-credit-management/data/tests/utils.test.js
+++ b/src/components/learner-credit-management/data/tests/utils.test.js
@@ -589,6 +589,7 @@ describe('retrieveBudgetDetailActivityOverview', () => {
         isAssignable: true,
         assignmentConfiguration: { uuid: 'config-123' },
         bnrEnabled: true,
+        uuid: 'policy-uuid-123',
       },
       enterpriseUUID: 'enterprise-uuid-123',
       isTopDownAssignmentEnabled: true,
@@ -611,6 +612,7 @@ describe('retrieveBudgetDetailActivityOverview', () => {
     expect(EnterpriseAccessApiService.listContentAssignments).toHaveBeenCalledWith('config-123', {});
     expect(EnterpriseAccessApiService.fetchBnrSubsidyRequests).toHaveBeenCalledWith(
       'enterprise-uuid-123',
+      'policy-uuid-123',
       expect.objectContaining({
         state: 'approved',
       }),

--- a/src/components/learner-credit-management/data/utils.js
+++ b/src/components/learner-credit-management/data/utils.js
@@ -319,8 +319,8 @@ export async function fetchContentAssignments(assignmentConfigurationUUID, optio
  *
  * @returns Camelcased response from the BnR subsidy requests.
  */
-export async function fetchBnrRequest(enterpriseUUID, options = {}) {
-  const response = await EnterpriseAccessApiService.fetchBnrSubsidyRequests(enterpriseUUID, options);
+export async function fetchBnrRequest(enterpriseUUID, policyUuid, options = {}) {
+  const response = await EnterpriseAccessApiService.fetchBnrSubsidyRequests(enterpriseUUID, policyUuid, options);
   return camelCaseObject(response.data);
 }
 
@@ -411,7 +411,7 @@ export async function retrieveBudgetDetailActivityOverview({
     promisesToFulfill.push(fetchContentAssignments(subsidyAccessPolicy.assignmentConfiguration.uuid));
   }
   if (isBnrEnabledSubsidy) {
-    promisesToFulfill.push(fetchBnrRequest(enterpriseUUID, {
+    promisesToFulfill.push(fetchBnrRequest(enterpriseUUID, subsidyAccessPolicy.uuid, {
       state: APPROVED_REQUEST_TYPE,
     }));
   }

--- a/src/data/services/EnterpriseAccessApiService.ts
+++ b/src/data/services/EnterpriseAccessApiService.ts
@@ -319,9 +319,10 @@ class EnterpriseAccessApiService {
    * @param {Object} options - Additional query parameters to filter the requests.
    * @returns {Promise<AxiosResponse>} - A promise that resolves to the API response.
    */
-  static fetchBnrSubsidyRequests(enterpriseUUID, options = {}) {
+  static fetchBnrSubsidyRequests(enterpriseUUID, policyUuid, options = {}) {
     const params = new URLSearchParams({
       enterprise_customer_uuid: enterpriseUUID,
+      policy_uuid: policyUuid,
       ...options,
     });
     const url = `${EnterpriseAccessApiService.baseUrl}/learner-credit-requests/?${params.toString()}`;

--- a/src/data/services/tests/EnterpriseAccessApiService.test.js
+++ b/src/data/services/tests/EnterpriseAccessApiService.test.js
@@ -15,6 +15,7 @@ axios.post = jest.fn();
 axios.patch = jest.fn();
 const enterpriseAccessBaseUrl = `${process.env.ENTERPRISE_ACCESS_BASE_URL}`;
 const mockEnterpriseUUID = 'test-enterprise-id';
+const mockPolicyId = 'test-policy-id';
 const mockLicenseRequestUUID = 'test-license-request-uuid';
 const mockCouponCodeRequestUUID = 'test-coupon-code-request-uuid';
 const mockAssignmentConfigurationUUID = 'test-assignment-configuration-uuid';
@@ -258,10 +259,11 @@ describe('EnterpriseAccessApiService', () => {
     expect(axios.get).toBeCalledWith(`${enterpriseAccessBaseUrl}/api/v1/admin-view/learner_profile/?${queryParams.toString()}`);
   });
   test('fetchBnrSubsidyRequests calls enterprise-access with enterpriseUUID only', () => {
-    EnterpriseAccessApiService.fetchBnrSubsidyRequests(mockEnterpriseUUID);
+    EnterpriseAccessApiService.fetchBnrSubsidyRequests(mockEnterpriseUUID, mockPolicyId);
 
     const expectedParams = new URLSearchParams({
       enterprise_customer_uuid: mockEnterpriseUUID,
+      policy_uuid: mockPolicyId,
     });
 
     expect(axios.get).toBeCalledWith(
@@ -295,10 +297,11 @@ describe('EnterpriseAccessApiService', () => {
       ordering: '-created',
     };
 
-    EnterpriseAccessApiService.fetchBnrSubsidyRequests(mockEnterpriseUUID, options);
+    EnterpriseAccessApiService.fetchBnrSubsidyRequests(mockEnterpriseUUID, mockPolicyId, options);
 
     const expectedParams = new URLSearchParams({
       enterprise_customer_uuid: mockEnterpriseUUID,
+      policy_uuid: mockPolicyId,
       page: '2',
       page_size: '10',
       state: 'requested,declined',


### PR DESCRIPTION
**Description:** Pass the policy uuid to only get requests for a specific policy.

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
