### PR TITLE
feat: change help center text for BNR

### DIFF
--- a/src/components/learner-credit-management/request-status-chips/FailedCancellation.jsx
+++ b/src/components/learner-credit-management/request-status-chips/FailedCancellation.jsx
@@ -69,7 +69,7 @@ const FailedCancellation = ({ trackEvent }) => {
                   onClick={helpCenterTrackEvent}
                   target="_blank"
                 >
-                  Help Center
+                  Help Center: Learner Selected Content
                 </Hyperlink>
               </li>
             </ul>

--- a/src/components/learner-credit-management/request-status-chips/FailedRedemption.jsx
+++ b/src/components/learner-credit-management/request-status-chips/FailedRedemption.jsx
@@ -70,7 +70,7 @@ const FailedRedemption = ({ trackEvent }) => {
                   onClick={helpCenterTrackEvent}
                   target="_blank"
                 >
-                  Help Center
+                  Help Center: Learner Selected Content
                 </Hyperlink>.
               </li>
             </ul>

--- a/src/components/learner-credit-management/request-status-chips/WaitingForLearner.jsx
+++ b/src/components/learner-credit-management/request-status-chips/WaitingForLearner.jsx
@@ -61,7 +61,7 @@ const WaitingForLearner = ({ learnerEmail, trackEvent }) => {
                 onClick={helpCenterTrackEvent}
                 target="_blank"
               >
-                Help Center: Course Assignments
+                Help Center: Learner Selected Content
               </Hyperlink>.
             </p>
           </div>

--- a/src/components/learner-credit-management/requests-tab/RequestFailureModal.jsx
+++ b/src/components/learner-credit-management/requests-tab/RequestFailureModal.jsx
@@ -41,7 +41,7 @@ const RequestFailureModal = ({
                 }
                 target="_blank"
               >
-                Help Center
+                Help Center: Learner Selected Content
               </Hyperlink>
             </li>
           </ul>

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -1863,7 +1863,7 @@ describe('<BudgetDetailPage />', () => {
       expect(screen.getByText('This approved request was not canceled. Something went wrong behind the scenes.')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('Help Center')).toBeInTheDocument();
+    expect(screen.getByText('Help Center: Learner Selected Content')).toBeInTheDocument();
   });
 
   it('renders failed redemption status chip and handles interactions', async () => {
@@ -1940,7 +1940,7 @@ describe('<BudgetDetailPage />', () => {
       expect(screen.getByText('Something went wrong behind the scenes when the learner attempted to redeem the requested course. Associated Learner credit funds have been released into your available balance.')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('Help Center')).toBeInTheDocument();
+    expect(screen.getByText('Help Center: Learner Selected Content')).toBeInTheDocument();
   });
 
   it('renders request status cells with different statuses', async () => {


### PR DESCRIPTION
**Ticket:** [ENT-10742](https://2u-internal.atlassian.net/browse/ENT-10742)
**Description:** Changed text on status chips from `Help Center` to `Help Center: Learner Selected Content`.

# For all changes

- [x] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [x] Ensure to attach screenshots
- [x] Ensure to have UX team confirm screenshots

<img width="488" height="255" alt="image" src="https://github.com/user-attachments/assets/6f4e9a4d-737c-4258-88c3-9e4cfc2b4a21" />
<img width="488" height="271" alt="image" src="https://github.com/user-attachments/assets/008d476a-9406-4ba6-865a-3488f2245233" />
<img width="976" height="638" alt="image" src="https://github.com/user-attachments/assets/69e85a5c-c6e8-4e77-81e8-30d51c667fab" />
<img width="488" height="319" alt="image" src="https://github.com/user-attachments/assets/2319ea48-1999-4a86-b404-2983583afcb7" />

