### PR TITLE
fix: add Learn More link to zero state groups tour step

### DIFF
--- a/src/components/ProductTours/AdminOnboardingTours/flows/OrganizeLearnersFlow.tsx
+++ b/src/components/ProductTours/AdminOnboardingTours/flows/OrganizeLearnersFlow.tsx
@@ -1,10 +1,12 @@
-import { useIntl } from '@edx/frontend-platform/i18n';
+import { useIntl, FormattedMessage } from '@edx/frontend-platform/i18n';
+import { Hyperlink } from '@openedx/paragon';
 
 import { ADMIN_TOUR_EVENT_NAMES, ORGANIZE_LEARNER_TARGETS } from '../constants';
 import messages from '../messages';
 import { configuration } from '../../../../config';
 import { TourStep } from '../../types';
 import useHydrateAdminOnboardingData, { HydratedAdminOnboardingData } from '../data/useHydrateAdminOnboardingData';
+import { ENTERPRISE_HELP_GROUPING } from '../../../settings/data/constants';
 
 interface OrganizeLearnersFlowProps {
   enterpriseId: string;
@@ -25,6 +27,20 @@ const OrganizeLearnersFlow = ({
     configuration.ADMIN_ONBOARDING_UUIDS.FLOW_ORGANIZE_LEARNERS_UUID,
   );
   const onOrganizeBack = () => handleBackTour(ADMIN_TOUR_EVENT_NAMES.ORGANIZE_LEARNERS_BACK_EVENT_NAME);
+
+  const createGroupStepBody = <FormattedMessage
+    {...messages.organizeLearnersStepFiveBody}
+    values={{
+      a: (chunks) => (
+        <Hyperlink
+          destination={ENTERPRISE_HELP_GROUPING}
+          target="_blank"
+        >
+          {chunks}
+        </Hyperlink>
+      ),
+    }}
+  />
 
   const tourNoMembers: Array<TourStep> = [{
     target: `#${ORGANIZE_LEARNER_TARGETS.PEOPLE_MANAGEMENT_SIDEBAR}`,
@@ -61,7 +77,7 @@ const OrganizeLearnersFlow = ({
   }, {
     target: `#${ORGANIZE_LEARNER_TARGETS.CREATE_GROUP_BUTTON}`,
     placement: 'left',
-    body: intl.formatMessage(messages.organizeLearnersStepFiveBody),
+    body: createGroupStepBody,
     onEnd: onOrganizeEnd,
     onBack: onOrganizeBack,
   }];

--- a/src/components/ProductTours/AdminOnboardingTours/messages.js
+++ b/src/components/ProductTours/AdminOnboardingTours/messages.js
@@ -135,7 +135,7 @@ const messages = defineMessages({
   },
   organizeLearnersStepFiveBody: {
     id: 'adminPortal.productTours.adminOnboarding.organizeLearners.body.5',
-    defaultMessage: 'When you\'re ready, use "Create Group" to get started.',
+    defaultMessage: 'When you\'re ready, use "Create Group" to get started. <a>Learn more</a>.',
     description: 'Description for the organize learners flow step five',
   },
   organizeLearnersWithGroupsStepFourBody: {

--- a/src/components/ProductTours/AdminOnboardingTours/tests/OrganizeLearnersFlow.test.jsx
+++ b/src/components/ProductTours/AdminOnboardingTours/tests/OrganizeLearnersFlow.test.jsx
@@ -88,8 +88,8 @@ describe('useCreateOrganizeLearnersFlow', () => {
     expect(flow[4]).toMatchObject({
       target: `#${ORGANIZE_LEARNER_TARGETS.CREATE_GROUP_BUTTON}`,
       placement: 'left',
-      body: messages.organizeLearnersStepFiveBody.defaultMessage,
     });
+    expect(flow[4].body.props).toMatchObject(messages.organizeLearnersStepFiveBody);
   });
 
   it('uses correct target selectors for organize learners flow', () => {

--- a/src/components/settings/data/constants.js
+++ b/src/components/settings/data/constants.js
@@ -42,6 +42,7 @@ export const HELP_CENTER_GROUPS_INVITE_LINK = 'https://business-support.edx.org/
 
 export const API_CLIENT_DOCUMENTATION = 'https://edx-enterprise-api.readthedocs.io/en/latest/index.html';
 export const API_TERMS_OF_SERVICE = 'https://courses.edx.org/api-admin/terms-of-service/';
+export const ENTERPRISE_HELP_GROUPING = 'https://enterprise-support.edx.org/s/article/Grouping-Functionality';
 export const ENTERPRISE_CUSTOMER_SUPPORT_EMAIL = 'enterprise-support@edx.org';
 
 export const ACTIVATE_TOAST_MESSAGE = 'Learning platform integration successfully activated.';


### PR DESCRIPTION
[Jira Ticket](https://2u-internal.atlassian.net/browse/ENT-10795)

Adds 'Learn more' link to Groups page tour

## Testing Instructions
- Check out branch and start server with `npm run start:stage`
- Navigate to https://localhost.stage.edx.org:1991/bessie-test-inc/admin/people-management/
- Open Tour button and click on 'Organize learner'
- Navigate to step 5, and click 'Learn more', verify it takes to enterprise support page about groups

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
