### PR TITLE
feat: add failed redemption chip for approved requests table

### DIFF
--- a/src/components/learner-credit-management/RequestStatusTableCell.jsx
+++ b/src/components/learner-credit-management/RequestStatusTableCell.jsx
@@ -4,8 +4,11 @@ import { Chip } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 import WaitingForLearner from './request-status-chips/WaitingForLearner';
 import FailedCancellation from './request-status-chips/FailedCancellation';
+import FailedRedemption from './request-status-chips/FailedRedemption';
 import { capitalizeFirstLetter } from '../../utils';
-import { REQUEST_RECENT_ACTIONS, useBudgetId, useSubsidyAccessPolicy } from './data';
+import {
+  REQUEST_ERROR_STATES, REQUEST_RECENT_ACTIONS, useBudgetId, useSubsidyAccessPolicy,
+} from './data';
 
 const RequestStatusTableCell = ({ enterpriseId, row }) => {
   const { original } = row;
@@ -40,12 +43,18 @@ const RequestStatusTableCell = ({ enterpriseId, row }) => {
   // Currently we check both `lastActionErrorReason` and `lastActionStatus` which creates
   // confusion since status information comes from two different sources. The API should
   // be updated to return a single, unified status field to simplify this logic.
-  if (lastActionErrorReason === 'failed_cancellation') {
+  if (lastActionErrorReason === REQUEST_ERROR_STATES.failed_cancellation) {
     return (
       <FailedCancellation
         learnerEmail={learnerEmail}
         trackEvent={sendGenericTrackEvent}
       />
+    );
+  }
+
+  if (lastActionErrorReason === REQUEST_ERROR_STATES.failed_redemption) {
+    return (
+      <FailedRedemption trackEvent={sendGenericTrackEvent} />
     );
   }
 

--- a/src/components/learner-credit-management/data/constants.js
+++ b/src/components/learner-credit-management/data/constants.js
@@ -202,3 +202,11 @@ export const REQUEST_ERROR_REASON = {
   failed_redemption: 'Failed: Redemption',
   failed_reversal: 'Failed: Reversal',
 };
+
+export const REQUEST_ERROR_STATES = {
+  failed_approval: 'failed_approval',
+  failed_decline: 'failed_decline',
+  failed_cancellation: 'failed_cancellation',
+  failed_redemption: 'failed_redemption',
+  failed_reversal: 'failed_reversal',
+};

--- a/src/components/learner-credit-management/request-status-chips/FailedRedemption.jsx
+++ b/src/components/learner-credit-management/request-status-chips/FailedRedemption.jsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+import { Chip, Hyperlink } from '@openedx/paragon';
+import { Error } from '@openedx/paragon/icons';
+import { getConfig } from '@edx/frontend-platform/config';
+
+import BaseModalPopup from '../assignments-status-chips/BaseModalPopup';
+import EVENT_NAMES from '../../../eventTracking';
+import { useStatusChip } from '../data';
+
+const FailedRedemption = ({ trackEvent }) => {
+  const [target, setTarget] = useState(null);
+
+  const {
+    BUDGET_DETAILS_REQUEST_DATATABLE_CHIP_FAILED_REDEMPTION,
+    BUDGET_DETAILS_REQUEST_DATATABLE_CHIP_FAILED_REDEMPTION_HELP_CENTER,
+  } = EVENT_NAMES.LEARNER_CREDIT_MANAGEMENT;
+
+  const {
+    openChipModal,
+    closeChipModal,
+    isChipModalOpen,
+    helpCenterTrackEvent,
+  } = useStatusChip({
+    chipInteractionEventName: BUDGET_DETAILS_REQUEST_DATATABLE_CHIP_FAILED_REDEMPTION,
+    chipHelpCenterEventName: BUDGET_DETAILS_REQUEST_DATATABLE_CHIP_FAILED_REDEMPTION_HELP_CENTER,
+    trackEvent,
+  });
+
+  return (
+    <>
+      <Chip
+        ref={setTarget}
+        iconBefore={Error}
+        onClick={openChipModal}
+        onKeyPress={openChipModal}
+        tabIndex={0}
+        variant="dark"
+      >
+        Failed: Redemption
+      </Chip>
+      <BaseModalPopup
+        positionRef={target}
+        isOpen={isChipModalOpen}
+        onClose={closeChipModal}
+        withPortal
+      >
+        <BaseModalPopup.Heading icon={Error} iconClassName="text-danger">
+          Failed: Redemption
+        </BaseModalPopup.Heading>
+        <BaseModalPopup.Content>
+          <p>
+            Something went wrong behind the scenes when the learner attempted to redeem the requested course.
+            Associated Learner credit funds have been released into your available balance.
+          </p>
+          <div className="micro">
+            <p className="h6">Resolution steps</p>
+            <ul className="text-gray pl-3">
+              <li>
+                Confirm that the learner is not registered for this course before they request the course again.
+              </li>
+              <li>
+                If the issue continues, contact customer support.
+              </li>
+              <li>
+                Get more troubleshooting help at{' '}
+                <Hyperlink
+                  destination={getConfig().ENTERPRISE_SUPPORT_LEARNER_CREDIT_URL}
+                  onClick={helpCenterTrackEvent}
+                  target="_blank"
+                >
+                  Help Center
+                </Hyperlink>.
+              </li>
+            </ul>
+          </div>
+        </BaseModalPopup.Content>
+      </BaseModalPopup>
+    </>
+  );
+};
+
+FailedRedemption.propTypes = {
+  trackEvent: PropTypes.func.isRequired,
+};
+
+export default FailedRedemption;

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -1866,6 +1866,83 @@ describe('<BudgetDetailPage />', () => {
     expect(screen.getByText('Help Center')).toBeInTheDocument();
   });
 
+  it('renders failed redemption status chip and handles interactions', async () => {
+    const user = userEvent.setup();
+    const NUMBER_OF_APPROVE_REQUEST_TO_GENERATE = 1;
+    useParams.mockReturnValue({
+      enterpriseSlug: 'test-enterprise-slug',
+      enterpriseAppPage: 'test-enterprise-page',
+      budgetId: mockSubsidyAccessPolicyUUID,
+      activeTabKey: 'activity',
+    });
+    useSubsidyAccessPolicy.mockReturnValue({
+      isInitialLoading: false,
+      data: mockPerLearnerSpendLimitSubsidyAccessPolicyWithBnrEnabled,
+    });
+    useEnterpriseGroupLearners.mockReturnValue({
+      data: {
+        count: 0,
+        currentPage: 1,
+        next: null,
+        numPages: 1,
+        results: [],
+      },
+    });
+    useBudgetDetailActivityOverview.mockReturnValue({
+      isLoading: false,
+      data: {
+        approvedBnrRequests: { count: NUMBER_OF_APPROVE_REQUEST_TO_GENERATE },
+        contentAssignments: undefined,
+        spentTransactions: { count: 0 },
+      },
+    });
+    const mockFetchLearnerCreditRequests = jest.fn();
+
+    const mockFailedRedemptionRequest = {
+      ...mockApprovedRequest,
+      lastActionErrorReason: 'failed_redemption',
+      latestAction: {
+        ...mockApprovedRequest.latestAction,
+        errorReason: 'failed_redemption',
+      },
+    };
+    useBnrSubsidyRequests.mockReturnValue({
+      isLoading: false,
+      bnrRequests: {
+        itemCount: NUMBER_OF_APPROVE_REQUEST_TO_GENERATE,
+        results: [mockFailedRedemptionRequest],
+        pageCount: 1,
+      },
+      fetchBnrRequests: mockFetchLearnerCreditRequests,
+    });
+    useBudgetRedemptions.mockReturnValue({
+      isLoading: false,
+      budgetRedemptions: mockEmptyBudgetRedemptions,
+      fetchBudgetRedemptions: jest.fn(),
+    });
+    useEnterpriseRemovedGroupMembers.mockReturnValue({
+      isRemovedMembersLoading: false,
+      removedGroupMembersCount: 0,
+    });
+
+    renderWithRouter(<BudgetDetailPageWrapper />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Pending')).toBeInTheDocument();
+    });
+
+    const failedRedemptionChip = screen.getByText('Failed: Redemption');
+    expect(failedRedemptionChip).toBeInTheDocument();
+
+    await user.click(failedRedemptionChip);
+
+    await waitFor(() => {
+      expect(screen.getByText('Something went wrong behind the scenes when the learner attempted to redeem the requested course. Associated Learner credit funds have been released into your available balance.')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Help Center')).toBeInTheDocument();
+  });
+
   it('renders request status cells with different statuses', async () => {
     const NUMBER_OF_APPROVE_REQUEST_TO_GENERATE = 3;
     useParams.mockReturnValue({

--- a/src/eventTracking.js
+++ b/src/eventTracking.js
@@ -199,6 +199,7 @@ export const LEARNER_CREDIT_MANAGEMENT_EVENTS = {
   BUDGET_DETAILS_ASSIGNED_DATATABLE_CHIP_GENERIC_ERROR: `${BUDGET_DETAIL_ACTIVITY_TAB_PREFIX}.assigned_table_chip_generic_error.clicked`,
   // Request tab chips
   BUDGET_DETAILS_REQUEST_DATATABLE_CHIP_FAILED_CANCELLATION: `${BUDGET_DETAIL_ACTIVITY_TAB_PREFIX}.request_table_chip_failed_cancellation.clicked`,
+  BUDGET_DETAILS_REQUEST_DATATABLE_CHIP_FAILED_REDEMPTION: `${BUDGET_DETAIL_ACTIVITY_TAB_PREFIX}.request_table_chip_failed_redemption.clicked`,
   BUDGET_DETAILS_REQUEST_DATATABLE_CHIP_WAITING_FOR_LEARNER: `${BUDGET_DETAIL_ACTIVITY_TAB_PREFIX}.request_table_chip_waiting_for_learner.clicked`,
   BUDGET_DETAILS_REQUEST_DATATABLE_CHIP_GENERIC_ERROR: `${BUDGET_DETAIL_ACTIVITY_TAB_PREFIX}.request_table_chip_generic_error.clicked`,
   // Activity tab chips help center links
@@ -212,6 +213,7 @@ export const LEARNER_CREDIT_MANAGEMENT_EVENTS = {
   BUDGET_DETAILS_ASSIGNED_DATATABLE_CHIP_GENERIC_ERROR_HELP_CENTER: `${BUDGET_DETAIL_ACTIVITY_TAB_PREFIX}.assigned_table_chip_generic_error_help_center.clicked`,
   // Request tab chips help center links
   BUDGET_DETAILS_REQUEST_DATATABLE_CHIP_FAILED_CANCELLATION_HELP_CENTER: `${BUDGET_DETAIL_ACTIVITY_TAB_PREFIX}.request_table_chip_failed_cancellation_help_center.clicked`,
+  BUDGET_DETAILS_REQUEST_DATATABLE_CHIP_FAILED_REDEMPTION_HELP_CENTER: `${BUDGET_DETAIL_ACTIVITY_TAB_PREFIX}.request_table_chip_failed_redemption_help_center.clicked`,
   BUDGET_DETAILS_REQUEST_DATATABLE_CHIP_WAITING_FOR_LEARNER_HELP_CENTER: `${BUDGET_DETAIL_ACTIVITY_TAB_PREFIX}.request_table_chip_waiting_for_learner_help_center.clicked`,
   BUDGET_DETAILS_REQUEST_DATATABLE_CHIP_GENERIC_ERROR_HELP_CENTER: `${BUDGET_DETAIL_ACTIVITY_TAB_PREFIX}.request_table_chip_generic_error_help_center.clicked`,
   // Activity tab - Invite Members Modal


### PR DESCRIPTION
**Ticket:** [ENT-10732](https://2u-internal.atlassian.net/browse/ENT-10732)
**Description:** Added a chip component to display failed redemption error status in approved requests table.

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [x] Ensure to have UX team confirm screenshots

<img width="1574" height="558" alt="image" src="https://github.com/user-attachments/assets/cb7cf34b-dfc2-4150-aa89-c4db13da2dc4" />
