### PR TITLE
chore: remove the faker package from repo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,6 @@
       "devDependencies": {
         "@edx/browserslist-config": "1.5.0",
         "@edx/typescript-config": "1.1.0",
-        "@faker-js/faker": "^7.6.0",
         "@openedx/frontend-build": "14.5.0",
         "@testing-library/dom": "10.4.0",
         "@testing-library/jest-dom": "5.17.0",
@@ -2704,17 +2703,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@faker-js/faker": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
-      "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=6.0.0"
       }
     },
     "node_modules/@floating-ui/core": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
   "devDependencies": {
     "@edx/browserslist-config": "1.5.0",
     "@edx/typescript-config": "1.1.0",
-    "@faker-js/faker": "^7.6.0",
     "@openedx/frontend-build": "14.5.0",
     "@testing-library/dom": "10.4.0",
     "@testing-library/jest-dom": "5.17.0",

--- a/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
+++ b/src/components/learner-credit-management/tests/BudgetDetailPage.test.jsx
@@ -13,7 +13,6 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { renderWithRouter, sendEnterpriseTrackEvent } from '@edx/frontend-enterprise-utils';
 import { act } from 'react-dom/test-utils';
 import { v4 as uuidv4, validate as uuidValidate } from 'uuid';
-import { faker } from '@faker-js/faker';
 import dayjs from 'dayjs';
 
 import EnterpriseAccessApiService from '../../../data/services/EnterpriseAccessApiService';
@@ -25,6 +24,7 @@ import {
   PAGE_SIZE,
   useBudgetContentAssignments,
   useBudgetDetailActivityOverview,
+  useBudgetId,
   useBudgetRedemptions,
   useEnterpriseCustomer,
   useEnterpriseFlexGroups,
@@ -35,12 +35,8 @@ import {
   useIsLargeOrGreater,
   useSubsidyAccessPolicy,
   useSubsidySummaryAnalyticsApi,
-  useBudgetId,
 } from '../data';
-import {
-  BUDGET_DETAIL_ACTIVITY_TAB,
-  BUDGET_DETAIL_CATALOG_TAB,
-} from '../data/constants';
+import { BUDGET_DETAIL_ACTIVITY_TAB, BUDGET_DETAIL_CATALOG_TAB } from '../data/constants';
 import { EnterpriseSubsidiesContext } from '../../EnterpriseSubsidiesContext';
 import {
   mockAssignableSubsidyAccessPolicy,
@@ -178,7 +174,7 @@ const mockLearnerContentAssignment = {
 const createMockLearnerContentAssignment = () => ({
   ...mockLearnerContentAssignment,
   uuid: uuidv4(),
-  learnerEmail: faker.internet.email(),
+  learnerEmail: 'example@edx.org',
 });
 const mockEnrollmentTransactionReversal = {
   uuid: 'test-transaction-reversal-uuid',
@@ -235,7 +231,7 @@ const mockApprovedRequest = {
 const createMockApprovedRequest = () => ({
   ...mockApprovedRequest,
   uuid: uuidv4(),
-  email: faker.internet.email(),
+  email: 'example@edx.org',
 });
 
 const mockEmptyApprovedRequests = {


### PR DESCRIPTION
Follow up to recently merged PR -> https://github.com/openedx/frontend-app-admin-portal/pull/1194 which takes the initiative to optimize the bundled package by removing usage of [faker-js](https://www.npmjs.com/package/@faker-js/faker).

Removes the  faker-js package from the repo. The only remaining usage was a set of fake email addresses that has been hard coded. There are no factories that exist that utilize faker.



