### PR TITLE
feat: add codes deprecation alert

### DIFF
--- a/src/components/CodeDeprecationAlert/CodeDeprecationAlert.tsx
+++ b/src/components/CodeDeprecationAlert/CodeDeprecationAlert.tsx
@@ -1,0 +1,28 @@
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { Alert } from '@openedx/paragon';
+import React from 'react';
+
+const boldRichText = { b: (chunks: React.ReactNode) => <b>{chunks}</b> };
+
+const CodeDeprecationAlert = (): React.ReactNode => (
+  <Alert
+    variant="info"
+  >
+    <Alert.Heading>
+      <FormattedMessage
+        id="admin.portal.codes.codeDeprecationAlert.header"
+        defaultMessage="<b>Feature deprecation notice:</b>"
+        description="Header indicating the deprecation of a current feature"
+        values={boldRichText}
+      />
+    </Alert.Heading>
+    <FormattedMessage
+      id="admin.portal.codes.codeDeprecationAlert.message"
+      defaultMessage="The codes feature will be retired after <b>September 30</b>, upon retirement all codes will no longer be valid. We will be sharing more details soon about new enrollment options."
+      description="Message to inform user of an impending deprecation of the current feature"
+      values={boldRichText}
+    />
+  </Alert>
+);
+
+export default CodeDeprecationAlert;

--- a/src/components/CodeManagement/ManageCodesTab.jsx
+++ b/src/components/CodeManagement/ManageCodesTab.jsx
@@ -4,10 +4,7 @@ import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import {
-  Alert,
-  Button,
-  Icon,
-  Pagination,
+  Alert, Button, Icon, Pagination,
 } from '@openedx/paragon';
 import {
   CheckCircle, Info, Plus, SpinnerIcon, WarningFilled,
@@ -19,12 +16,13 @@ import CodeSearchResults from '../CodeSearchResults';
 import LoadingMessage from '../LoadingMessage';
 import Coupon from '../Coupon';
 import { updateUrl } from '../../utils';
-import { fetchCouponOrders, clearCouponOrders } from '../../data/actions/coupons';
+import { clearCouponOrders, fetchCouponOrders } from '../../data/actions/coupons';
 import { ROUTE_NAMES } from '../EnterpriseApp/data/constants';
 import NewFeatureAlertBrowseAndRequest from '../NewFeatureAlertBrowseAndRequest';
 import { SubsidyRequestsContext } from '../subsidy-requests';
 import { SUPPORTED_SUBSIDY_TYPES } from '../../data/constants/subsidyRequests';
 import { withLocation, withNavigate } from '../../hoc';
+import CodeDeprecationAlert from '../CodeDeprecationAlert/CodeDeprecationAlert';
 
 class ManageCodesTab extends React.Component {
   constructor(props) {
@@ -279,6 +277,7 @@ class ManageCodesTab extends React.Component {
     return (
       <>
         {this.renderRequestCodesSuccessMessage()}
+        <CodeDeprecationAlert />
         {isBrowseAndRequestFeatureAlertShown && <NewFeatureAlertBrowseAndRequest />}
         <div className="row mt-4 mb-3 no-gutters">
           <div className="col-12 col-xl-3 mb-3 mb-xl-0">

--- a/src/components/subscriptions/data/constants.js
+++ b/src/components/subscriptions/data/constants.js
@@ -57,9 +57,6 @@ export const SUBSCRIPTION_STATUS_BADGE_MAP = {
 
 // Browse and request constants `BrowseAndRequestAlert`
 export const BROWSE_AND_REQUEST_ALERT_COOKIE_PREFIX = 'dismissed-browse-and-request-alert';
-export const BROWSE_AND_REQUEST_ALERT_TEXT = 'New! You can now allow all learners to browse'
-+ ' your catalog and request enrollment to courses.';
-export const REDIRECT_SETTINGS_BUTTON_TEXT = 'Go to settings';
 
 // Tabs
 export const MANAGE_LEARNERS_TAB = 'manage-learners';
@@ -92,14 +89,3 @@ export const DEFAULT_TAB = MANAGE_LEARNERS_TAB;
  * Consumed by useCurrentSubscriptionsTab hook to get tab value
  */
 export const SUBSCRIPTIONS_TAB_PARAM = 'subscriptionsTab';
-
-/**
- * Generates subscriptions url matching from SUBSCRIPTION_TABS_VALUES
- * @example :subscriptionsTab(tab0|tab1)?/
- */
-const generatePathMatch = () => {
-  const matchTabs = Object.values(SUBSCRIPTION_TABS_VALUES).join('|');
-  return `:${SUBSCRIPTIONS_TAB_PARAM}(${matchTabs})?/`;
-};
-
-export const SUBSCRIPTIONS_PARAM_MATCH = generatePathMatch();

--- a/src/types/paragon.d.ts
+++ b/src/types/paragon.d.ts
@@ -1,0 +1,8 @@
+import { AlertHeadingProps as OriginalAlertHeadingProps } from '@openedx/paragon';
+
+declare module '@openedx/paragon' {
+  // Extend the AlertHeadingProps interface to include className
+  export interface AlertHeadingProps extends OriginalAlertHeadingProps {
+    className?: string;
+  }
+}


### PR DESCRIPTION
Adds a persistent deprecation alert to the top of the codes management page. The intention is to convey the end of feature and support of the codes subsidy.

<img width="1512" height="547" alt="Screenshot 2025-08-27 at 12 20 56 PM" src="https://github.com/user-attachments/assets/03b35bbe-209d-4738-af57-3cd911488488" />

