### PR TITLE
feat: Added course type filter for Analytics V2

### DIFF
--- a/src/components/AdvanceAnalyticsV2.0/AnalyticsFilters.jsx
+++ b/src/components/AdvanceAnalyticsV2.0/AnalyticsFilters.jsx
@@ -4,12 +4,20 @@ import { Form, IconButton, Icon } from '@openedx/paragon';
 import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import PropTypes from 'prop-types';
 import IconWithTooltip from '../IconWithTooltip';
-import { GRANULARITY, CALCULATION, DATE_RANGE } from './data/constants';
+import {
+  GRANULARITY, CALCULATION, DATE_RANGE, COURSE_TYPES,
+} from './data/constants';
 import { get90DayPriorDate } from './data/utils';
 
 export const DEFAULT_GROUP = '';
 
 const AnalyticsFilters = ({
+  startDate,
+  setStartDate,
+  endDate,
+  setEndDate,
+  courseType,
+  setCourseType,
   granularity,
   setGranularity,
   calculation,
@@ -27,8 +35,6 @@ const AnalyticsFilters = ({
   const [collapsed, setCollapsed] = useState(false);
   const isProgressOrOutcomesTab = activeTab === 'progress' || activeTab === 'outcomes';
   const [dateRangeValue, setDateRangeValue] = useState(DATE_RANGE.LAST_90_DAYS);
-  const [startDate, setStartDate] = useState();
-  const [endDate, setEndDate] = useState();
 
   const handleDateRangeChange = (selectedRange) => {
     setDateRangeValue(selectedRange);
@@ -397,10 +403,32 @@ const AnalyticsFilters = ({
                   <Form.Control
                     controlClassName="font-weight-normal analytics-filter-form-controls rounded-0"
                     as="select"
-                    disabled
-                    value=""
+                    onChange={(e) => setCourseType(e.target.value)}
+                    disabled={isFetching}
+                    defaultValue={COURSE_TYPES.ALL_COURSE_TYPES}
+                    value={courseType}
                   >
-                    <option value="">All course types</option>
+                    <option value={COURSE_TYPES.OPEN_COURSES}>
+                      {intl.formatMessage({
+                        id: 'advance.analytics.course.type.filter.option.open.courses',
+                        defaultMessage: 'Open Courses',
+                        description: 'Option for open courses in course type filter in the admin portal analytics page',
+                      })}
+                    </option>
+                    <option value={COURSE_TYPES.EXECUTIVE_EDUCATION}>
+                      {intl.formatMessage({
+                        id: 'advance.analytics.course.type.filter.option.executive.education',
+                        defaultMessage: 'Executive Education',
+                        description: 'Option for executive education in course type filter in the admin portal analytics page',
+                      })}
+                    </option>
+                    <option value={COURSE_TYPES.ALL_COURSE_TYPES}>
+                      {intl.formatMessage({
+                        id: 'advance.analytics.course.type.filter.option.all.courses',
+                        defaultMessage: 'All Courses',
+                        description: 'Option for all courses in course type filter in the admin portal analytics page',
+                      })}
+                    </option>
                   </Form.Control>
                 </Form.Group>
               </div>
@@ -413,6 +441,12 @@ const AnalyticsFilters = ({
 };
 
 AnalyticsFilters.propTypes = {
+  startDate: PropTypes.string,
+  setStartDate: PropTypes.func.isRequired,
+  endDate: PropTypes.string,
+  setEndDate: PropTypes.func.isRequired,
+  courseType: PropTypes.string,
+  setCourseType: PropTypes.func.isRequired,
   granularity: PropTypes.string.isRequired,
   setGranularity: PropTypes.func.isRequired,
   calculation: PropTypes.string.isRequired,

--- a/src/components/AdvanceAnalyticsV2.0/data/constants.js
+++ b/src/components/AdvanceAnalyticsV2.0/data/constants.js
@@ -121,3 +121,8 @@ export const DATE_RANGE = {
   YEAR_TO_DATE: 'year_to_date',
   CUSTOM: 'custom',
 };
+export const COURSE_TYPES = {
+  OPEN_COURSES: 'OCM',
+  EXECUTIVE_EDUCATION: 'Executive Education',
+  ALL_COURSE_TYPES: 'all_course_types',
+};

--- a/src/components/AdvanceAnalyticsV2.0/data/hooks/useEnterpriseEngagementData.js
+++ b/src/components/AdvanceAnalyticsV2.0/data/hooks/useEnterpriseEngagementData.js
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { cloneDeep } from 'lodash-es';
 
 import { useMemo } from 'react';
-import { ANALYTICS_TABS, generateKey } from '../constants';
+import { ANALYTICS_TABS, generateKey, COURSE_TYPES } from '../constants';
 import { applyGranularity, applyCalculation } from '../utils';
 import EnterpriseDataApiService from '../../../../data/services/EnterpriseDataApiService';
 
@@ -61,9 +61,14 @@ const useEnterpriseEngagementData = ({
   granularity = undefined,
   calculation = undefined,
   groupUUID = undefined,
+  courseType = undefined,
   queryOptions = {},
 }) => {
-  const requestOptions = { startDate, endDate, groupUUID };
+  const requestOptions = courseType === COURSE_TYPES.ALL_COURSE_TYPES
+    ? { startDate, endDate, groupUUID }
+    : {
+      startDate, endDate, groupUUID, courseType,
+    };
   const response = useQuery({
     queryKey: generateKey('engagements', enterpriseCustomerUUID, requestOptions),
     queryFn: () => EnterpriseDataApiService.fetchAdminAnalyticsData(

--- a/src/components/AdvanceAnalyticsV2.0/data/hooks/useEnterpriseEngagementData.test.js
+++ b/src/components/AdvanceAnalyticsV2.0/data/hooks/useEnterpriseEngagementData.test.js
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react';
 import { useQuery } from '@tanstack/react-query';
 import * as utils from '../utils';
 import useEnterpriseEngagementData from './useEnterpriseEngagementData';
-import { generateKey } from '../constants';
+import { generateKey, COURSE_TYPES } from '../constants';
 
 jest.mock('@tanstack/react-query');
 jest.mock('../utils', () => ({
@@ -15,6 +15,7 @@ describe('useEnterpriseEngagementData', () => {
   const enterpriseCustomerUUID = 'enterprise-123';
   const startDate = '2023-01-01';
   const endDate = '2023-01-31';
+  const courseType = COURSE_TYPES.OPEN_COURSES;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -110,5 +111,60 @@ describe('useEnterpriseEngagementData', () => {
     }));
 
     expect(result.current).toEqual(rawResponse);
+  });
+
+  it('calls useQuery with correct parameters for course type', () => {
+    useQuery.mockReturnValue({ data: null, isFetching: false });
+
+    renderHook(() => useEnterpriseEngagementData({
+      enterpriseCustomerUUID,
+      startDate,
+      endDate,
+      courseType,
+    }));
+
+    expect(useQuery).toHaveBeenCalledTimes(1);
+
+    const expectedKey = generateKey('engagements', enterpriseCustomerUUID, {
+      startDate,
+      endDate,
+      groupUUID: undefined,
+      courseType,
+    });
+
+    expect(useQuery).toHaveBeenCalledWith(expect.objectContaining({
+      queryKey: expectedKey,
+      queryFn: expect.any(Function),
+      staleTime: 0.5 * 60 * 60 * 1000,
+      cacheTime: 0.75 * 60 * 60 * 1000,
+      keepPreviousData: true,
+    }));
+  });
+
+  it('calls useQuery with correct parameters when courseType is ALL_COURSE_TYPES', () => {
+    useQuery.mockReturnValue({ data: null, isFetching: false });
+
+    renderHook(() => useEnterpriseEngagementData({
+      enterpriseCustomerUUID,
+      startDate,
+      endDate,
+      courseType: COURSE_TYPES.ALL_COURSE_TYPES,
+    }));
+
+    expect(useQuery).toHaveBeenCalledTimes(1);
+
+    const expectedKey = generateKey('engagements', enterpriseCustomerUUID, {
+      startDate,
+      endDate,
+      groupUUID: undefined,
+    });
+
+    expect(useQuery).toHaveBeenCalledWith(expect.objectContaining({
+      queryKey: expectedKey,
+      queryFn: expect.any(Function),
+      staleTime: 0.5 * 60 * 60 * 1000,
+      cacheTime: 0.75 * 60 * 60 * 1000,
+      keepPreviousData: true,
+    }));
   });
 });

--- a/src/components/AdvanceAnalyticsV2.0/tabs/Engagements.jsx
+++ b/src/components/AdvanceAnalyticsV2.0/tabs/Engagements.jsx
@@ -1,7 +1,9 @@
+import { useState } from 'react';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import PropTypes from 'prop-types';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { ANALYTICS_TABS } from '../constants';
+import { COURSE_TYPES } from '../data/constants';
 import {
   useEnterpriseEngagementData,
   useEnterpriseAnalyticsAggregatesData,
@@ -21,14 +23,11 @@ import TopCoursesByLearningHoursTable from '../tables/TopCoursesByLearningHoursT
 import TopSubjectsByEnrollmentTable from '../tables/TopSubjectsByEnrollmentTable';
 import TopSubjectsByLearningHoursTable from '../tables/TopSubjectsByLearningHoursTable';
 import EVENT_NAMES from '../../../eventTracking';
+import { get90DayPriorDate } from '../data/utils';
 
 const Engagements = ({ enterpriseId }) => {
   // Filters
   const {
-    startDate,
-    setStartDate,
-    endDate,
-    setEndDate,
     granularity,
     setGranularity,
     calculation,
@@ -39,6 +38,10 @@ const Engagements = ({ enterpriseId }) => {
     groups,
     isGroupsLoading,
   } = useAnalyticsFilters();
+
+  const [startDate, setStartDate] = useState(get90DayPriorDate());
+  const [endDate, setEndDate] = useState(currentDate);
+  const [courseType, setCourseType] = useState(COURSE_TYPES.ALL_COURSE_TYPES);
 
   // Stats Data
   const { isFetching: isStatsFetching, isError: isStatsError, data: statsData } = useEnterpriseAnalyticsAggregatesData({
@@ -68,6 +71,7 @@ const Engagements = ({ enterpriseId }) => {
     granularity,
     calculation,
     groupUUID,
+    courseType,
   });
 
   // Enrollments Data
@@ -118,6 +122,8 @@ const Engagements = ({ enterpriseId }) => {
           setStartDate={setStartDate}
           endDate={endDate}
           setEndDate={setEndDate}
+          courseType={courseType}
+          setCourseType={setCourseType}
           granularity={granularity}
           setGranularity={setGranularity}
           calculation={calculation}

--- a/src/components/AdvanceAnalyticsV2.0/tabs/Outcomes.jsx
+++ b/src/components/AdvanceAnalyticsV2.0/tabs/Outcomes.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import PropTypes from 'prop-types';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
@@ -14,14 +15,11 @@ import TopSkillsChart from '../charts/TopSkillsChart';
 import CompletionsOverTimeChart from '../charts/CompletionsOverTimeChart';
 import TopSkillsByCompletionChart from '../charts/TopSkillsByCompletionChart';
 import EVENT_NAMES from '../../../eventTracking';
+import { get90DayPriorDate } from '../data/utils';
 
 const Outcomes = ({ enterpriseId }) => {
   // Filters
   const {
-    startDate,
-    setStartDate,
-    endDate,
-    setEndDate,
     granularity,
     setGranularity,
     calculation,
@@ -32,6 +30,9 @@ const Outcomes = ({ enterpriseId }) => {
     groups,
     isGroupsLoading,
   } = useAnalyticsFilters();
+
+  const [startDate, setStartDate] = useState(get90DayPriorDate());
+  const [endDate, setEndDate] = useState(currentDate);
 
   // Stats Data
   const { isFetching: isStatsFetching, isError: isStatsError, data: statsData } = useEnterpriseAnalyticsAggregatesData({

--- a/src/components/AdvanceAnalyticsV2.0/tabs/Progress.jsx
+++ b/src/components/AdvanceAnalyticsV2.0/tabs/Progress.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import PropTypes from 'prop-types';
 import { ANALYTICS_TABS } from '../constants';
@@ -7,14 +8,11 @@ import { useAnalyticsFilters } from '../AnalyticsFiltersContext';
 import TopCoursesByCompletionTable from '../tables/TopCoursesByCompletionTable';
 import TopSubjectsByCompletionTable from '../tables/TopSubjectsByCompletionTable';
 import IndividualCompletionsTable from '../tables/IndividualCompletionsTable';
+import { get90DayPriorDate } from '../data/utils';
 
 const Progress = ({ enterpriseId }) => {
   // Filters
   const {
-    startDate,
-    setStartDate,
-    endDate,
-    setEndDate,
     granularity,
     setGranularity,
     calculation,
@@ -26,6 +24,8 @@ const Progress = ({ enterpriseId }) => {
     isGroupsLoading,
   } = useAnalyticsFilters();
 
+  const [startDate, setStartDate] = useState(get90DayPriorDate());
+  const [endDate, setEndDate] = useState(currentDate);
   // Stats Data
   const { data: statsData } = useEnterpriseAnalyticsAggregatesData({
     enterpriseCustomerUUID: enterpriseId,


### PR DESCRIPTION
**Description**: This PR wires the courseType (OCM or EE) to the backend service call and also enables the dropdown for the AnalyticsV2. Some fixes related to start and end dates state management within the respective tabs are also included.

**JIRA**: [ENT-10718](https://2u-internal.atlassian.net/browse/ENT-10718)

**Screenshots**
<img width="1415" height="843" alt="image" src="https://github.com/user-attachments/assets/b014c262-fad0-4a62-866e-3d9ad90b72b8" />

<img width="1518" height="951" alt="image" src="https://github.com/user-attachments/assets/080820f0-338d-4412-9355-f3eed336e9e2" />


# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
