### PR TITLE
Replacement of injectIntl with useIntl part 1

### DIFF
--- a/src/components/Admin/Admin.test.jsx
+++ b/src/components/Admin/Admin.test.jsx
@@ -163,7 +163,7 @@ describe('<Admin />', () => {
           />
         ))
         .toJSON();
-      expect(mockFetchDashboardAnalytics).toHaveBeenCalled();
+      waitFor(() => expect(mockFetchDashboardAnalytics).toHaveBeenCalled());
       expect(tree).toMatchSnapshot();
     });
 

--- a/src/components/Admin/AdminCards.jsx
+++ b/src/components/Admin/AdminCards.jsx
@@ -1,106 +1,108 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import {
   Award, Check, Groups, RemoveRedEye,
 } from '@openedx/paragon/icons';
 
 import NumberCard from '../NumberCard';
 
-class AdminCards extends React.Component {
-  constructor(props) {
-    super(props);
-    const { intl } = this.props;
+const AdminCards = ({
+  activeLearners,
+  numberOfUsers,
+  courseCompletions,
+  enrolledLearners,
+}) => {
+  const intl = useIntl();
 
-    this.cards = {
-      numberOfUsers: {
-        ref: React.createRef(),
-        description: intl.formatMessage({
-          id: 'adminPortal.cards.registeredLearners',
-          defaultMessage: 'total number of learners registered',
+  const cards = {
+    numberOfUsers: {
+      ref: React.createRef(),
+      description: intl.formatMessage({
+        id: 'adminPortal.cards.registeredLearners',
+        defaultMessage: 'total number of learners registered',
+      }),
+      icon: Groups,
+      actions: [{
+        label: intl.formatMessage({
+          id: 'adminPortal.cards.registeredUnenrolledLearners',
+          defaultMessage: 'Which learners are registered but not yet enrolled in any courses?',
         }),
-        icon: Groups,
-        actions: [{
-          label: intl.formatMessage({
-            id: 'adminPortal.cards.registeredUnenrolledLearners',
-            defaultMessage: 'Which learners are registered but not yet enrolled in any courses?',
-          }),
-          slug: 'registered-unenrolled-learners',
-        }],
-      },
-      enrolledLearners: {
-        id: 'enrolled-learners',
-        ref: React.createRef(),
-        description: intl.formatMessage({
-          id: 'adminPortal.cards.enrolledOneCourse',
-          defaultMessage: 'learners enrolled in at least one course',
+        slug: 'registered-unenrolled-learners',
+      }],
+    },
+    enrolledLearners: {
+      id: 'enrolled-learners',
+      ref: React.createRef(),
+      description: intl.formatMessage({
+        id: 'adminPortal.cards.enrolledOneCourse',
+        defaultMessage: 'learners enrolled in at least one course',
+      }),
+      icon: Check,
+      actions: [{
+        label: intl.formatMessage({
+          id: 'adminPortal.cards.enrolledLearners',
+          defaultMessage: 'How many courses are learners enrolled in?',
         }),
-        icon: Check,
-        actions: [{
-          label: intl.formatMessage({
-            id: 'adminPortal.cards.enrolledLearners',
-            defaultMessage: 'How many courses are learners enrolled in?',
-          }),
-          slug: 'enrolled-learners',
-        }, {
-          label: intl.formatMessage({
-            id: 'adminPortal.cards.enrolledLearnersInactiveCourses',
-            defaultMessage: 'Who is no longer enrolled in a current course?',
-          }),
-          slug: 'enrolled-learners-inactive-courses',
-        }],
-      },
-      activeLearners: {
-        ref: React.createRef(),
-        description: intl.formatMessage({
-          id: 'adminPortal.cards.activeLearnersPastWeek',
-          defaultMessage: 'active learners in the past week',
+        slug: 'enrolled-learners',
+      }, {
+        label: intl.formatMessage({
+          id: 'adminPortal.cards.enrolledLearnersInactiveCourses',
+          defaultMessage: 'Who is no longer enrolled in a current course?',
         }),
-        icon: RemoveRedEye,
-        actions: [{
-          label: intl.formatMessage({
-            id: 'adminPortal.cards.learnersActiveWeek',
-            defaultMessage: 'Who are my top active learners?',
-          }),
-          slug: 'learners-active-week',
-        }, {
-          label: intl.formatMessage({
-            id: 'adminPortal.cards.learnersInactiveWeek',
-            defaultMessage: 'Who has not been active for over a week?',
-          }),
-          slug: 'learners-inactive-week',
-        }, {
-          label: intl.formatMessage({
-            id: 'adminPortal.cards.learnersInactiveMonth',
-            defaultMessage: 'Who has not been active for over a month?',
-          }),
-          slug: 'learners-inactive-month',
-        }],
-      },
-      courseCompletions: {
-        ref: React.createRef(),
-        description: 'course completions',
-        icon: Award,
-        actions: [{
-          label: intl.formatMessage({
-            id: 'adminPortal.cards.completedLearners',
-            defaultMessage: 'How many courses have been completed by learners?',
-          }),
-          slug: 'completed-learners',
-        }, {
-          label: intl.formatMessage({
-            id: 'adminPortal.cards.completedLearnersWeek',
-            defaultMessage: 'Who completed a course in the past week?',
-          }),
-          slug: 'completed-learners-week',
-        }],
-      },
-    };
-  }
+        slug: 'enrolled-learners-inactive-courses',
+      }],
+    },
+    activeLearners: {
+      ref: React.createRef(),
+      description: intl.formatMessage({
+        id: 'adminPortal.cards.activeLearnersPastWeek',
+        defaultMessage: 'active learners in the past week',
+      }),
+      icon: RemoveRedEye,
+      actions: [{
+        label: intl.formatMessage({
+          id: 'adminPortal.cards.learnersActiveWeek',
+          defaultMessage: 'Who are my top active learners?',
+        }),
+        slug: 'learners-active-week',
+      }, {
+        label: intl.formatMessage({
+          id: 'adminPortal.cards.learnersInactiveWeek',
+          defaultMessage: 'Who has not been active for over a week?',
+        }),
+        slug: 'learners-inactive-week',
+      }, {
+        label: intl.formatMessage({
+          id: 'adminPortal.cards.learnersInactiveMonth',
+          defaultMessage: 'Who has not been active for over a month?',
+        }),
+        slug: 'learners-inactive-month',
+      }],
+    },
+    courseCompletions: {
+      ref: React.createRef(),
+      description: 'course completions',
+      icon: Award,
+      actions: [{
+        label: intl.formatMessage({
+          id: 'adminPortal.cards.completedLearners',
+          defaultMessage: 'How many courses have been completed by learners?',
+        }),
+        slug: 'completed-learners',
+      }, {
+        label: intl.formatMessage({
+          id: 'adminPortal.cards.completedLearnersWeek',
+          defaultMessage: 'Who completed a course in the past week?',
+        }),
+        slug: 'completed-learners-week',
+      }],
+    },
+  };
 
-  renderCard({ title, cardKey }) {
-    const card = this.cards[cardKey];
+  const renderCard = ({ title, cardKey }) => {
+    const card = cards[cardKey];
 
     return (
       <div
@@ -117,31 +119,22 @@ class AdminCards extends React.Component {
         />
       </div>
     );
-  }
+  };
 
-  render() {
-    const {
-      activeLearners,
-      numberOfUsers,
-      courseCompletions,
-      enrolledLearners,
-    } = this.props;
+  const data = {
+    activeLearners: activeLearners.past_week,
+    numberOfUsers,
+    courseCompletions,
+    enrolledLearners,
+  };
 
-    const data = {
-      activeLearners: activeLearners.past_week,
-      numberOfUsers,
-      courseCompletions,
-      enrolledLearners,
-    };
-
-    return Object.keys(this.cards).map(cardKey => (
-      this.renderCard({
-        title: data[cardKey],
-        cardKey,
-      })
-    ));
-  }
-}
+  return Object.keys(cards).map(cardKey => (
+    renderCard({
+      title: data[cardKey],
+      cardKey,
+    })
+  ));
+};
 
 AdminCards.propTypes = {
   activeLearners: PropTypes.shape({
@@ -151,8 +144,6 @@ AdminCards.propTypes = {
   numberOfUsers: PropTypes.number.isRequired,
   courseCompletions: PropTypes.number.isRequired,
   enrolledLearners: PropTypes.number.isRequired,
-  // injected
-  intl: intlShape.isRequired,
 };
 
-export default injectIntl(AdminCards);
+export default AdminCards;

--- a/src/components/Admin/AdminSearchForm.jsx
+++ b/src/components/Admin/AdminSearchForm.jsx
@@ -1,12 +1,12 @@
 /* eslint-disable camelcase */
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { Form } from '@openedx/paragon';
 import { Info } from '@openedx/paragon/icons';
 
-import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
 import SearchBar from '../SearchBar';
@@ -15,36 +15,25 @@ import IconWithTooltip from '../IconWithTooltip';
 import { withLocation, withNavigate } from '../../hoc';
 import EVENT_NAMES from '../../eventTracking';
 
-class AdminSearchForm extends React.Component {
-  componentDidUpdate(prevProps) {
-    const {
-      searchParams: {
-        searchQuery, searchCourseQuery, searchDateQuery, searchBudgetQuery, searchGroupQuery,
-      },
-    } = this.props;
-    const {
-      searchParams: {
-        searchQuery: prevSearchQuery,
-        searchCourseQuery: prevSearchCourseQuery,
-        searchDateQuery: prevSearchDateQuery,
-        searchBudgetQuery: prevSearchBudgetQuery,
-        searchGroupQuery: prevSearchGroupQuery,
-      },
-    } = prevProps;
+const AdminSearchForm = ({
+  searchEnrollmentsList,
+  searchParams: {
+    searchQuery, searchCourseQuery, searchDateQuery, searchBudgetQuery, searchGroupQuery,
+  },
+  tableData = [],
+  budgets,
+  groups,
+  navigate,
+  location,
+  enterpriseId,
+}) => {
+  const intl = useIntl();
 
-    if (searchQuery !== prevSearchQuery || searchCourseQuery !== prevSearchCourseQuery
-        || searchDateQuery !== prevSearchDateQuery || searchBudgetQuery !== prevSearchBudgetQuery
-        || searchGroupQuery !== prevSearchGroupQuery) {
-      this.handleSearch();
-    }
-  }
+  useEffect(() => {
+    searchEnrollmentsList();
+  }, [searchEnrollmentsList]);
 
-  handleSearch() {
-    this.props.searchEnrollmentsList();
-  }
-
-  onCourseSelect(event) {
-    const { navigate, location } = this.props;
+  const onCourseSelect = (event) => {
     const updateParams = {
       search_course: event.target.value,
       page: 1,
@@ -53,248 +42,234 @@ class AdminSearchForm extends React.Component {
       updateParams.search_start_date = '';
     }
     updateUrl(navigate, location.pathname, updateParams);
-  }
+  };
 
-  onBudgetSelect(event) {
-    const { navigate, location } = this.props;
+  const onBudgetSelect = (event) => {
     const updateParams = {
       budget_uuid: event.target.value,
       page: 1,
     };
     updateUrl(navigate, location.pathname, updateParams);
-  }
+  };
 
-  onGroupSelect(event) {
-    const { navigate, location } = this.props;
+  const onGroupSelect = (event) => {
     const updateParams = {
       group_uuid: event.target.value,
       page: 1,
     };
     updateUrl(navigate, location.pathname, updateParams);
     sendEnterpriseTrackEvent(
-      this.props.enterpriseId,
+      enterpriseId,
       EVENT_NAMES.LEARNER_PROGRESS_REPORT.FILTER_BY_GROUP_DROPDOWN,
       { group: event.target.value },
     );
-  }
+  };
 
-  render() {
-    const {
-      intl,
-      tableData,
-      budgets,
-      groups,
-      searchParams: {
-        searchCourseQuery, searchDateQuery, searchQuery, searchBudgetQuery, searchGroupQuery,
-      },
-    } = this.props;
+  const courseTitles = Array.from(new Set(tableData.map(en => en.course_title).sort()));
+  const courseDates = Array.from(new Set(tableData.map(en => en.course_start_date).sort().reverse()));
+  const columnWidth = (budgets?.length || groups?.length) ? 'col-md-3' : 'col-md-6';
 
-    const courseTitles = Array.from(new Set(tableData.map(en => en.course_title).sort()));
-    const courseDates = Array.from(new Set(tableData.map(en => en.course_start_date).sort().reverse()));
-    const columnWidth = (budgets?.length || groups?.length) ? 'col-md-3' : 'col-md-6';
-
-    return (
-      <div className="row">
-        <div className="col-12 pr-md-0 mb-0">
-          <div className="row w-100 m-0">
-            {groups?.length ? (
-              <div data-testid="form-control-group-filter" className="col-12 col-md-3 my-2 my-md-0 px-0 px-md-2 px-lg-3">
-                <Form.Group>
-                  <Form.Label className="search-label mb-2">
-                    <FormattedMessage
-                      id="admin.portal.lpr.filter.by.group.dropdown.label"
-                      defaultMessage="Filter by group"
-                      description="Label for the group filter dropdown in the admin portal LPR page."
-                    />
-                  </Form.Label>
-                  <Form.Control
-                    className="w-100 groups-dropdown"
-                    as="select"
-                    value={searchGroupQuery}
-                    onChange={e => this.onGroupSelect(e)}
-                  >
-                    <option value="">
-                      {intl.formatMessage({
-                        id: 'admin.portal.lpr.filter.by.group.dropdown.option.all.groups',
-                        defaultMessage: 'All Groups',
-                        description: 'Label for the all groups option in the group filter dropdown in the admin portal LPR page.',
-                      })}
-                    </option>
-                    {groups.map(group => (
-                      <option
-                        value={group.uuid}
-                        key={group.uuid}
-                      >
-                        {group.name}
-                      </option>
-                    ))}
-                  </Form.Control>
-                </Form.Group>
-              </div>
-            ) : null}
-            <div className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3">
+  return (
+    <div className="row">
+      <div className="col-12 pr-md-0 mb-0">
+        <div className="row w-100 m-0">
+          {groups?.length ? (
+            <div data-testid="form-control-group-filter" className="col-12 col-md-3 my-2 my-md-0 px-0 px-md-2 px-lg-3">
               <Form.Group>
                 <Form.Label className="search-label mb-2">
                   <FormattedMessage
-                    id="admin.portal.lpr.filter.by.course.dropdown.label"
-                    defaultMessage="Filter by course"
-                    description="Label for the course filter dropdown in the admin portal LPR page."
+                    id="admin.portal.lpr.filter.by.group.dropdown.label"
+                    defaultMessage="Filter by group"
+                    description="Label for the group filter dropdown in the admin portal LPR page."
                   />
                 </Form.Label>
                 <Form.Control
-                  data-testid="form-control-course-filter"
-                  className="w-100"
+                  className="w-100 groups-dropdown"
                   as="select"
-                  value={searchCourseQuery}
-                  onChange={e => this.onCourseSelect(e)}
+                  value={searchGroupQuery}
+                  onChange={e => onGroupSelect(e)}
                 >
                   <option value="">
                     {intl.formatMessage({
-                      id: 'admin.portal.lpr.filter.by.course.dropdown.option.all.courses',
-                      defaultMessage: 'All Courses',
-                      description: 'Label for the all courses option in the course filter dropdown in the admin portal LPR page.',
+                      id: 'admin.portal.lpr.filter.by.group.dropdown.option.all.groups',
+                      defaultMessage: 'All Groups',
+                      description: 'Label for the all groups option in the group filter dropdown in the admin portal LPR page.',
                     })}
                   </option>
-                  {courseTitles.map(title => (
+                  {groups.map(group => (
                     <option
-                      value={title}
-                      key={title}
+                      value={group.uuid}
+                      key={group.uuid}
                     >
-                      {title}
+                      {group.name}
                     </option>
                   ))}
                 </Form.Control>
               </Form.Group>
             </div>
-            <div className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3">
+          ) : null}
+          <div className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3">
+            <Form.Group>
+              <Form.Label className="search-label mb-2">
+                <FormattedMessage
+                  id="admin.portal.lpr.filter.by.course.dropdown.label"
+                  defaultMessage="Filter by course"
+                  description="Label for the course filter dropdown in the admin portal LPR page."
+                />
+              </Form.Label>
+              <Form.Control
+                data-testid="form-control-course-filter"
+                className="w-100"
+                as="select"
+                value={searchCourseQuery}
+                onChange={e => onCourseSelect(e)}
+              >
+                <option value="">
+                  {intl.formatMessage({
+                    id: 'admin.portal.lpr.filter.by.course.dropdown.option.all.courses',
+                    defaultMessage: 'All Courses',
+                    description: 'Label for the all courses option in the course filter dropdown in the admin portal LPR page.',
+                  })}
+                </option>
+                {courseTitles.map(title => (
+                  <option
+                    value={title}
+                    key={title}
+                  >
+                    {title}
+                  </option>
+                ))}
+              </Form.Control>
+            </Form.Group>
+          </div>
+          <div className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3">
+            <Form.Group>
+              <Form.Label className="search-label mb-2 d-flex align-items-center">
+                <span>
+                  <FormattedMessage
+                    id="admin.portal.lpr.filter.by.start.date.dropdown.label"
+                    defaultMessage="Filter by start date"
+                    description="Label for the start date filter dropdown in the admin portal LPR page."
+                  />
+                </span>
+                <IconWithTooltip
+                  icon={Info}
+                  altText={intl.formatMessage({
+                    id: 'admin.portal.lpr.filter.by.start.date.alt.text',
+                    defaultMessage: 'More information',
+                    description: 'Alt text for the info icon in the start date filter dropdown in the admin portal LPR page.',
+                  })}
+                  tooltipText={intl.formatMessage({
+                    id: 'admin.portal.lpr.filter.by.start.date.dropdown.tooltip',
+                    defaultMessage: 'A start date can be selected after the course name is selected.',
+                    description: 'Tooltip text for the start date filter dropdown in the admin portal LPR page.',
+                  })}
+                />
+              </Form.Label>
+              <Form.Control
+                data-testid="form-control-date-filter"
+                as="select"
+                className="w-100"
+                value={searchDateQuery}
+                onChange={event => updateUrl(navigate, location.pathname, {
+                  search_start_date: event.target.value,
+                  page: 1,
+                })}
+                disabled={!searchCourseQuery}
+              >
+                <option value="">
+                  {searchCourseQuery ? intl.formatMessage({
+                    id: 'admin.portal.lpr.filter.by.start.date.dropdown.option.all.dates',
+                    defaultMessage: 'All Dates',
+                    description: 'Label for the all dates option in the start date filter dropdown in the admin portal LPR page.',
+                  }) : intl.formatMessage({
+                    id: 'admin.portal.lpr.filter.by.start.date.dropdown.option.choose.course',
+                    defaultMessage: 'Choose a course',
+                    description: 'Label for the Choose a course option in the start date filter dropdown in the admin portal LPR page.',
+                  })}
+                </option>
+                {searchCourseQuery && courseDates.map(date => (
+                  <option
+                    value={date}
+                    key={date}
+                  >
+                    {intl.formatDate(formatTimestamp({ timestamp: date }), {
+                      year: 'numeric',
+                      month: 'long',
+                      day: 'numeric',
+                    })}
+                  </option>
+                ))}
+              </Form.Control>
+            </Form.Group>
+          </div>
+          {budgets?.length ? (
+            <div className="col-12 col-md-3 my-2 my-md-0 px-0 px-md-2 px-lg-3">
               <Form.Group>
-                <Form.Label className="search-label mb-2 d-flex align-items-center">
-                  <span>
-                    <FormattedMessage
-                      id="admin.portal.lpr.filter.by.start.date.dropdown.label"
-                      defaultMessage="Filter by start date"
-                      description="Label for the start date filter dropdown in the admin portal LPR page."
-                    />
-                  </span>
-                  <IconWithTooltip
-                    icon={Info}
-                    altText={intl.formatMessage({
-                      id: 'admin.portal.lpr.filter.by.start.date.alt.text',
-                      defaultMessage: 'More information',
-                      description: 'Alt text for the info icon in the start date filter dropdown in the admin portal LPR page.',
-                    })}
-                    tooltipText={intl.formatMessage({
-                      id: 'admin.portal.lpr.filter.by.start.date.dropdown.tooltip',
-                      defaultMessage: 'A start date can be selected after the course name is selected.',
-                      description: 'Tooltip text for the start date filter dropdown in the admin portal LPR page.',
-                    })}
+                <Form.Label className="search-label mb-2">
+                  <FormattedMessage
+                    id="admin.portal.lpr.filter.by.budget.dropdown.label"
+                    defaultMessage="Filter by budget"
+                    description="Label for the budget filter dropdown in the admin portal LPR page."
                   />
                 </Form.Label>
                 <Form.Control
-                  data-testid="form-control-date-filter"
+                  data-testid="form-control-budget-filter"
+                  className="w-100 budgets-dropdown"
                   as="select"
-                  className="w-100"
-                  value={searchDateQuery}
-                  onChange={event => updateUrl(this.props.navigate, this.props.location.pathname, {
-                    search_start_date: event.target.value,
-                    page: 1,
-                  })}
-                  disabled={!searchCourseQuery}
+                  value={searchBudgetQuery}
+                  onChange={e => onBudgetSelect(e)}
                 >
                   <option value="">
-                    {searchCourseQuery ? intl.formatMessage({
-                      id: 'admin.portal.lpr.filter.by.start.date.dropdown.option.all.dates',
-                      defaultMessage: 'All Dates',
-                      description: 'Label for the all dates option in the start date filter dropdown in the admin portal LPR page.',
-                    }) : intl.formatMessage({
-                      id: 'admin.portal.lpr.filter.by.start.date.dropdown.option.choose.course',
-                      defaultMessage: 'Choose a course',
-                      description: 'Label for the Choose a course option in the start date filter dropdown in the admin portal LPR page.',
+                    {intl.formatMessage({
+                      id: 'admin.portal.lpr.filter.by.budget.dropdown.option.all.budgets',
+                      defaultMessage: 'All budgets',
+                      description: 'Label for the all budgets option in the budget filter dropdown in the admin portal LPR page.',
                     })}
                   </option>
-                  {searchCourseQuery && courseDates.map(date => (
+                  {budgets.map(budget => (
                     <option
-                      value={date}
-                      key={date}
+                      value={budget.subsidy_access_policy_uuid}
+                      key={budget.subsidy_access_policy_uuid}
                     >
-                      {intl.formatDate(formatTimestamp({ timestamp: date }), {
-                        year: 'numeric',
-                        month: 'long',
-                        day: 'numeric',
-                      })}
+                      {budget.subsidy_access_policy_display_name}
                     </option>
                   ))}
                 </Form.Control>
               </Form.Group>
             </div>
-            {budgets?.length ? (
-              <div className="col-12 col-md-3 my-2 my-md-0 px-0 px-md-2 px-lg-3">
-                <Form.Group>
-                  <Form.Label className="search-label mb-2">
-                    <FormattedMessage
-                      id="admin.portal.lpr.filter.by.budget.dropdown.label"
-                      defaultMessage="Filter by budget"
-                      description="Label for the budget filter dropdown in the admin portal LPR page."
-                    />
-                  </Form.Label>
-                  <Form.Control
-                    data-testid="form-control-budget-filter"
-                    className="w-100 budgets-dropdown"
-                    as="select"
-                    value={searchBudgetQuery}
-                    onChange={e => this.onBudgetSelect(e)}
-                  >
-                    <option value="">
-                      {intl.formatMessage({
-                        id: 'admin.portal.lpr.filter.by.budget.dropdown.option.all.budgets',
-                        defaultMessage: 'All budgets',
-                        description: 'Label for the all budgets option in the budget filter dropdown in the admin portal LPR page.',
-                      })}
-                    </option>
-                    {budgets.map(budget => (
-                      <option
-                        value={budget.subsidy_access_policy_uuid}
-                        key={budget.subsidy_access_policy_uuid}
-                      >
-                        {budget.subsidy_access_policy_display_name}
-                      </option>
-                    ))}
-                  </Form.Control>
-                </Form.Group>
-              </div>
-            ) : null }
-            <div className={classNames('col-12 my-2 my-md-0 px-0 px-md-2 px-lg-3', columnWidth)}>
-              <Form.Label id="search-email-label" className="mb-2">
-                <FormattedMessage
-                  id="admin.portal.lpr.filter.by.email.input.label"
-                  defaultMessage="Filter by email"
-                  description="Label for the email filter dropdown in the admin portal LPR page"
-                />
-              </Form.Label>
-              <SearchBar
-                data-testid="admin-form-search-bar"
-                placeholder={intl.formatMessage({
-                  id: 'admin.portal.lpr.filter.by.email.input.placeholder',
-                  defaultMessage: 'Search by email...',
-                  description: 'Placeholder text for the email filter input in the admin portal LPR page.',
-                })}
-                onSearch={query => updateUrl(this.props.navigate, this.props.location.pathname, {
-                  search: query,
-                  page: 1,
-                })}
-                onClear={() => updateUrl(this.props.navigate, this.props.location.pathname, { search: undefined })}
-                value={searchQuery}
-                aria-labelledby="search-email-label"
-                className="py-0"
-                inputProps={{ 'data-hj-suppress': true }}
+          ) : null }
+          <div className={classNames('col-12 my-2 my-md-0 px-0 px-md-2 px-lg-3', columnWidth)}>
+            <Form.Label id="search-email-label" className="mb-2">
+              <FormattedMessage
+                id="admin.portal.lpr.filter.by.email.input.label"
+                defaultMessage="Filter by email"
+                description="Label for the email filter dropdown in the admin portal LPR page"
               />
-            </div>
+            </Form.Label>
+            <SearchBar
+              data-testid="admin-form-search-bar"
+              placeholder={intl.formatMessage({
+                id: 'admin.portal.lpr.filter.by.email.input.placeholder',
+                defaultMessage: 'Search by email...',
+                description: 'Placeholder text for the email filter input in the admin portal LPR page.',
+              })}
+              onSearch={query => updateUrl(navigate, location.pathname, {
+                search: query,
+                page: 1,
+              })}
+              onClear={() => updateUrl(navigate, location.pathname, { search: undefined })}
+              value={searchQuery}
+              aria-labelledby="search-email-label"
+              className="py-0"
+              inputProps={{ 'data-hj-suppress': true }}
+            />
           </div>
         </div>
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
 
 AdminSearchForm.defaultProps = {
   tableData: [],
@@ -317,8 +292,6 @@ AdminSearchForm.propTypes = {
     pathname: PropTypes.string,
   }),
   enterpriseId: PropTypes.string,
-  // injected
-  intl: intlShape.isRequired,
 };
 
-export default withLocation(withNavigate(injectIntl(AdminSearchForm)));
+export default withLocation(withNavigate(AdminSearchForm));

--- a/src/components/Admin/__snapshots__/Admin.test.jsx.snap
+++ b/src/components/Admin/__snapshots__/Admin.test.jsx.snap
@@ -1047,7 +1047,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # cou
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field21"
+                              htmlFor="form-field19"
                             >
                               Filter by group
                             </label>
@@ -1056,7 +1056,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # cou
                             >
                               <select
                                 className="form-control"
-                                id="form-field21"
+                                id="form-field19"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -1079,7 +1079,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # cou
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field22"
+                              htmlFor="form-field20"
                             >
                               Filter by course
                             </label>
@@ -1089,7 +1089,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # cou
                               <select
                                 className="form-control"
                                 data-testid="form-control-course-filter"
-                                id="form-field22"
+                                id="form-field20"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -1111,7 +1111,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # cou
                           >
                             <label
                               className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                              htmlFor="form-field23"
+                              htmlFor="form-field21"
                             >
                               <span>
                                 Filter by start date
@@ -1148,7 +1148,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # cou
                                 className="form-control"
                                 data-testid="form-control-date-filter"
                                 disabled={true}
-                                id="form-field23"
+                                id="form-field21"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -1170,7 +1170,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # cou
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field24"
+                              htmlFor="form-field22"
                             >
                               Filter by budget
                             </label>
@@ -1180,7 +1180,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # cou
                               <select
                                 className="form-control"
                                 data-testid="form-control-budget-filter"
-                                id="form-field24"
+                                id="form-field22"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -1222,7 +1222,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # cou
                             >
                               <label
                                 className="m-0"
-                                htmlFor="pgn-searchfield-input-25"
+                                htmlFor="pgn-searchfield-input-23"
                               >
                                 <span
                                   className="sr-only"
@@ -1234,7 +1234,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # cou
                                 className="form-control"
                                 data-hj-suppress={true}
                                 disabled={false}
-                                id="pgn-searchfield-input-25"
+                                id="pgn-searchfield-input-23"
                                 name="searchfield-input"
                                 onBlur={[Function]}
                                 onChange={[Function]}
@@ -2091,7 +2091,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field71"
+                              htmlFor="form-field64"
                             >
                               Filter by group
                             </label>
@@ -2100,7 +2100,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                             >
                               <select
                                 className="form-control"
-                                id="form-field71"
+                                id="form-field64"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -2123,7 +2123,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field72"
+                              htmlFor="form-field65"
                             >
                               Filter by course
                             </label>
@@ -2133,7 +2133,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                               <select
                                 className="form-control"
                                 data-testid="form-control-course-filter"
-                                id="form-field72"
+                                id="form-field65"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -2155,7 +2155,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                           >
                             <label
                               className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                              htmlFor="form-field73"
+                              htmlFor="form-field66"
                             >
                               <span>
                                 Filter by start date
@@ -2192,7 +2192,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                                 className="form-control"
                                 data-testid="form-control-date-filter"
                                 disabled={true}
-                                id="form-field73"
+                                id="form-field66"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -2214,7 +2214,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field74"
+                              htmlFor="form-field67"
                             >
                               Filter by budget
                             </label>
@@ -2224,7 +2224,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                               <select
                                 className="form-control"
                                 data-testid="form-control-budget-filter"
-                                id="form-field74"
+                                id="form-field67"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -2266,7 +2266,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                             >
                               <label
                                 className="m-0"
-                                htmlFor="pgn-searchfield-input-75"
+                                htmlFor="pgn-searchfield-input-68"
                               >
                                 <span
                                   className="sr-only"
@@ -2278,7 +2278,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                                 className="form-control"
                                 data-hj-suppress={true}
                                 disabled={false}
-                                id="pgn-searchfield-input-75"
+                                id="pgn-searchfield-input-68"
                                 name="searchfield-input"
                                 onBlur={[Function]}
                                 onChange={[Function]}
@@ -3135,7 +3135,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field81"
+                              htmlFor="form-field73"
                             >
                               Filter by group
                             </label>
@@ -3144,7 +3144,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                             >
                               <select
                                 className="form-control"
-                                id="form-field81"
+                                id="form-field73"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -3167,7 +3167,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field82"
+                              htmlFor="form-field74"
                             >
                               Filter by course
                             </label>
@@ -3177,7 +3177,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                               <select
                                 className="form-control"
                                 data-testid="form-control-course-filter"
-                                id="form-field82"
+                                id="form-field74"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -3199,7 +3199,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                           >
                             <label
                               className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                              htmlFor="form-field83"
+                              htmlFor="form-field75"
                             >
                               <span>
                                 Filter by start date
@@ -3236,7 +3236,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                                 className="form-control"
                                 data-testid="form-control-date-filter"
                                 disabled={true}
-                                id="form-field83"
+                                id="form-field75"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -3258,7 +3258,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field84"
+                              htmlFor="form-field76"
                             >
                               Filter by budget
                             </label>
@@ -3268,7 +3268,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                               <select
                                 className="form-control"
                                 data-testid="form-control-budget-filter"
-                                id="form-field84"
+                                id="form-field76"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -3310,7 +3310,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                             >
                               <label
                                 className="m-0"
-                                htmlFor="pgn-searchfield-input-85"
+                                htmlFor="pgn-searchfield-input-77"
                               >
                                 <span
                                   className="sr-only"
@@ -3322,7 +3322,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders # of 
                                 className="form-control"
                                 data-hj-suppress={true}
                                 disabled={false}
-                                id="pgn-searchfield-input-85"
+                                id="pgn-searchfield-input-77"
                                 name="searchfield-input"
                                 onBlur={[Function]}
                                 onChange={[Function]}
@@ -4179,7 +4179,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field91"
+                              htmlFor="form-field82"
                             >
                               Filter by group
                             </label>
@@ -4188,7 +4188,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                             >
                               <select
                                 className="form-control"
-                                id="form-field91"
+                                id="form-field82"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -4211,7 +4211,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field92"
+                              htmlFor="form-field83"
                             >
                               Filter by course
                             </label>
@@ -4221,7 +4221,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                               <select
                                 className="form-control"
                                 data-testid="form-control-course-filter"
-                                id="form-field92"
+                                id="form-field83"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -4243,7 +4243,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                           >
                             <label
                               className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                              htmlFor="form-field93"
+                              htmlFor="form-field84"
                             >
                               <span>
                                 Filter by start date
@@ -4280,7 +4280,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                                 className="form-control"
                                 data-testid="form-control-date-filter"
                                 disabled={true}
-                                id="form-field93"
+                                id="form-field84"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -4302,7 +4302,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field94"
+                              htmlFor="form-field85"
                             >
                               Filter by budget
                             </label>
@@ -4312,7 +4312,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                               <select
                                 className="form-control"
                                 data-testid="form-control-budget-filter"
-                                id="form-field94"
+                                id="form-field85"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -4354,7 +4354,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                             >
                               <label
                                 className="m-0"
-                                htmlFor="pgn-searchfield-input-95"
+                                htmlFor="pgn-searchfield-input-86"
                               >
                                 <span
                                   className="sr-only"
@@ -4366,7 +4366,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders colla
                                 className="form-control"
                                 data-hj-suppress={true}
                                 disabled={false}
-                                id="pgn-searchfield-input-95"
+                                id="pgn-searchfield-input-86"
                                 name="searchfield-input"
                                 onBlur={[Function]}
                                 onChange={[Function]}
@@ -6267,7 +6267,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field61"
+                              htmlFor="form-field55"
                             >
                               Filter by group
                             </label>
@@ -6276,7 +6276,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                             >
                               <select
                                 className="form-control"
-                                id="form-field61"
+                                id="form-field55"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -6299,7 +6299,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field62"
+                              htmlFor="form-field56"
                             >
                               Filter by course
                             </label>
@@ -6309,7 +6309,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                               <select
                                 className="form-control"
                                 data-testid="form-control-course-filter"
-                                id="form-field62"
+                                id="form-field56"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -6331,7 +6331,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                           >
                             <label
                               className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                              htmlFor="form-field63"
+                              htmlFor="form-field57"
                             >
                               <span>
                                 Filter by start date
@@ -6368,7 +6368,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                                 className="form-control"
                                 data-testid="form-control-date-filter"
                                 disabled={true}
-                                id="form-field63"
+                                id="form-field57"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -6390,7 +6390,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field64"
+                              htmlFor="form-field58"
                             >
                               Filter by budget
                             </label>
@@ -6400,7 +6400,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                               <select
                                 className="form-control"
                                 data-testid="form-control-budget-filter"
-                                id="form-field64"
+                                id="form-field58"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -6442,7 +6442,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                             >
                               <label
                                 className="m-0"
-                                htmlFor="pgn-searchfield-input-65"
+                                htmlFor="pgn-searchfield-input-59"
                               >
                                 <span
                                   className="sr-only"
@@ -6454,7 +6454,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                                 className="form-control"
                                 data-hj-suppress={true}
                                 disabled={false}
-                                id="pgn-searchfield-input-65"
+                                id="pgn-searchfield-input-59"
                                 name="searchfield-input"
                                 onBlur={[Function]}
                                 onChange={[Function]}
@@ -7311,7 +7311,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field51"
+                              htmlFor="form-field46"
                             >
                               Filter by group
                             </label>
@@ -7320,7 +7320,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                             >
                               <select
                                 className="form-control"
-                                id="form-field51"
+                                id="form-field46"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -7343,7 +7343,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field52"
+                              htmlFor="form-field47"
                             >
                               Filter by course
                             </label>
@@ -7353,7 +7353,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                               <select
                                 className="form-control"
                                 data-testid="form-control-course-filter"
-                                id="form-field52"
+                                id="form-field47"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -7375,7 +7375,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                           >
                             <label
                               className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                              htmlFor="form-field53"
+                              htmlFor="form-field48"
                             >
                               <span>
                                 Filter by start date
@@ -7412,7 +7412,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                                 className="form-control"
                                 data-testid="form-control-date-filter"
                                 disabled={true}
-                                id="form-field53"
+                                id="form-field48"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -7434,7 +7434,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field54"
+                              htmlFor="form-field49"
                             >
                               Filter by budget
                             </label>
@@ -7444,7 +7444,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                               <select
                                 className="form-control"
                                 data-testid="form-control-budget-filter"
-                                id="form-field54"
+                                id="form-field49"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -7486,7 +7486,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                             >
                               <label
                                 className="m-0"
-                                htmlFor="pgn-searchfield-input-55"
+                                htmlFor="pgn-searchfield-input-50"
                               >
                                 <span
                                   className="sr-only"
@@ -7498,7 +7498,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders inact
                                 className="form-control"
                                 data-hj-suppress={true}
                                 disabled={false}
-                                id="pgn-searchfield-input-55"
+                                id="pgn-searchfield-input-50"
                                 name="searchfield-input"
                                 onBlur={[Function]}
                                 onChange={[Function]}
@@ -8355,7 +8355,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders learn
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field31"
+                              htmlFor="form-field28"
                             >
                               Filter by group
                             </label>
@@ -8364,7 +8364,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders learn
                             >
                               <select
                                 className="form-control"
-                                id="form-field31"
+                                id="form-field28"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -8387,7 +8387,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders learn
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field32"
+                              htmlFor="form-field29"
                             >
                               Filter by course
                             </label>
@@ -8397,7 +8397,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders learn
                               <select
                                 className="form-control"
                                 data-testid="form-control-course-filter"
-                                id="form-field32"
+                                id="form-field29"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -8419,7 +8419,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders learn
                           >
                             <label
                               className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                              htmlFor="form-field33"
+                              htmlFor="form-field30"
                             >
                               <span>
                                 Filter by start date
@@ -8456,7 +8456,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders learn
                                 className="form-control"
                                 data-testid="form-control-date-filter"
                                 disabled={true}
-                                id="form-field33"
+                                id="form-field30"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -8478,7 +8478,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders learn
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field34"
+                              htmlFor="form-field31"
                             >
                               Filter by budget
                             </label>
@@ -8488,7 +8488,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders learn
                               <select
                                 className="form-control"
                                 data-testid="form-control-budget-filter"
-                                id="form-field34"
+                                id="form-field31"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -8530,7 +8530,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders learn
                             >
                               <label
                                 className="m-0"
-                                htmlFor="pgn-searchfield-input-35"
+                                htmlFor="pgn-searchfield-input-32"
                               >
                                 <span
                                   className="sr-only"
@@ -8542,7 +8542,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders learn
                                 className="form-control"
                                 data-hj-suppress={true}
                                 disabled={false}
-                                id="pgn-searchfield-input-35"
+                                id="pgn-searchfield-input-32"
                                 name="searchfield-input"
                                 onBlur={[Function]}
                                 onChange={[Function]}
@@ -9399,7 +9399,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders regis
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field11"
+                              htmlFor="form-field10"
                             >
                               Filter by group
                             </label>
@@ -9408,7 +9408,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders regis
                             >
                               <select
                                 className="form-control"
-                                id="form-field11"
+                                id="form-field10"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -9431,7 +9431,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders regis
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field12"
+                              htmlFor="form-field11"
                             >
                               Filter by course
                             </label>
@@ -9441,7 +9441,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders regis
                               <select
                                 className="form-control"
                                 data-testid="form-control-course-filter"
-                                id="form-field12"
+                                id="form-field11"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -9463,7 +9463,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders regis
                           >
                             <label
                               className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                              htmlFor="form-field13"
+                              htmlFor="form-field12"
                             >
                               <span>
                                 Filter by start date
@@ -9500,7 +9500,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders regis
                                 className="form-control"
                                 data-testid="form-control-date-filter"
                                 disabled={true}
-                                id="form-field13"
+                                id="form-field12"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -9522,7 +9522,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders regis
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field14"
+                              htmlFor="form-field13"
                             >
                               Filter by budget
                             </label>
@@ -9532,7 +9532,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders regis
                               <select
                                 className="form-control"
                                 data-testid="form-control-budget-filter"
-                                id="form-field14"
+                                id="form-field13"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -9574,7 +9574,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders regis
                             >
                               <label
                                 className="m-0"
-                                htmlFor="pgn-searchfield-input-15"
+                                htmlFor="pgn-searchfield-input-14"
                               >
                                 <span
                                   className="sr-only"
@@ -9586,7 +9586,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders regis
                                 className="form-control"
                                 data-hj-suppress={true}
                                 disabled={false}
-                                id="pgn-searchfield-input-15"
+                                id="pgn-searchfield-input-14"
                                 name="searchfield-input"
                                 onBlur={[Function]}
                                 onChange={[Function]}
@@ -10443,7 +10443,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders top a
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field41"
+                              htmlFor="form-field37"
                             >
                               Filter by group
                             </label>
@@ -10452,7 +10452,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders top a
                             >
                               <select
                                 className="form-control"
-                                id="form-field41"
+                                id="form-field37"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -10475,7 +10475,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders top a
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field42"
+                              htmlFor="form-field38"
                             >
                               Filter by course
                             </label>
@@ -10485,7 +10485,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders top a
                               <select
                                 className="form-control"
                                 data-testid="form-control-course-filter"
-                                id="form-field42"
+                                id="form-field38"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -10507,7 +10507,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders top a
                           >
                             <label
                               className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                              htmlFor="form-field43"
+                              htmlFor="form-field39"
                             >
                               <span>
                                 Filter by start date
@@ -10544,7 +10544,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders top a
                                 className="form-control"
                                 data-testid="form-control-date-filter"
                                 disabled={true}
-                                id="form-field43"
+                                id="form-field39"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -10566,7 +10566,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders top a
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field44"
+                              htmlFor="form-field40"
                             >
                               Filter by budget
                             </label>
@@ -10576,7 +10576,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders top a
                               <select
                                 className="form-control"
                                 data-testid="form-control-budget-filter"
-                                id="form-field44"
+                                id="form-field40"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -10618,7 +10618,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders top a
                             >
                               <label
                                 className="m-0"
-                                htmlFor="pgn-searchfield-input-45"
+                                htmlFor="pgn-searchfield-input-41"
                               >
                                 <span
                                   className="sr-only"
@@ -10630,7 +10630,7 @@ exports[`<Admin /> renders correctly with dashboard analytics data renders top a
                                 className="form-control"
                                 data-hj-suppress={true}
                                 disabled={false}
-                                id="pgn-searchfield-input-45"
+                                id="pgn-searchfield-input-41"
                                 name="searchfield-input"
                                 onBlur={[Function]}
                                 onChange={[Function]}
@@ -11536,7 +11536,7 @@ exports[`<Admin /> renders correctly with dashboard insights data renders dashbo
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field111"
+                              htmlFor="form-field100"
                             >
                               Filter by group
                             </label>
@@ -11545,7 +11545,7 @@ exports[`<Admin /> renders correctly with dashboard insights data renders dashbo
                             >
                               <select
                                 className="form-control"
-                                id="form-field111"
+                                id="form-field100"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -11568,7 +11568,7 @@ exports[`<Admin /> renders correctly with dashboard insights data renders dashbo
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field112"
+                              htmlFor="form-field101"
                             >
                               Filter by course
                             </label>
@@ -11578,7 +11578,7 @@ exports[`<Admin /> renders correctly with dashboard insights data renders dashbo
                               <select
                                 className="form-control"
                                 data-testid="form-control-course-filter"
-                                id="form-field112"
+                                id="form-field101"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -11600,7 +11600,7 @@ exports[`<Admin /> renders correctly with dashboard insights data renders dashbo
                           >
                             <label
                               className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                              htmlFor="form-field113"
+                              htmlFor="form-field102"
                             >
                               <span>
                                 Filter by start date
@@ -11637,7 +11637,7 @@ exports[`<Admin /> renders correctly with dashboard insights data renders dashbo
                                 className="form-control"
                                 data-testid="form-control-date-filter"
                                 disabled={true}
-                                id="form-field113"
+                                id="form-field102"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -11659,7 +11659,7 @@ exports[`<Admin /> renders correctly with dashboard insights data renders dashbo
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field114"
+                              htmlFor="form-field103"
                             >
                               Filter by budget
                             </label>
@@ -11669,7 +11669,7 @@ exports[`<Admin /> renders correctly with dashboard insights data renders dashbo
                               <select
                                 className="form-control"
                                 data-testid="form-control-budget-filter"
-                                id="form-field114"
+                                id="form-field103"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -11711,7 +11711,7 @@ exports[`<Admin /> renders correctly with dashboard insights data renders dashbo
                             >
                               <label
                                 className="m-0"
-                                htmlFor="pgn-searchfield-input-115"
+                                htmlFor="pgn-searchfield-input-104"
                               >
                                 <span
                                   className="sr-only"
@@ -11723,7 +11723,7 @@ exports[`<Admin /> renders correctly with dashboard insights data renders dashbo
                                 className="form-control"
                                 data-hj-suppress={true}
                                 disabled={false}
-                                id="pgn-searchfield-input-115"
+                                id="pgn-searchfield-input-104"
                                 name="searchfield-input"
                                 onBlur={[Function]}
                                 onChange={[Function]}
@@ -12580,7 +12580,7 @@ exports[`<Admin /> renders correctly with enterprise budgets data renders budget
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field121"
+                              htmlFor="form-field109"
                             >
                               Filter by group
                             </label>
@@ -12589,7 +12589,7 @@ exports[`<Admin /> renders correctly with enterprise budgets data renders budget
                             >
                               <select
                                 className="form-control"
-                                id="form-field121"
+                                id="form-field109"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -12612,7 +12612,7 @@ exports[`<Admin /> renders correctly with enterprise budgets data renders budget
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field122"
+                              htmlFor="form-field110"
                             >
                               Filter by course
                             </label>
@@ -12622,7 +12622,7 @@ exports[`<Admin /> renders correctly with enterprise budgets data renders budget
                               <select
                                 className="form-control"
                                 data-testid="form-control-course-filter"
-                                id="form-field122"
+                                id="form-field110"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -12644,7 +12644,7 @@ exports[`<Admin /> renders correctly with enterprise budgets data renders budget
                           >
                             <label
                               className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                              htmlFor="form-field123"
+                              htmlFor="form-field111"
                             >
                               <span>
                                 Filter by start date
@@ -12681,7 +12681,7 @@ exports[`<Admin /> renders correctly with enterprise budgets data renders budget
                                 className="form-control"
                                 data-testid="form-control-date-filter"
                                 disabled={true}
-                                id="form-field123"
+                                id="form-field111"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -12703,7 +12703,7 @@ exports[`<Admin /> renders correctly with enterprise budgets data renders budget
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field124"
+                              htmlFor="form-field112"
                             >
                               Filter by budget
                             </label>
@@ -12713,7 +12713,7 @@ exports[`<Admin /> renders correctly with enterprise budgets data renders budget
                               <select
                                 className="form-control"
                                 data-testid="form-control-budget-filter"
-                                id="form-field124"
+                                id="form-field112"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -12755,7 +12755,7 @@ exports[`<Admin /> renders correctly with enterprise budgets data renders budget
                             >
                               <label
                                 className="m-0"
-                                htmlFor="pgn-searchfield-input-125"
+                                htmlFor="pgn-searchfield-input-113"
                               >
                                 <span
                                   className="sr-only"
@@ -12767,7 +12767,7 @@ exports[`<Admin /> renders correctly with enterprise budgets data renders budget
                                 className="form-control"
                                 data-hj-suppress={true}
                                 disabled={false}
-                                id="pgn-searchfield-input-125"
+                                id="pgn-searchfield-input-113"
                                 name="searchfield-input"
                                 onBlur={[Function]}
                                 onChange={[Function]}
@@ -12829,1050 +12829,6 @@ exports[`<Admin /> renders correctly with enterprise budgets data renders budget
 `;
 
 exports[`<Admin /> renders correctly with enterprise groups data renders groups correctly 1`] = `
-<main
-  className="learner-progress-report"
-  data-enterprise-id="test-enterprise"
-  data-testid="dashboard-root"
-  role="main"
->
-  <div
-    className="hero hero-brand"
-  >
-    <div>
-      <h1>
-        Learner Progress Report
-      </h1>
-    </div>
-    <div>
-      <img
-        alt="edX logo"
-        src="https://edx-cdn.org/v3/prod/logo.svg"
-      />
-    </div>
-  </div>
-  <div
-    className="container-fluid"
-  >
-    <div
-      id="lpr-overview"
-    >
-      <div
-        className="row mt-4"
-      >
-        <div
-          className="col"
-        >
-          <h2>
-            Overview
-          </h2>
-        </div>
-      </div>
-      <div
-        className="row mt-4"
-      >
-        <div
-          className="col"
-          id="ai-summary"
-        />
-      </div>
-      <div
-        className="row mt-3"
-      >
-        <div
-          className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
-          id="numberOfUsers"
-        >
-          <div
-            className="number-card w-100 has-details"
-          >
-            <div
-              className="card"
-            >
-              <div
-                className="card-body"
-              >
-                <h3
-                  className="card-title d-flex align-items-center justify-content-between"
-                >
-                  <span>
-                    3
-                  </span>
-                  <span
-                    className="pgn__icon d-flex align-items-center justify-content-center"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      fill="none"
-                      focusable={false}
-                      height={24}
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width={24}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M12 12.75c1.63 0 3.07.39 4.24.9 1.08.48 1.76 1.56 1.76 2.73V18H6v-1.61c0-1.18.68-2.26 1.76-2.73 1.17-.52 2.61-.91 4.24-.91zM4 13c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm1.13 1.1c-.37-.06-.74-.1-1.13-.1-.99 0-1.93.21-2.78.58A2.01 2.01 0 0 0 0 16.43V18h4.5v-1.61c0-.83.23-1.61.63-2.29zM20 13c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm4 3.43c0-.81-.48-1.53-1.22-1.85A6.95 6.95 0 0 0 20 14c-.39 0-.76.04-1.13.1.4.68.63 1.46.63 2.29V18H24v-1.57zM12 6c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                  </span>
-                </h3>
-                <p
-                  className="card-text"
-                >
-                  total number of learners registered
-                </p>
-              </div>
-            </div>
-            <div
-              className="card-footer"
-            >
-              <div
-                className="footer-title"
-              >
-                <button
-                  aria-controls="footer-body-numberOfUsers"
-                  aria-expanded={false}
-                  className="toggle-collapse btn-block btn btn-link"
-                  disabled={false}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  type="button"
-                >
-                  <div
-                    className="d-flex justify-content-between align-items-center"
-                  >
-                    <div
-                      className="details-btn-text mr-1"
-                    >
-                      Details
-                    </div>
-                    <div>
-                      <span
-                        className="pgn__icon"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="none"
-                          focusable={false}
-                          height={24}
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width={24}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="m7 10 5 5 5-5H7Z"
-                            fill="currentColor"
-                          />
-                        </svg>
-                        <span
-                          className="sr-only"
-                        >
-                          Show details
-                        </span>
-                      </span>
-                    </div>
-                  </div>
-                </button>
-              </div>
-              <div
-                className="footer-body mt-1 d-none"
-                data-testid="details-actions"
-                id="footer-body-numberOfUsers"
-              >
-                <a
-                  className="btn btn-link"
-                  data-testid="details-action-item"
-                  href="/registered-unenrolled-learners"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                >
-                  <div
-                    className="d-flex justify-content-between align-items-center"
-                  >
-                    <span
-                      className="label"
-                    >
-                      Which learners are registered but not yet enrolled in any courses?
-                    </span>
-                  </div>
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
-          id="enrolledLearners"
-        >
-          <div
-            className="number-card w-100 has-details"
-          >
-            <div
-              className="card"
-            >
-              <div
-                className="card-body"
-              >
-                <h3
-                  className="card-title d-flex align-items-center justify-content-between"
-                >
-                  <span>
-                    1
-                  </span>
-                  <span
-                    className="pgn__icon d-flex align-items-center justify-content-center"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      fill="none"
-                      focusable={false}
-                      height={24}
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width={24}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                  </span>
-                </h3>
-                <p
-                  className="card-text"
-                >
-                  learners enrolled in at least one course
-                </p>
-              </div>
-            </div>
-            <div
-              className="card-footer"
-            >
-              <div
-                className="footer-title"
-              >
-                <button
-                  aria-controls="footer-body-enrolledLearners"
-                  aria-expanded={false}
-                  className="toggle-collapse btn-block btn btn-link"
-                  disabled={false}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  type="button"
-                >
-                  <div
-                    className="d-flex justify-content-between align-items-center"
-                  >
-                    <div
-                      className="details-btn-text mr-1"
-                    >
-                      Details
-                    </div>
-                    <div>
-                      <span
-                        className="pgn__icon"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="none"
-                          focusable={false}
-                          height={24}
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width={24}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="m7 10 5 5 5-5H7Z"
-                            fill="currentColor"
-                          />
-                        </svg>
-                        <span
-                          className="sr-only"
-                        >
-                          Show details
-                        </span>
-                      </span>
-                    </div>
-                  </div>
-                </button>
-              </div>
-              <div
-                className="footer-body mt-1 d-none"
-                data-testid="details-actions"
-                id="footer-body-enrolledLearners"
-              >
-                <a
-                  className="btn btn-link"
-                  data-testid="details-action-item"
-                  href="/enrolled-learners"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                >
-                  <div
-                    className="d-flex justify-content-between align-items-center"
-                  >
-                    <span
-                      className="label"
-                    >
-                      How many courses are learners enrolled in?
-                    </span>
-                  </div>
-                </a>
-                <a
-                  className="btn btn-link"
-                  data-testid="details-action-item"
-                  href="/enrolled-learners-inactive-courses"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                >
-                  <div
-                    className="d-flex justify-content-between align-items-center"
-                  >
-                    <span
-                      className="label"
-                    >
-                      Who is no longer enrolled in a current course?
-                    </span>
-                  </div>
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
-          id="activeLearners"
-        >
-          <div
-            className="number-card w-100 has-details"
-          >
-            <div
-              className="card"
-            >
-              <div
-                className="card-body"
-              >
-                <h3
-                  className="card-title d-flex align-items-center justify-content-between"
-                >
-                  <span>
-                    1
-                  </span>
-                  <span
-                    className="pgn__icon d-flex align-items-center justify-content-center"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      fill="none"
-                      focusable={false}
-                      height={24}
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width={24}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                  </span>
-                </h3>
-                <p
-                  className="card-text"
-                >
-                  active learners in the past week
-                </p>
-              </div>
-            </div>
-            <div
-              className="card-footer"
-            >
-              <div
-                className="footer-title"
-              >
-                <button
-                  aria-controls="footer-body-activeLearners"
-                  aria-expanded={false}
-                  className="toggle-collapse btn-block btn btn-link"
-                  disabled={false}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  type="button"
-                >
-                  <div
-                    className="d-flex justify-content-between align-items-center"
-                  >
-                    <div
-                      className="details-btn-text mr-1"
-                    >
-                      Details
-                    </div>
-                    <div>
-                      <span
-                        className="pgn__icon"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="none"
-                          focusable={false}
-                          height={24}
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width={24}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="m7 10 5 5 5-5H7Z"
-                            fill="currentColor"
-                          />
-                        </svg>
-                        <span
-                          className="sr-only"
-                        >
-                          Show details
-                        </span>
-                      </span>
-                    </div>
-                  </div>
-                </button>
-              </div>
-              <div
-                className="footer-body mt-1 d-none"
-                data-testid="details-actions"
-                id="footer-body-activeLearners"
-              >
-                <a
-                  className="btn btn-link"
-                  data-testid="details-action-item"
-                  href="/learners-active-week"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                >
-                  <div
-                    className="d-flex justify-content-between align-items-center"
-                  >
-                    <span
-                      className="label"
-                    >
-                      Who are my top active learners?
-                    </span>
-                  </div>
-                </a>
-                <a
-                  className="btn btn-link"
-                  data-testid="details-action-item"
-                  href="/learners-inactive-week"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                >
-                  <div
-                    className="d-flex justify-content-between align-items-center"
-                  >
-                    <span
-                      className="label"
-                    >
-                      Who has not been active for over a week?
-                    </span>
-                  </div>
-                </a>
-                <a
-                  className="btn btn-link"
-                  data-testid="details-action-item"
-                  href="/learners-inactive-month"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                >
-                  <div
-                    className="d-flex justify-content-between align-items-center"
-                  >
-                    <span
-                      className="label"
-                    >
-                      Who has not been active for over a month?
-                    </span>
-                  </div>
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
-          id="courseCompletions"
-        >
-          <div
-            className="number-card w-100 has-details"
-          >
-            <div
-              className="card"
-            >
-              <div
-                className="card-body"
-              >
-                <h3
-                  className="card-title d-flex align-items-center justify-content-between"
-                >
-                  <span>
-                    1
-                  </span>
-                  <span
-                    className="pgn__icon d-flex align-items-center justify-content-center"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      fill="none"
-                      focusable={false}
-                      height={24}
-                      role="img"
-                      viewBox="0 0 24 24"
-                      width={24}
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M19 5h-2V3H7v2H5c-1.1 0-2 .9-2 2v1c0 2.55 1.92 4.63 4.39 4.94A5.01 5.01 0 0 0 11 15.9V19H7v2h10v-2h-4v-3.1a5.01 5.01 0 0 0 3.61-2.96C19.08 12.63 21 10.55 21 8V7c0-1.1-.9-2-2-2ZM5 8V7h2v3.82C5.84 10.4 5 9.3 5 8Zm14 0c0 1.3-.84 2.4-2 2.82V7h2v1Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                  </span>
-                </h3>
-                <p
-                  className="card-text"
-                >
-                  course completions
-                </p>
-              </div>
-            </div>
-            <div
-              className="card-footer"
-            >
-              <div
-                className="footer-title"
-              >
-                <button
-                  aria-controls="footer-body-courseCompletions"
-                  aria-expanded={false}
-                  className="toggle-collapse btn-block btn btn-link"
-                  disabled={false}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  type="button"
-                >
-                  <div
-                    className="d-flex justify-content-between align-items-center"
-                  >
-                    <div
-                      className="details-btn-text mr-1"
-                    >
-                      Details
-                    </div>
-                    <div>
-                      <span
-                        className="pgn__icon"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          fill="none"
-                          focusable={false}
-                          height={24}
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width={24}
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="m7 10 5 5 5-5H7Z"
-                            fill="currentColor"
-                          />
-                        </svg>
-                        <span
-                          className="sr-only"
-                        >
-                          Show details
-                        </span>
-                      </span>
-                    </div>
-                  </div>
-                </button>
-              </div>
-              <div
-                className="footer-body mt-1 d-none"
-                data-testid="details-actions"
-                id="footer-body-courseCompletions"
-              >
-                <a
-                  className="btn btn-link"
-                  data-testid="details-action-item"
-                  href="/completed-learners"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                >
-                  <div
-                    className="d-flex justify-content-between align-items-center"
-                  >
-                    <span
-                      className="label"
-                    >
-                      How many courses have been completed by learners?
-                    </span>
-                  </div>
-                </a>
-                <a
-                  className="btn btn-link"
-                  data-testid="details-action-item"
-                  href="/completed-learners-week"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                >
-                  <div
-                    className="d-flex justify-content-between align-items-center"
-                  >
-                    <span
-                      className="label"
-                    >
-                      Who completed a course in the past week?
-                    </span>
-                  </div>
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="row"
-    >
-      <div
-        className="col mb-4.5"
-      >
-        <div
-          className="loading d-flex align-items-center justify-content-center subscriptions"
-          data-testid="loading-message"
-        >
-          Loading...
-          <span
-            className="sr-only"
-          >
-            Loading
-          </span>
-        </div>
-      </div>
-    </div>
-    <div
-      className="row mt-4"
-      id="learner-progress-report"
-    >
-      <div
-        className="col"
-      >
-        <div
-          className="row"
-        >
-          <div
-            className="col-12 col-md-3 col-xl-2 mb-2 mb-md-0"
-          >
-            <h2
-              className="table-title"
-            >
-              Full Report
-            </h2>
-          </div>
-          <div
-            className="col-12 col-md-9 col-xl-10 mb-2 mb-md-0 mt-0 mt-md-1"
-          />
-        </div>
-        <div
-          className="row"
-        >
-          <div
-            className="col"
-          />
-        </div>
-      </div>
-    </div>
-    <div
-      className="tabs-container"
-      id="progress-report"
-    >
-      <div
-        className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
-      >
-        Showing data as of 
-        July 31, 2018
-      </div>
-      <div>
-        <nav
-          className="pgn__tabs nav nav-tabs"
-          onKeyDown={[Function]}
-          role="tablist"
-        >
-          <a
-            className="pgn__tab_more nav-item nav-link"
-            data-rb-event-key={null}
-            href="#"
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            role="tab"
-          >
-            <div
-              className="pgn__dropdown pgn__dropdown-light dropdown"
-              data-testid="dropdown"
-            >
-              <button
-                aria-expanded={false}
-                aria-haspopup={true}
-                className="nav-link dropdown-toggle btn btn-link"
-                disabled={false}
-                id="pgn__tab-toggle"
-                onClick={[Function]}
-                type="button"
-              >
-                More...
-              </button>
-            </div>
-          </a>
-          <a
-            aria-selected={true}
-            className="pgn__tab_invisible nav-item nav-link active"
-            data-rb-event-key="learner-progress-report"
-            href="#"
-            id="full-progress-report"
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            role="tab"
-          >
-            Learner Progress Report
-          </a>
-        </nav>
-        <div
-          className="tab-content"
-        >
-          <div
-            aria-hidden={true}
-            aria-labelledby={null}
-            className="fade tab-pane"
-            id={null}
-            role="tabpanel"
-          />
-          <div
-            aria-hidden={false}
-            aria-labelledby={null}
-            className="fade tab-pane active show"
-            id={null}
-            role="tabpanel"
-          >
-            <div
-              className="row"
-            >
-              <div
-                className="col"
-              >
-                <div
-                  className="row pb-3 mt-2"
-                >
-                  <div
-                    className="col-12 col-md-12 col-xl-12"
-                  >
-                    <button
-                      className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
-                      data-testid="download-csv-btn"
-                      disabled={true}
-                      id="csv-download"
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      <svg
-                        className="mr-2"
-                        fill="none"
-                        height={24}
-                        viewBox="0 0 24 24"
-                        width={24}
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                      Download full report (CSV)
-                    </button>
-                  </div>
-                </div>
-                <span
-                  id="filter"
-                >
-                  <div
-                    className="row"
-                  >
-                    <div
-                      className="col-12 pr-md-0 mb-0"
-                    >
-                      <div
-                        className="row w-100 m-0"
-                      >
-                        <div
-                          className="col-12 col-md-3 my-2 my-md-0 px-0 px-md-2 px-lg-3"
-                          data-testid="form-control-group-filter"
-                        >
-                          <div
-                            className="pgn__form-group"
-                          >
-                            <label
-                              className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field144"
-                            >
-                              Filter by group
-                            </label>
-                            <div
-                              className="pgn__form-control-decorator-group w-100 groups-dropdown"
-                            >
-                              <select
-                                className="form-control"
-                                id="form-field144"
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                value=""
-                              >
-                                <option
-                                  value=""
-                                >
-                                  All Groups
-                                </option>
-                                <option />
-                              </select>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
-                        >
-                          <div
-                            className="pgn__form-group"
-                          >
-                            <label
-                              className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field145"
-                            >
-                              Filter by course
-                            </label>
-                            <div
-                              className="pgn__form-control-decorator-group w-100"
-                            >
-                              <select
-                                className="form-control"
-                                data-testid="form-control-course-filter"
-                                id="form-field145"
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                value=""
-                              >
-                                <option
-                                  value=""
-                                >
-                                  All Courses
-                                </option>
-                              </select>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
-                        >
-                          <div
-                            className="pgn__form-group"
-                          >
-                            <label
-                              className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                              htmlFor="form-field146"
-                            >
-                              <span>
-                                Filter by start date
-                              </span>
-                              <span
-                                alt="More information"
-                                className="pgn__icon ml-1"
-                                onBlur={[Function]}
-                                onFocus={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseOver={[Function]}
-                              >
-                                <svg
-                                  aria-hidden={true}
-                                  fill="none"
-                                  focusable={false}
-                                  height={24}
-                                  role="img"
-                                  viewBox="0 0 24 24"
-                                  width={24}
-                                  xmlns="http://www.w3.org/2000/svg"
-                                >
-                                  <path
-                                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
-                                    fill="currentColor"
-                                  />
-                                </svg>
-                              </span>
-                            </label>
-                            <div
-                              className="pgn__form-control-decorator-group w-100"
-                            >
-                              <select
-                                className="form-control"
-                                data-testid="form-control-date-filter"
-                                disabled={true}
-                                id="form-field146"
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                value=""
-                              >
-                                <option
-                                  value=""
-                                >
-                                  Choose a course
-                                </option>
-                              </select>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          className="col-12 col-md-3 my-2 my-md-0 px-0 px-md-2 px-lg-3"
-                        >
-                          <div
-                            className="pgn__form-group"
-                          >
-                            <label
-                              className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field147"
-                            >
-                              Filter by budget
-                            </label>
-                            <div
-                              className="pgn__form-control-decorator-group w-100 budgets-dropdown"
-                            >
-                              <select
-                                className="form-control"
-                                data-testid="form-control-budget-filter"
-                                id="form-field147"
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                value=""
-                              >
-                                <option
-                                  value=""
-                                >
-                                  All budgets
-                                </option>
-                                <option
-                                  value="8d6503dd-e40d-42b8-442b-37dd4c5450e3"
-                                >
-                                  Everything
-                                </option>
-                              </select>
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          className="col-12 my-2 my-md-0 px-0 px-md-2 px-lg-3 col-md-3"
-                        >
-                          <label
-                            className="pgn__form-label mb-2"
-                            id="search-email-label"
-                          >
-                            Filter by email
-                          </label>
-                          <div
-                            aria-labelledby="search-email-label"
-                            className="pgn__searchfield d-flex py-0"
-                            data-testid="admin-form-search-bar"
-                            onSearch={[Function]}
-                          >
-                            <form
-                              className="pgn__searchfield-form"
-                              onReset={[Function]}
-                              onSubmit={[Function]}
-                              role="search"
-                            >
-                              <label
-                                className="m-0"
-                                htmlFor="pgn-searchfield-input-148"
-                              >
-                                <span
-                                  className="sr-only"
-                                >
-                                  search
-                                </span>
-                              </label>
-                              <input
-                                className="form-control"
-                                data-hj-suppress={true}
-                                disabled={false}
-                                id="pgn-searchfield-input-148"
-                                name="searchfield-input"
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder="Search by email..."
-                                role="searchbox"
-                                type="text"
-                                value=""
-                              />
-                              <button
-                                aria-label="submit search"
-                                className="btn-icon btn-icon-primary btn-icon-sm pgn__searchfield__iconbutton-submit"
-                                disabled={false}
-                                onClick={[Function]}
-                                type="submit"
-                              >
-                                <span
-                                  className="btn-icon__icon-container"
-                                >
-                                  <span
-                                    className="pgn__icon btn-icon__icon"
-                                  >
-                                    <svg
-                                      aria-hidden={true}
-                                      fill="none"
-                                      focusable={false}
-                                      height={24}
-                                      role="img"
-                                      viewBox="0 0 24 24"
-                                      width={24}
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    >
-                                      <path
-                                        d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
-                                        fill="currentColor"
-                                      />
-                                    </svg>
-                                  </span>
-                                </span>
-                              </button>
-                            </form>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </span>
-                <div
-                  className="mt-3 mb-5"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</main>
-`;
-
-exports[`<Admin /> renders correctly with enterprise module activity data renders module activity data correctly 1`] = `
 <main
   className="learner-progress-report"
   data-enterprise-id="test-enterprise"
@@ -14856,6 +13812,1050 @@ exports[`<Admin /> renders correctly with enterprise module activity data render
                                 data-hj-suppress={true}
                                 disabled={false}
                                 id="pgn-searchfield-input-135"
+                                name="searchfield-input"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder="Search by email..."
+                                role="searchbox"
+                                type="text"
+                                value=""
+                              />
+                              <button
+                                aria-label="submit search"
+                                className="btn-icon btn-icon-primary btn-icon-sm pgn__searchfield__iconbutton-submit"
+                                disabled={false}
+                                onClick={[Function]}
+                                type="submit"
+                              >
+                                <span
+                                  className="btn-icon__icon-container"
+                                >
+                                  <span
+                                    className="pgn__icon btn-icon__icon"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      fill="none"
+                                      focusable={false}
+                                      height={24}
+                                      role="img"
+                                      viewBox="0 0 24 24"
+                                      width={24}
+                                      xmlns="http://www.w3.org/2000/svg"
+                                    >
+                                      <path
+                                        d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14Z"
+                                        fill="currentColor"
+                                      />
+                                    </svg>
+                                  </span>
+                                </span>
+                              </button>
+                            </form>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </span>
+                <div
+                  className="mt-3 mb-5"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>
+`;
+
+exports[`<Admin /> renders correctly with enterprise module activity data renders module activity data correctly 1`] = `
+<main
+  className="learner-progress-report"
+  data-enterprise-id="test-enterprise"
+  data-testid="dashboard-root"
+  role="main"
+>
+  <div
+    className="hero hero-brand"
+  >
+    <div>
+      <h1>
+        Learner Progress Report
+      </h1>
+    </div>
+    <div>
+      <img
+        alt="edX logo"
+        src="https://edx-cdn.org/v3/prod/logo.svg"
+      />
+    </div>
+  </div>
+  <div
+    className="container-fluid"
+  >
+    <div
+      id="lpr-overview"
+    >
+      <div
+        className="row mt-4"
+      >
+        <div
+          className="col"
+        >
+          <h2>
+            Overview
+          </h2>
+        </div>
+      </div>
+      <div
+        className="row mt-4"
+      >
+        <div
+          className="col"
+          id="ai-summary"
+        />
+      </div>
+      <div
+        className="row mt-3"
+      >
+        <div
+          className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+          id="numberOfUsers"
+        >
+          <div
+            className="number-card w-100 has-details"
+          >
+            <div
+              className="card"
+            >
+              <div
+                className="card-body"
+              >
+                <h3
+                  className="card-title d-flex align-items-center justify-content-between"
+                >
+                  <span>
+                    3
+                  </span>
+                  <span
+                    className="pgn__icon d-flex align-items-center justify-content-center"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      fill="none"
+                      focusable={false}
+                      height={24}
+                      role="img"
+                      viewBox="0 0 24 24"
+                      width={24}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M12 12.75c1.63 0 3.07.39 4.24.9 1.08.48 1.76 1.56 1.76 2.73V18H6v-1.61c0-1.18.68-2.26 1.76-2.73 1.17-.52 2.61-.91 4.24-.91zM4 13c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm1.13 1.1c-.37-.06-.74-.1-1.13-.1-.99 0-1.93.21-2.78.58A2.01 2.01 0 0 0 0 16.43V18h4.5v-1.61c0-.83.23-1.61.63-2.29zM20 13c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm4 3.43c0-.81-.48-1.53-1.22-1.85A6.95 6.95 0 0 0 20 14c-.39 0-.76.04-1.13.1.4.68.63 1.46.63 2.29V18H24v-1.57zM12 6c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </span>
+                </h3>
+                <p
+                  className="card-text"
+                >
+                  total number of learners registered
+                </p>
+              </div>
+            </div>
+            <div
+              className="card-footer"
+            >
+              <div
+                className="footer-title"
+              >
+                <button
+                  aria-controls="footer-body-numberOfUsers"
+                  aria-expanded={false}
+                  className="toggle-collapse btn-block btn btn-link"
+                  disabled={false}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
+                >
+                  <div
+                    className="d-flex justify-content-between align-items-center"
+                  >
+                    <div
+                      className="details-btn-text mr-1"
+                    >
+                      Details
+                    </div>
+                    <div>
+                      <span
+                        className="pgn__icon"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          fill="none"
+                          focusable={false}
+                          height={24}
+                          role="img"
+                          viewBox="0 0 24 24"
+                          width={24}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="m7 10 5 5 5-5H7Z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                        <span
+                          className="sr-only"
+                        >
+                          Show details
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                </button>
+              </div>
+              <div
+                className="footer-body mt-1 d-none"
+                data-testid="details-actions"
+                id="footer-body-numberOfUsers"
+              >
+                <a
+                  className="btn btn-link"
+                  data-testid="details-action-item"
+                  href="/registered-unenrolled-learners"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  <div
+                    className="d-flex justify-content-between align-items-center"
+                  >
+                    <span
+                      className="label"
+                    >
+                      Which learners are registered but not yet enrolled in any courses?
+                    </span>
+                  </div>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+          id="enrolledLearners"
+        >
+          <div
+            className="number-card w-100 has-details"
+          >
+            <div
+              className="card"
+            >
+              <div
+                className="card-body"
+              >
+                <h3
+                  className="card-title d-flex align-items-center justify-content-between"
+                >
+                  <span>
+                    1
+                  </span>
+                  <span
+                    className="pgn__icon d-flex align-items-center justify-content-center"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      fill="none"
+                      focusable={false}
+                      height={24}
+                      role="img"
+                      viewBox="0 0 24 24"
+                      width={24}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9 16.2 4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2Z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </span>
+                </h3>
+                <p
+                  className="card-text"
+                >
+                  learners enrolled in at least one course
+                </p>
+              </div>
+            </div>
+            <div
+              className="card-footer"
+            >
+              <div
+                className="footer-title"
+              >
+                <button
+                  aria-controls="footer-body-enrolledLearners"
+                  aria-expanded={false}
+                  className="toggle-collapse btn-block btn btn-link"
+                  disabled={false}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
+                >
+                  <div
+                    className="d-flex justify-content-between align-items-center"
+                  >
+                    <div
+                      className="details-btn-text mr-1"
+                    >
+                      Details
+                    </div>
+                    <div>
+                      <span
+                        className="pgn__icon"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          fill="none"
+                          focusable={false}
+                          height={24}
+                          role="img"
+                          viewBox="0 0 24 24"
+                          width={24}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="m7 10 5 5 5-5H7Z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                        <span
+                          className="sr-only"
+                        >
+                          Show details
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                </button>
+              </div>
+              <div
+                className="footer-body mt-1 d-none"
+                data-testid="details-actions"
+                id="footer-body-enrolledLearners"
+              >
+                <a
+                  className="btn btn-link"
+                  data-testid="details-action-item"
+                  href="/enrolled-learners"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  <div
+                    className="d-flex justify-content-between align-items-center"
+                  >
+                    <span
+                      className="label"
+                    >
+                      How many courses are learners enrolled in?
+                    </span>
+                  </div>
+                </a>
+                <a
+                  className="btn btn-link"
+                  data-testid="details-action-item"
+                  href="/enrolled-learners-inactive-courses"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  <div
+                    className="d-flex justify-content-between align-items-center"
+                  >
+                    <span
+                      className="label"
+                    >
+                      Who is no longer enrolled in a current course?
+                    </span>
+                  </div>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+          id="activeLearners"
+        >
+          <div
+            className="number-card w-100 has-details"
+          >
+            <div
+              className="card"
+            >
+              <div
+                className="card-body"
+              >
+                <h3
+                  className="card-title d-flex align-items-center justify-content-between"
+                >
+                  <span>
+                    1
+                  </span>
+                  <span
+                    className="pgn__icon d-flex align-items-center justify-content-center"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      fill="none"
+                      focusable={false}
+                      height={24}
+                      role="img"
+                      viewBox="0 0 24 24"
+                      width={24}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </span>
+                </h3>
+                <p
+                  className="card-text"
+                >
+                  active learners in the past week
+                </p>
+              </div>
+            </div>
+            <div
+              className="card-footer"
+            >
+              <div
+                className="footer-title"
+              >
+                <button
+                  aria-controls="footer-body-activeLearners"
+                  aria-expanded={false}
+                  className="toggle-collapse btn-block btn btn-link"
+                  disabled={false}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
+                >
+                  <div
+                    className="d-flex justify-content-between align-items-center"
+                  >
+                    <div
+                      className="details-btn-text mr-1"
+                    >
+                      Details
+                    </div>
+                    <div>
+                      <span
+                        className="pgn__icon"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          fill="none"
+                          focusable={false}
+                          height={24}
+                          role="img"
+                          viewBox="0 0 24 24"
+                          width={24}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="m7 10 5 5 5-5H7Z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                        <span
+                          className="sr-only"
+                        >
+                          Show details
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                </button>
+              </div>
+              <div
+                className="footer-body mt-1 d-none"
+                data-testid="details-actions"
+                id="footer-body-activeLearners"
+              >
+                <a
+                  className="btn btn-link"
+                  data-testid="details-action-item"
+                  href="/learners-active-week"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  <div
+                    className="d-flex justify-content-between align-items-center"
+                  >
+                    <span
+                      className="label"
+                    >
+                      Who are my top active learners?
+                    </span>
+                  </div>
+                </a>
+                <a
+                  className="btn btn-link"
+                  data-testid="details-action-item"
+                  href="/learners-inactive-week"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  <div
+                    className="d-flex justify-content-between align-items-center"
+                  >
+                    <span
+                      className="label"
+                    >
+                      Who has not been active for over a week?
+                    </span>
+                  </div>
+                </a>
+                <a
+                  className="btn btn-link"
+                  data-testid="details-action-item"
+                  href="/learners-inactive-month"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  <div
+                    className="d-flex justify-content-between align-items-center"
+                  >
+                    <span
+                      className="label"
+                    >
+                      Who has not been active for over a month?
+                    </span>
+                  </div>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="col-xs-12 col-md-6 col-xl-3 mb-3 d-flex"
+          id="courseCompletions"
+        >
+          <div
+            className="number-card w-100 has-details"
+          >
+            <div
+              className="card"
+            >
+              <div
+                className="card-body"
+              >
+                <h3
+                  className="card-title d-flex align-items-center justify-content-between"
+                >
+                  <span>
+                    1
+                  </span>
+                  <span
+                    className="pgn__icon d-flex align-items-center justify-content-center"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      fill="none"
+                      focusable={false}
+                      height={24}
+                      role="img"
+                      viewBox="0 0 24 24"
+                      width={24}
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M19 5h-2V3H7v2H5c-1.1 0-2 .9-2 2v1c0 2.55 1.92 4.63 4.39 4.94A5.01 5.01 0 0 0 11 15.9V19H7v2h10v-2h-4v-3.1a5.01 5.01 0 0 0 3.61-2.96C19.08 12.63 21 10.55 21 8V7c0-1.1-.9-2-2-2ZM5 8V7h2v3.82C5.84 10.4 5 9.3 5 8Zm14 0c0 1.3-.84 2.4-2 2.82V7h2v1Z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </span>
+                </h3>
+                <p
+                  className="card-text"
+                >
+                  course completions
+                </p>
+              </div>
+            </div>
+            <div
+              className="card-footer"
+            >
+              <div
+                className="footer-title"
+              >
+                <button
+                  aria-controls="footer-body-courseCompletions"
+                  aria-expanded={false}
+                  className="toggle-collapse btn-block btn btn-link"
+                  disabled={false}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  type="button"
+                >
+                  <div
+                    className="d-flex justify-content-between align-items-center"
+                  >
+                    <div
+                      className="details-btn-text mr-1"
+                    >
+                      Details
+                    </div>
+                    <div>
+                      <span
+                        className="pgn__icon"
+                      >
+                        <svg
+                          aria-hidden={true}
+                          fill="none"
+                          focusable={false}
+                          height={24}
+                          role="img"
+                          viewBox="0 0 24 24"
+                          width={24}
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="m7 10 5 5 5-5H7Z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                        <span
+                          className="sr-only"
+                        >
+                          Show details
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                </button>
+              </div>
+              <div
+                className="footer-body mt-1 d-none"
+                data-testid="details-actions"
+                id="footer-body-courseCompletions"
+              >
+                <a
+                  className="btn btn-link"
+                  data-testid="details-action-item"
+                  href="/completed-learners"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  <div
+                    className="d-flex justify-content-between align-items-center"
+                  >
+                    <span
+                      className="label"
+                    >
+                      How many courses have been completed by learners?
+                    </span>
+                  </div>
+                </a>
+                <a
+                  className="btn btn-link"
+                  data-testid="details-action-item"
+                  href="/completed-learners-week"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
+                  <div
+                    className="d-flex justify-content-between align-items-center"
+                  >
+                    <span
+                      className="label"
+                    >
+                      Who completed a course in the past week?
+                    </span>
+                  </div>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="row"
+    >
+      <div
+        className="col mb-4.5"
+      >
+        <div
+          className="loading d-flex align-items-center justify-content-center subscriptions"
+          data-testid="loading-message"
+        >
+          Loading...
+          <span
+            className="sr-only"
+          >
+            Loading
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      className="row mt-4"
+      id="learner-progress-report"
+    >
+      <div
+        className="col"
+      >
+        <div
+          className="row"
+        >
+          <div
+            className="col-12 col-md-3 col-xl-2 mb-2 mb-md-0"
+          >
+            <h2
+              className="table-title"
+            >
+              Full Report
+            </h2>
+          </div>
+          <div
+            className="col-12 col-md-9 col-xl-10 mb-2 mb-md-0 mt-0 mt-md-1"
+          />
+        </div>
+        <div
+          className="row"
+        >
+          <div
+            className="col"
+          />
+        </div>
+      </div>
+    </div>
+    <div
+      className="tabs-container"
+      id="progress-report"
+    >
+      <div
+        className="col-12 col-md-6  col-xl-4 pt-1 pb-3"
+      >
+        Showing data as of 
+        July 31, 2018
+      </div>
+      <div>
+        <nav
+          className="pgn__tabs nav nav-tabs"
+          onKeyDown={[Function]}
+          role="tablist"
+        >
+          <a
+            className="pgn__tab_more nav-item nav-link"
+            data-rb-event-key={null}
+            href="#"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            <div
+              className="pgn__dropdown pgn__dropdown-light dropdown"
+              data-testid="dropdown"
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                className="nav-link dropdown-toggle btn btn-link"
+                disabled={false}
+                id="pgn__tab-toggle"
+                onClick={[Function]}
+                type="button"
+              >
+                More...
+              </button>
+            </div>
+          </a>
+          <a
+            aria-selected={true}
+            className="pgn__tab_invisible nav-item nav-link active"
+            data-rb-event-key="learner-progress-report"
+            href="#"
+            id="full-progress-report"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+          >
+            Learner Progress Report
+          </a>
+        </nav>
+        <div
+          className="tab-content"
+        >
+          <div
+            aria-hidden={true}
+            aria-labelledby={null}
+            className="fade tab-pane"
+            id={null}
+            role="tabpanel"
+          />
+          <div
+            aria-hidden={false}
+            aria-labelledby={null}
+            className="fade tab-pane active show"
+            id={null}
+            role="tabpanel"
+          >
+            <div
+              className="row"
+            >
+              <div
+                className="col"
+              >
+                <div
+                  className="row pb-3 mt-2"
+                >
+                  <div
+                    className="col-12 col-md-12 col-xl-12"
+                  >
+                    <button
+                      className="download-btn d-sm-inline float-md-right btn btn-outline-primary"
+                      data-testid="download-csv-btn"
+                      disabled={true}
+                      id="csv-download"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <svg
+                        className="mr-2"
+                        fill="none"
+                        height={24}
+                        viewBox="0 0 24 24"
+                        width={24}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                      Download full report (CSV)
+                    </button>
+                  </div>
+                </div>
+                <span
+                  id="filter"
+                >
+                  <div
+                    className="row"
+                  >
+                    <div
+                      className="col-12 pr-md-0 mb-0"
+                    >
+                      <div
+                        className="row w-100 m-0"
+                      >
+                        <div
+                          className="col-12 col-md-3 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                          data-testid="form-control-group-filter"
+                        >
+                          <div
+                            className="pgn__form-group"
+                          >
+                            <label
+                              className="pgn__form-label search-label mb-2"
+                              htmlFor="form-field118"
+                            >
+                              Filter by group
+                            </label>
+                            <div
+                              className="pgn__form-control-decorator-group w-100 groups-dropdown"
+                            >
+                              <select
+                                className="form-control"
+                                id="form-field118"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                value=""
+                              >
+                                <option
+                                  value=""
+                                >
+                                  All Groups
+                                </option>
+                                <option />
+                              </select>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3"
+                        >
+                          <div
+                            className="pgn__form-group"
+                          >
+                            <label
+                              className="pgn__form-label search-label mb-2"
+                              htmlFor="form-field119"
+                            >
+                              Filter by course
+                            </label>
+                            <div
+                              className="pgn__form-control-decorator-group w-100"
+                            >
+                              <select
+                                className="form-control"
+                                data-testid="form-control-course-filter"
+                                id="form-field119"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                value=""
+                              >
+                                <option
+                                  value=""
+                                >
+                                  All Courses
+                                </option>
+                              </select>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3"
+                        >
+                          <div
+                            className="pgn__form-group"
+                          >
+                            <label
+                              className="pgn__form-label search-label mb-2 d-flex align-items-center"
+                              htmlFor="form-field120"
+                            >
+                              <span>
+                                Filter by start date
+                              </span>
+                              <span
+                                alt="More information"
+                                className="pgn__icon ml-1"
+                                onBlur={[Function]}
+                                onFocus={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  fill="none"
+                                  focusable={false}
+                                  height={24}
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  width={24}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm1 15h-2v-6h2v6Zm0-8h-2V7h2v2Z"
+                                    fill="currentColor"
+                                  />
+                                </svg>
+                              </span>
+                            </label>
+                            <div
+                              className="pgn__form-control-decorator-group w-100"
+                            >
+                              <select
+                                className="form-control"
+                                data-testid="form-control-date-filter"
+                                disabled={true}
+                                id="form-field120"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                value=""
+                              >
+                                <option
+                                  value=""
+                                >
+                                  Choose a course
+                                </option>
+                              </select>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          className="col-12 col-md-3 my-2 my-md-0 px-0 px-md-2 px-lg-3"
+                        >
+                          <div
+                            className="pgn__form-group"
+                          >
+                            <label
+                              className="pgn__form-label search-label mb-2"
+                              htmlFor="form-field121"
+                            >
+                              Filter by budget
+                            </label>
+                            <div
+                              className="pgn__form-control-decorator-group w-100 budgets-dropdown"
+                            >
+                              <select
+                                className="form-control"
+                                data-testid="form-control-budget-filter"
+                                id="form-field121"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                value=""
+                              >
+                                <option
+                                  value=""
+                                >
+                                  All budgets
+                                </option>
+                                <option
+                                  value="8d6503dd-e40d-42b8-442b-37dd4c5450e3"
+                                >
+                                  Everything
+                                </option>
+                              </select>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          className="col-12 my-2 my-md-0 px-0 px-md-2 px-lg-3 col-md-3"
+                        >
+                          <label
+                            className="pgn__form-label mb-2"
+                            id="search-email-label"
+                          >
+                            Filter by email
+                          </label>
+                          <div
+                            aria-labelledby="search-email-label"
+                            className="pgn__searchfield d-flex py-0"
+                            data-testid="admin-form-search-bar"
+                            onSearch={[Function]}
+                          >
+                            <form
+                              className="pgn__searchfield-form"
+                              onReset={[Function]}
+                              onSubmit={[Function]}
+                              role="search"
+                            >
+                              <label
+                                className="m-0"
+                                htmlFor="pgn-searchfield-input-122"
+                              >
+                                <span
+                                  className="sr-only"
+                                >
+                                  search
+                                </span>
+                              </label>
+                              <input
+                                className="form-control"
+                                data-hj-suppress={true}
+                                disabled={false}
+                                id="pgn-searchfield-input-122"
                                 name="searchfield-input"
                                 onBlur={[Function]}
                                 onChange={[Function]}
@@ -16245,7 +16245,7 @@ exports[`<Admin /> renders correctly with no dashboard insights data 1`] = `
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field101"
+                              htmlFor="form-field91"
                             >
                               Filter by group
                             </label>
@@ -16254,7 +16254,7 @@ exports[`<Admin /> renders correctly with no dashboard insights data 1`] = `
                             >
                               <select
                                 className="form-control"
-                                id="form-field101"
+                                id="form-field91"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -16277,7 +16277,7 @@ exports[`<Admin /> renders correctly with no dashboard insights data 1`] = `
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field102"
+                              htmlFor="form-field92"
                             >
                               Filter by course
                             </label>
@@ -16287,7 +16287,7 @@ exports[`<Admin /> renders correctly with no dashboard insights data 1`] = `
                               <select
                                 className="form-control"
                                 data-testid="form-control-course-filter"
-                                id="form-field102"
+                                id="form-field92"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -16309,7 +16309,7 @@ exports[`<Admin /> renders correctly with no dashboard insights data 1`] = `
                           >
                             <label
                               className="pgn__form-label search-label mb-2 d-flex align-items-center"
-                              htmlFor="form-field103"
+                              htmlFor="form-field93"
                             >
                               <span>
                                 Filter by start date
@@ -16346,7 +16346,7 @@ exports[`<Admin /> renders correctly with no dashboard insights data 1`] = `
                                 className="form-control"
                                 data-testid="form-control-date-filter"
                                 disabled={true}
-                                id="form-field103"
+                                id="form-field93"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -16368,7 +16368,7 @@ exports[`<Admin /> renders correctly with no dashboard insights data 1`] = `
                           >
                             <label
                               className="pgn__form-label search-label mb-2"
-                              htmlFor="form-field104"
+                              htmlFor="form-field94"
                             >
                               Filter by budget
                             </label>
@@ -16378,7 +16378,7 @@ exports[`<Admin /> renders correctly with no dashboard insights data 1`] = `
                               <select
                                 className="form-control"
                                 data-testid="form-control-budget-filter"
-                                id="form-field104"
+                                id="form-field94"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 value=""
@@ -16420,7 +16420,7 @@ exports[`<Admin /> renders correctly with no dashboard insights data 1`] = `
                             >
                               <label
                                 className="m-0"
-                                htmlFor="pgn-searchfield-input-105"
+                                htmlFor="pgn-searchfield-input-95"
                               >
                                 <span
                                   className="sr-only"
@@ -16432,7 +16432,7 @@ exports[`<Admin /> renders correctly with no dashboard insights data 1`] = `
                                 className="form-control"
                                 data-hj-suppress={true}
                                 disabled={false}
-                                id="pgn-searchfield-input-105"
+                                id="pgn-searchfield-input-95"
                                 name="searchfield-input"
                                 onBlur={[Function]}
                                 onChange={[Function]}

--- a/src/components/AdminV2/AdminCards.jsx
+++ b/src/components/AdminV2/AdminCards.jsx
@@ -1,105 +1,107 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import {
   Award, Check, Groups, RemoveRedEye,
 } from '@openedx/paragon/icons';
 
 import NumberCard from './cards/NumberCard';
 
-class AdminCards extends React.Component {
-  constructor(props) {
-    super(props);
-    const { intl } = this.props;
+const AdminCards = ({
+  activeLearners,
+  numberOfUsers,
+  courseCompletions,
+  enrolledLearners,
+}) => {
+  const intl = useIntl();
 
-    this.cards = {
-      numberOfUsers: {
-        ref: React.createRef(),
-        description: intl.formatMessage({
-          id: 'adminPortal.cards.registeredLearners',
-          defaultMessage: 'total number of learners registered',
+  const cards = {
+    numberOfUsers: {
+      ref: React.createRef(),
+      description: intl.formatMessage({
+        id: 'adminPortal.cards.registeredLearners',
+        defaultMessage: 'total number of learners registered',
+      }),
+      icon: Groups,
+      actions: [{
+        label: intl.formatMessage({
+          id: 'adminPortal.cards.registeredUnenrolledLearners',
+          defaultMessage: 'Which learners are registered but not yet enrolled in any courses?',
         }),
-        icon: Groups,
-        actions: [{
-          label: intl.formatMessage({
-            id: 'adminPortal.cards.registeredUnenrolledLearners',
-            defaultMessage: 'Which learners are registered but not yet enrolled in any courses?',
-          }),
-          slug: 'registered-unenrolled-learners',
-        }],
-      },
-      enrolledLearners: {
-        ref: React.createRef(),
-        description: intl.formatMessage({
-          id: 'adminPortal.cards.enrolledOneCourse',
-          defaultMessage: 'learners enrolled in at least one course',
+        slug: 'registered-unenrolled-learners',
+      }],
+    },
+    enrolledLearners: {
+      ref: React.createRef(),
+      description: intl.formatMessage({
+        id: 'adminPortal.cards.enrolledOneCourse',
+        defaultMessage: 'learners enrolled in at least one course',
+      }),
+      icon: Check,
+      actions: [{
+        label: intl.formatMessage({
+          id: 'adminPortal.cards.enrolledLearners',
+          defaultMessage: 'How many courses are learners enrolled in?',
         }),
-        icon: Check,
-        actions: [{
-          label: intl.formatMessage({
-            id: 'adminPortal.cards.enrolledLearners',
-            defaultMessage: 'How many courses are learners enrolled in?',
-          }),
-          slug: 'enrolled-learners',
-        }, {
-          label: intl.formatMessage({
-            id: 'adminPortal.cards.enrolledLearnersInactiveCourses',
-            defaultMessage: 'Who is no longer enrolled in a current course?',
-          }),
-          slug: 'enrolled-learners-inactive-courses',
-        }],
-      },
-      activeLearners: {
-        ref: React.createRef(),
-        description: intl.formatMessage({
-          id: 'adminPortal.cards.activeLearnersPastWeek',
-          defaultMessage: 'active learners in the past week',
+        slug: 'enrolled-learners',
+      }, {
+        label: intl.formatMessage({
+          id: 'adminPortal.cards.enrolledLearnersInactiveCourses',
+          defaultMessage: 'Who is no longer enrolled in a current course?',
         }),
-        icon: RemoveRedEye,
-        actions: [{
-          label: intl.formatMessage({
-            id: 'adminPortal.cards.learnersActiveWeek',
-            defaultMessage: 'Who are my top active learners?',
-          }),
-          slug: 'learners-active-week',
-        }, {
-          label: intl.formatMessage({
-            id: 'adminPortal.cards.learnersInactiveWeek',
-            defaultMessage: 'Who has not been active for over a week?',
-          }),
-          slug: 'learners-inactive-week',
-        }, {
-          label: intl.formatMessage({
-            id: 'adminPortal.cards.learnersInactiveMonth',
-            defaultMessage: 'Who has not been active for over a month?',
-          }),
-          slug: 'learners-inactive-month',
-        }],
-      },
-      courseCompletions: {
-        ref: React.createRef(),
-        description: 'course completions',
-        icon: Award,
-        actions: [{
-          label: intl.formatMessage({
-            id: 'adminPortal.cards.completedLearners',
-            defaultMessage: 'How many courses have been completed by learners?',
-          }),
-          slug: 'completed-learners',
-        }, {
-          label: intl.formatMessage({
-            id: 'adminPortal.cards.completedLearnersWeek',
-            defaultMessage: 'Who completed a course in the past week?',
-          }),
-          slug: 'completed-learners-week',
-        }],
-      },
-    };
-  }
+        slug: 'enrolled-learners-inactive-courses',
+      }],
+    },
+    activeLearners: {
+      ref: React.createRef(),
+      description: intl.formatMessage({
+        id: 'adminPortal.cards.activeLearnersPastWeek',
+        defaultMessage: 'active learners in the past week',
+      }),
+      icon: RemoveRedEye,
+      actions: [{
+        label: intl.formatMessage({
+          id: 'adminPortal.cards.learnersActiveWeek',
+          defaultMessage: 'Who are my top active learners?',
+        }),
+        slug: 'learners-active-week',
+      }, {
+        label: intl.formatMessage({
+          id: 'adminPortal.cards.learnersInactiveWeek',
+          defaultMessage: 'Who has not been active for over a week?',
+        }),
+        slug: 'learners-inactive-week',
+      }, {
+        label: intl.formatMessage({
+          id: 'adminPortal.cards.learnersInactiveMonth',
+          defaultMessage: 'Who has not been active for over a month?',
+        }),
+        slug: 'learners-inactive-month',
+      }],
+    },
+    courseCompletions: {
+      ref: React.createRef(),
+      description: 'course completions',
+      icon: Award,
+      actions: [{
+        label: intl.formatMessage({
+          id: 'adminPortal.cards.completedLearners',
+          defaultMessage: 'How many courses have been completed by learners?',
+        }),
+        slug: 'completed-learners',
+      }, {
+        label: intl.formatMessage({
+          id: 'adminPortal.cards.completedLearnersWeek',
+          defaultMessage: 'Who completed a course in the past week?',
+        }),
+        slug: 'completed-learners-week',
+      }],
+    },
+  };
 
-  renderCard({ title, cardKey }) {
-    const card = this.cards[cardKey];
+  const renderCard = ({ title, cardKey }) => {
+    const card = cards[cardKey];
 
     return (
       <div
@@ -115,31 +117,22 @@ class AdminCards extends React.Component {
         />
       </div>
     );
-  }
+  };
 
-  render() {
-    const {
-      activeLearners,
-      numberOfUsers,
-      courseCompletions,
-      enrolledLearners,
-    } = this.props;
+  const data = {
+    activeLearners: activeLearners.past_week,
+    numberOfUsers,
+    courseCompletions,
+    enrolledLearners,
+  };
 
-    const data = {
-      activeLearners: activeLearners.past_week,
-      numberOfUsers,
-      courseCompletions,
-      enrolledLearners,
-    };
-
-    return Object.keys(this.cards).map(cardKey => (
-      this.renderCard({
-        title: data[cardKey],
-        cardKey,
-      })
-    ));
-  }
-}
+  return Object.keys(cards).map(cardKey => (
+    renderCard({
+      title: data[cardKey],
+      cardKey,
+    })
+  ));
+};
 
 AdminCards.propTypes = {
   activeLearners: PropTypes.shape({
@@ -149,8 +142,6 @@ AdminCards.propTypes = {
   numberOfUsers: PropTypes.number.isRequired,
   courseCompletions: PropTypes.number.isRequired,
   enrolledLearners: PropTypes.number.isRequired,
-  // injected
-  intl: intlShape.isRequired,
 };
 
-export default injectIntl(AdminCards);
+export default AdminCards;

--- a/src/components/AdminV2/AdminSearchForm.jsx
+++ b/src/components/AdminV2/AdminSearchForm.jsx
@@ -1,12 +1,12 @@
 /* eslint-disable camelcase */
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { Form } from '@openedx/paragon';
 import { Info } from '@openedx/paragon/icons';
 
-import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
 import { sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 
 import SearchBar from '../SearchBar';
@@ -15,36 +15,25 @@ import IconWithTooltip from '../IconWithTooltip';
 import { withLocation, withNavigate } from '../../hoc';
 import EVENT_NAMES from '../../eventTracking';
 
-class AdminSearchForm extends React.Component {
-  componentDidUpdate(prevProps) {
-    const {
-      searchParams: {
-        searchQuery, searchCourseQuery, searchDateQuery, searchBudgetQuery, searchGroupQuery,
-      },
-    } = this.props;
-    const {
-      searchParams: {
-        searchQuery: prevSearchQuery,
-        searchCourseQuery: prevSearchCourseQuery,
-        searchDateQuery: prevSearchDateQuery,
-        searchBudgetQuery: prevSearchBudgetQuery,
-        searchGroupQuery: prevSearchGroupQuery,
-      },
-    } = prevProps;
+const AdminSearchForm = ({
+  searchEnrollmentsList,
+  searchParams: {
+    searchQuery, searchCourseQuery, searchDateQuery, searchBudgetQuery, searchGroupQuery,
+  },
+  tableData = [],
+  budgets,
+  groups,
+  navigate,
+  location,
+  enterpriseId,
+}) => {
+  const intl = useIntl();
 
-    if (searchQuery !== prevSearchQuery || searchCourseQuery !== prevSearchCourseQuery
-        || searchDateQuery !== prevSearchDateQuery || searchBudgetQuery !== prevSearchBudgetQuery
-        || searchGroupQuery !== prevSearchGroupQuery) {
-      this.handleSearch();
-    }
-  }
+  useEffect(() => {
+    searchEnrollmentsList();
+  }, [searchEnrollmentsList]);
 
-  handleSearch() {
-    this.props.searchEnrollmentsList();
-  }
-
-  onCourseSelect(event) {
-    const { navigate, location } = this.props;
+  const onCourseSelect = (event) => {
     const updateParams = {
       search_course: event.target.value,
       page: 1,
@@ -53,249 +42,235 @@ class AdminSearchForm extends React.Component {
       updateParams.search_start_date = '';
     }
     updateUrl(navigate, location.pathname, updateParams);
-  }
+  };
 
-  onBudgetSelect(event) {
-    const { navigate, location } = this.props;
+  const onBudgetSelect = (event) => {
     const updateParams = {
       budget_uuid: event.target.value,
       page: 1,
     };
     updateUrl(navigate, location.pathname, updateParams);
-  }
+  };
 
-  onGroupSelect(event) {
-    const { navigate, location } = this.props;
+  const onGroupSelect = (event) => {
     const updateParams = {
       group_uuid: event.target.value,
       page: 1,
     };
     updateUrl(navigate, location.pathname, updateParams);
     sendEnterpriseTrackEvent(
-      this.props.enterpriseId,
+      enterpriseId,
       EVENT_NAMES.LEARNER_PROGRESS_REPORT.FILTER_BY_GROUP_DROPDOWN,
       { group: event.target.value },
     );
-  }
+  };
 
-  render() {
-    const {
-      intl,
-      tableData,
-      budgets,
-      groups,
-      searchParams: {
-        searchCourseQuery, searchDateQuery, searchQuery, searchBudgetQuery, searchGroupQuery,
-      },
-    } = this.props;
+  const courseTitles = Array.from(new Set(tableData.map(en => en.course_title).sort()));
+  const courseDates = Array.from(new Set(tableData.map(en => en.course_start_date).sort().reverse()));
+  const columnWidth = (budgets?.length || groups?.length) ? 'col-md-3' : 'col-md-6';
 
-    const courseTitles = Array.from(new Set(tableData.map(en => en.course_title).sort()));
-    const courseDates = Array.from(new Set(tableData.map(en => en.course_start_date).sort().reverse()));
-    const columnWidth = (budgets?.length || groups?.length) ? 'col-md-3' : 'col-md-6';
-
-    return (
-      <div className="row">
-        <div className="col-12 pr-md-0 mb-0">
-          <div className="row w-100 m-0">
-            {groups?.length ? (
-              <div className="col-12 col-md-3 my-2 my-md-0 px-0 px-md-2 px-lg-3">
-                <Form.Group>
-                  <Form.Label className="search-label mb-2">
-                    <FormattedMessage
-                      id="admin.portal.lpr.filter.by.group.dropdown.label"
-                      defaultMessage="Filter by group"
-                      description="Label for the group filter dropdown in the admin portal LPR page."
-                    />
-                  </Form.Label>
-                  <Form.Control
-                    data-testid="admin-search-form-control"
-                    className="w-100 groups-dropdown"
-                    as="select"
-                    value={searchGroupQuery}
-                    onChange={e => this.onGroupSelect(e)}
-                  >
-                    <option value="">
-                      {intl.formatMessage({
-                        id: 'admin.portal.lpr.v2.filter.by.group.dropdown.option.all.groups',
-                        defaultMessage: 'All groups',
-                        description: 'Label for the all groups option in the group filter dropdown in the admin portal LPR page.',
-                      })}
-                    </option>
-                    {groups.map(group => (
-                      <option
-                        value={group.uuid}
-                        key={group.uuid}
-                      >
-                        {group.name}
-                      </option>
-                    ))}
-                  </Form.Control>
-                </Form.Group>
-              </div>
-            ) : null}
-            <div className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3">
+  return (
+    <div className="row">
+      <div className="col-12 pr-md-0 mb-0">
+        <div className="row w-100 m-0">
+          {groups?.length ? (
+            <div className="col-12 col-md-3 my-2 my-md-0 px-0 px-md-2 px-lg-3">
               <Form.Group>
                 <Form.Label className="search-label mb-2">
                   <FormattedMessage
-                    id="admin.portal.lpr.filter.by.course.dropdown.label"
-                    defaultMessage="Filter by course"
-                    description="Label for the course filter dropdown in the admin portal LPR page."
+                    id="admin.portal.lpr.filter.by.group.dropdown.label"
+                    defaultMessage="Filter by group"
+                    description="Label for the group filter dropdown in the admin portal LPR page."
                   />
                 </Form.Label>
                 <Form.Control
                   data-testid="admin-search-form-control"
-                  className="w-100 course-dropdown"
+                  className="w-100 groups-dropdown"
                   as="select"
-                  value={searchCourseQuery}
-                  onChange={e => this.onCourseSelect(e)}
+                  value={searchGroupQuery}
+                  onChange={e => onGroupSelect(e)}
                 >
                   <option value="">
                     {intl.formatMessage({
-                      id: 'admin.portal.lpr.v2.filter.by.course.dropdown.option.all.courses',
-                      defaultMessage: 'All courses',
-                      description: 'Label for the all courses option in the course filter dropdown in the admin portal LPR page.',
+                      id: 'admin.portal.lpr.v2.filter.by.group.dropdown.option.all.groups',
+                      defaultMessage: 'All groups',
+                      description: 'Label for the all groups option in the group filter dropdown in the admin portal LPR page.',
                     })}
                   </option>
-                  {courseTitles.map(title => (
+                  {groups.map(group => (
                     <option
-                      value={title}
-                      key={title}
+                      value={group.uuid}
+                      key={group.uuid}
                     >
-                      {title}
+                      {group.name}
                     </option>
                   ))}
                 </Form.Control>
               </Form.Group>
             </div>
-            <div className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3">
+          ) : null}
+          <div className="col-12 col-md-3 px-0 pl-0 pr-md-2 pr-lg-3">
+            <Form.Group>
+              <Form.Label className="search-label mb-2">
+                <FormattedMessage
+                  id="admin.portal.lpr.filter.by.course.dropdown.label"
+                  defaultMessage="Filter by course"
+                  description="Label for the course filter dropdown in the admin portal LPR page."
+                />
+              </Form.Label>
+              <Form.Control
+                data-testid="admin-search-form-control"
+                className="w-100 course-dropdown"
+                as="select"
+                value={searchCourseQuery}
+                onChange={e => onCourseSelect(e)}
+              >
+                <option value="">
+                  {intl.formatMessage({
+                    id: 'admin.portal.lpr.v2.filter.by.course.dropdown.option.all.courses',
+                    defaultMessage: 'All courses',
+                    description: 'Label for the all courses option in the course filter dropdown in the admin portal LPR page.',
+                  })}
+                </option>
+                {courseTitles.map(title => (
+                  <option
+                    value={title}
+                    key={title}
+                  >
+                    {title}
+                  </option>
+                ))}
+              </Form.Control>
+            </Form.Group>
+          </div>
+          <div className="col-12 col-md-3 px-0 pr-0 px-md-2 px-lg-3">
+            <Form.Group>
+              <Form.Label className="search-label mb-2 d-flex align-items-center">
+                <span>
+                  <FormattedMessage
+                    id="admin.portal.lpr.filter.by.start.date.dropdown.label"
+                    defaultMessage="Filter by start date"
+                    description="Label for the start date filter dropdown in the admin portal LPR page."
+                  />
+                </span>
+                <IconWithTooltip
+                  icon={Info}
+                  altText={intl.formatMessage({
+                    id: 'admin.portal.lpr.filter.by.start.date.alt.text',
+                    defaultMessage: 'More information',
+                    description: 'Alt text for the info icon in the start date filter dropdown in the admin portal LPR page.',
+                  })}
+                  tooltipText={intl.formatMessage({
+                    id: 'admin.portal.lpr.filter.by.start.date.dropdown.tooltip',
+                    defaultMessage: 'A start date can be selected after the course name is selected.',
+                    description: 'Tooltip text for the start date filter dropdown in the admin portal LPR page.',
+                  })}
+                />
+              </Form.Label>
+              <Form.Control
+                data-testid="admin-search-form-control"
+                as="select"
+                className="w-100 start-date-dropdown"
+                value={searchDateQuery}
+                onChange={event => updateUrl(navigate, location.pathname, {
+                  search_start_date: event.target.value,
+                  page: 1,
+                })}
+                disabled={!searchCourseQuery}
+              >
+                <option value="">
+                  {searchCourseQuery ? intl.formatMessage({
+                    id: 'admin.portal.lpr.filter.by.start.date.dropdown.option.all.dates',
+                    defaultMessage: 'All Dates',
+                    description: 'Label for the all dates option in the start date filter dropdown in the admin portal LPR page.',
+                  }) : intl.formatMessage({
+                    id: 'admin.portal.lpr.filter.by.start.date.dropdown.option.choose.course',
+                    defaultMessage: 'Choose a course',
+                    description: 'Label for the Choose a course option in the start date filter dropdown in the admin portal LPR page.',
+                  })}
+                </option>
+                {searchCourseQuery && courseDates.map(date => (
+                  <option
+                    value={date}
+                    key={date}
+                  >
+                    {intl.formatDate(formatTimestamp({ timestamp: date }), {
+                      year: 'numeric',
+                      month: 'long',
+                      day: 'numeric',
+                    })}
+                  </option>
+                ))}
+              </Form.Control>
+            </Form.Group>
+          </div>
+          {budgets?.length ? (
+            <div className="col-12 col-md-3 my-2 my-md-0 px-0 px-md-2 px-lg-3">
               <Form.Group>
-                <Form.Label className="search-label mb-2 d-flex align-items-center">
-                  <span>
-                    <FormattedMessage
-                      id="admin.portal.lpr.filter.by.start.date.dropdown.label"
-                      defaultMessage="Filter by start date"
-                      description="Label for the start date filter dropdown in the admin portal LPR page."
-                    />
-                  </span>
-                  <IconWithTooltip
-                    icon={Info}
-                    altText={intl.formatMessage({
-                      id: 'admin.portal.lpr.filter.by.start.date.alt.text',
-                      defaultMessage: 'More information',
-                      description: 'Alt text for the info icon in the start date filter dropdown in the admin portal LPR page.',
-                    })}
-                    tooltipText={intl.formatMessage({
-                      id: 'admin.portal.lpr.filter.by.start.date.dropdown.tooltip',
-                      defaultMessage: 'A start date can be selected after the course name is selected.',
-                      description: 'Tooltip text for the start date filter dropdown in the admin portal LPR page.',
-                    })}
+                <Form.Label className="search-label mb-2">
+                  <FormattedMessage
+                    id="admin.portal.lpr.filter.by.budget.dropdown.label"
+                    defaultMessage="Filter by budget"
+                    description="Label for the budget filter dropdown in the admin portal LPR page."
                   />
                 </Form.Label>
                 <Form.Control
                   data-testid="admin-search-form-control"
+                  className="w-100 budgets-dropdown"
                   as="select"
-                  className="w-100 start-date-dropdown"
-                  value={searchDateQuery}
-                  onChange={event => updateUrl(this.props.navigate, this.props.location.pathname, {
-                    search_start_date: event.target.value,
-                    page: 1,
-                  })}
-                  disabled={!searchCourseQuery}
+                  value={searchBudgetQuery}
+                  onChange={e => onBudgetSelect(e)}
                 >
                   <option value="">
-                    {searchCourseQuery ? intl.formatMessage({
-                      id: 'admin.portal.lpr.filter.by.start.date.dropdown.option.all.dates',
-                      defaultMessage: 'All Dates',
-                      description: 'Label for the all dates option in the start date filter dropdown in the admin portal LPR page.',
-                    }) : intl.formatMessage({
-                      id: 'admin.portal.lpr.filter.by.start.date.dropdown.option.choose.course',
-                      defaultMessage: 'Choose a course',
-                      description: 'Label for the Choose a course option in the start date filter dropdown in the admin portal LPR page.',
+                    {intl.formatMessage({
+                      id: 'admin.portal.lpr.filter.by.budget.dropdown.option.all.budgets',
+                      defaultMessage: 'All budgets',
+                      description: 'Label for the all budgets option in the budget filter dropdown in the admin portal LPR page.',
                     })}
                   </option>
-                  {searchCourseQuery && courseDates.map(date => (
+                  {budgets.map(budget => (
                     <option
-                      value={date}
-                      key={date}
+                      value={budget.subsidy_access_policy_uuid}
+                      key={budget.subsidy_access_policy_uuid}
                     >
-                      {intl.formatDate(formatTimestamp({ timestamp: date }), {
-                        year: 'numeric',
-                        month: 'long',
-                        day: 'numeric',
-                      })}
+                      {budget.subsidy_access_policy_display_name}
                     </option>
                   ))}
                 </Form.Control>
               </Form.Group>
             </div>
-            {budgets?.length ? (
-              <div className="col-12 col-md-3 my-2 my-md-0 px-0 px-md-2 px-lg-3">
-                <Form.Group>
-                  <Form.Label className="search-label mb-2">
-                    <FormattedMessage
-                      id="admin.portal.lpr.filter.by.budget.dropdown.label"
-                      defaultMessage="Filter by budget"
-                      description="Label for the budget filter dropdown in the admin portal LPR page."
-                    />
-                  </Form.Label>
-                  <Form.Control
-                    data-testid="admin-search-form-control"
-                    className="w-100 budgets-dropdown"
-                    as="select"
-                    value={searchBudgetQuery}
-                    onChange={e => this.onBudgetSelect(e)}
-                  >
-                    <option value="">
-                      {intl.formatMessage({
-                        id: 'admin.portal.lpr.filter.by.budget.dropdown.option.all.budgets',
-                        defaultMessage: 'All budgets',
-                        description: 'Label for the all budgets option in the budget filter dropdown in the admin portal LPR page.',
-                      })}
-                    </option>
-                    {budgets.map(budget => (
-                      <option
-                        value={budget.subsidy_access_policy_uuid}
-                        key={budget.subsidy_access_policy_uuid}
-                      >
-                        {budget.subsidy_access_policy_display_name}
-                      </option>
-                    ))}
-                  </Form.Control>
-                </Form.Group>
-              </div>
-            ) : null }
-            <div className={classNames('col-12 my-2 my-md-0 px-0 px-md-2 px-lg-3', columnWidth)}>
-              <Form.Label id="search-email-label" className="mb-2">
-                <FormattedMessage
-                  id="admin.portal.lpr.filter.by.email.input.label"
-                  defaultMessage="Filter by email"
-                  description="Label for the email filter dropdown in the admin portal LPR page"
-                />
-              </Form.Label>
-              <SearchBar
-                data-testid="admin-search-bar"
-                placeholder={intl.formatMessage({
-                  id: 'admin.portal.lpr.filter.by.email.input.placeholder',
-                  defaultMessage: 'Search by email...',
-                  description: 'Placeholder text for the email filter input in the admin portal LPR page.',
-                })}
-                onSearch={query => updateUrl(this.props.navigate, this.props.location.pathname, {
-                  search: query,
-                  page: 1,
-                })}
-                onClear={() => updateUrl(this.props.navigate, this.props.location.pathname, { search: undefined })}
-                value={searchQuery}
-                aria-labelledby="search-email-label"
-                className="py-0"
-                inputProps={{ 'data-hj-suppress': true }}
+          ) : null }
+          <div className={classNames('col-12 my-2 my-md-0 px-0 px-md-2 px-lg-3', columnWidth)}>
+            <Form.Label id="search-email-label" className="mb-2">
+              <FormattedMessage
+                id="admin.portal.lpr.filter.by.email.input.label"
+                defaultMessage="Filter by email"
+                description="Label for the email filter dropdown in the admin portal LPR page"
               />
-            </div>
+            </Form.Label>
+            <SearchBar
+              data-testid="admin-search-bar"
+              placeholder={intl.formatMessage({
+                id: 'admin.portal.lpr.filter.by.email.input.placeholder',
+                defaultMessage: 'Search by email...',
+                description: 'Placeholder text for the email filter input in the admin portal LPR page.',
+              })}
+              onSearch={query => updateUrl(navigate, location.pathname, {
+                search: query,
+                page: 1,
+              })}
+              onClear={() => updateUrl(navigate, location.pathname, { search: undefined })}
+              value={searchQuery}
+              aria-labelledby="search-email-label"
+              className="py-0"
+              inputProps={{ 'data-hj-suppress': true }}
+            />
           </div>
         </div>
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
 
 AdminSearchForm.defaultProps = {
   tableData: [],
@@ -318,8 +293,6 @@ AdminSearchForm.propTypes = {
     pathname: PropTypes.string,
   }),
   enterpriseId: PropTypes.string,
-  // injected
-  intl: intlShape.isRequired,
 };
 
-export default withLocation(withNavigate(injectIntl(AdminSearchForm)));
+export default withLocation(withNavigate(AdminSearchForm));


### PR DESCRIPTION
# Description 
As part of Unit test improvement project, we replace all usages of the deprecated injectIntl HOC with the useIntl() hook from @edx/frontend-platform/i18n.
Closes https://github.com/openedx/frontend-app-admin-portal/issues/1591.
Class components were refactored into functional components in order to use the useIntl hook, and some unit tests related to them were modified to make them pass.

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
