### PR TITLE
Replace of injectIntl with useIntl() 2/4

### DIFF
--- a/src/components/learner-credit-management/search/CatalogSearchResults.jsx
+++ b/src/components/learner-credit-management/search/CatalogSearchResults.jsx
@@ -1,9 +1,9 @@
-import React, { useContext, useEffect, useMemo } from 'react';
+import { useContext, useEffect, useMemo } from 'react';
 import { connectStateResults } from 'react-instantsearch-dom';
 import PropTypes from 'prop-types';
 
 import { SearchPagination, SearchContext } from '@edx/frontend-enterprise-catalog-search';
-import { FormattedMessage, injectIntl } from '@edx/frontend-platform/i18n';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
 import {
   Alert, CardView, DataTable, TextFilter,
 } from '@openedx/paragon';
@@ -141,4 +141,4 @@ BaseCatalogSearchResults.propTypes = {
   setNoContent: PropTypes.func,
 };
 
-export default connectStateResults(injectIntl(BaseCatalogSearchResults));
+export default connectStateResults(BaseCatalogSearchResults);

--- a/src/components/subscriptions/SubscriptionDetails.jsx
+++ b/src/components/subscriptions/SubscriptionDetails.jsx
@@ -1,8 +1,8 @@
-import React, { useContext, useState } from 'react';
+import { useContext, useState } from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 import dayjs from 'dayjs';
 import {
   Button, Row, Col, Toast, Icon,
@@ -15,7 +15,10 @@ import { SubscriptionContext } from './SubscriptionData';
 import SubscriptionExpirationBanner from './expiration/SubscriptionExpirationBanner';
 import { MANAGE_LEARNERS_TAB } from './data/constants';
 
-const SubscriptionDetails = ({ enterpriseSlug, intl }) => {
+const SubscriptionDetails = ({
+  enterpriseSlug,
+}) => {
+  const intl = useIntl();
   const { forceRefresh } = useContext(SubscriptionContext);
   const {
     hasMultipleSubscriptions,
@@ -138,11 +141,10 @@ const SubscriptionDetails = ({ enterpriseSlug, intl }) => {
 
 SubscriptionDetails.propTypes = {
   enterpriseSlug: PropTypes.string.isRequired,
-  intl: intlShape.isRequired,
 };
 
 const mapStateToProps = state => ({
   enterpriseSlug: state.portalConfiguration.enterpriseSlug,
 });
 
-export default connect(mapStateToProps)(injectIntl(SubscriptionDetails));
+export default connect(mapStateToProps)(SubscriptionDetails);

--- a/src/components/subscriptions/SubscriptionManagementPage.jsx
+++ b/src/components/subscriptions/SubscriptionManagementPage.jsx
@@ -1,15 +1,17 @@
-import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 import { Container } from '@openedx/paragon';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import Hero from '../Hero';
 import SubscriptionData from './SubscriptionData';
 import SubscriptionRoutes from './SubscriptionRoutes';
 
-const SubscriptionManagementPage = ({ enterpriseId, intl }) => {
+const SubscriptionManagementPage = ({
+  enterpriseId,
+}) => {
+  const intl = useIntl();
   const PAGE_TITLE = intl.formatMessage({
     id: 'admin.portal.subscription.management.page.title',
     defaultMessage: 'Subscription Management',
@@ -31,11 +33,10 @@ const SubscriptionManagementPage = ({ enterpriseId, intl }) => {
 
 SubscriptionManagementPage.propTypes = {
   enterpriseId: PropTypes.string.isRequired,
-  intl: intlShape.isRequired,
 };
 
 const mapStateToProps = state => ({
   enterpriseId: state.portalConfiguration.enterpriseId,
 });
 
-export default connect(mapStateToProps)(injectIntl(SubscriptionManagementPage));
+export default connect(mapStateToProps)(SubscriptionManagementPage);

--- a/src/components/subscriptions/buttons/DownloadCsvButton.jsx
+++ b/src/components/subscriptions/buttons/DownloadCsvButton.jsx
@@ -1,14 +1,15 @@
-import React, { useContext, useState } from 'react';
+import { useContext, useState } from 'react';
 import { StatefulButton, Icon, Spinner } from '@openedx/paragon';
 import { Download, Check } from '@openedx/paragon/icons';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { logError } from '@edx/frontend-platform/logging';
 import { saveAs } from 'file-saver';
 import { SubscriptionDetailContext } from '../SubscriptionDetailContextProvider';
 import LicenseManagerApiService from '../../../data/services/LicenseManagerAPIService';
 
-const DownloadCsvButton = ({ intl }) => {
+const DownloadCsvButton = () => {
+  const intl = useIntl();
   const { subscription } = useContext(SubscriptionDetailContext);
   const [buttonState, setButtonState] = useState('default');
 
@@ -71,8 +72,4 @@ const DownloadCsvButton = ({ intl }) => {
   );
 };
 
-DownloadCsvButton.propTypes = {
-  intl: intlShape.isRequired,
-};
-
-export default injectIntl(DownloadCsvButton);
+export default DownloadCsvButton;

--- a/src/components/subscriptions/buttons/InviteLearnersButton.jsx
+++ b/src/components/subscriptions/buttons/InviteLearnersButton.jsx
@@ -1,6 +1,6 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useIntl } from '@edx/frontend-platform/i18n';
 
 import InviteLearnersModal from '../../../containers/InviteLearnersModal';
 import ActionButtonWithModal from '../../ActionButtonWithModal';
@@ -9,8 +9,11 @@ import { SubscriptionDetailContext } from '../SubscriptionDetailContextProvider'
 export const INVITE_LEARNERS_BUTTON_TEXT = 'Invite learners';
 
 const InviteLearnersButton = ({
-  onSuccess, onClose, disabled, intl,
+  onSuccess,
+  onClose,
+  disabled,
 }) => {
+  const intl = useIntl();
   const { overview, subscription } = useContext(SubscriptionDetailContext);
   return (
     <ActionButtonWithModal
@@ -43,7 +46,6 @@ InviteLearnersButton.propTypes = {
   onSuccess: PropTypes.func.isRequired,
   onClose: PropTypes.func,
   disabled: PropTypes.bool,
-  intl: intlShape.isRequired,
 };
 
 InviteLearnersButton.defaultProps = {
@@ -51,4 +53,4 @@ InviteLearnersButton.defaultProps = {
   disabled: false,
 };
 
-export default injectIntl(InviteLearnersButton);
+export default InviteLearnersButton;


### PR DESCRIPTION
### Description
As part of the project for improvements as follow up of react-unit-test-utils, we are going to replace all usages of the deprecated `injectIntl` HOC with the `useIntl()` hook from @edx/frontend-platform/i18n. It is a very straight-forward change, in order to accomplish this we did the following changes:

- In components we have to remove the old `injectIntl`, remove intl as a prop and use the hook instead.
- In tests we need to stop using `injectIntl` and just use the desired component wrapped in a `IntlProvider` (from @edx/frontend-platform/i18n).

Files to refactor:
- src/components/learner-credit-management/search/CatalogSearchResults.jsx
- src/components/subscriptions/SubscriptionDetails.jsx
- src/components/subscriptions/SubscriptionManagementPage.jsx
- src/components/subscriptions/buttons/DownloadCsvButton.jsx
- src/components/subscriptions/buttons/InviteLearnersButton.jsx

#### Support Information
Closes #1592 
