### PR TITLE
[ENT-10849] Enable all filters for metrics on engagement and outcomes tab

### DIFF
--- a/src/components/AdvanceAnalyticsV2.0/AnalyticsFilters.jsx
+++ b/src/components/AdvanceAnalyticsV2.0/AnalyticsFilters.jsx
@@ -28,9 +28,7 @@ const AnalyticsFilters = ({
   groupUUID,
   setGroupUUID,
   currentDate,
-  data,
   groups,
-  isFetching,
   isGroupsLoading,
   budgets,
   isBudgetsFetching,
@@ -114,7 +112,6 @@ const AnalyticsFilters = ({
                   controlClassName="font-weight-normal analytics-filter-form-controls rounded-0"
                   as="select"
                   onChange={(e) => handleDateRangeChange(e.target.value)}
-                  disabled={isFetching}
                   defaultValue={dateRangeValue}
                   value={dateRangeValue}
                 >
@@ -169,9 +166,7 @@ const AnalyticsFilters = ({
                   controlClassName="font-weight-normal analytics-filter-form-controls rounded-0"
                   type="date"
                   value={startDate || get90DayPriorDate()}
-                  min={data?.minEnrollmentDate || ''}
                   onChange={(e) => handleStartDateChange(e.target.value)}
-                  disabled={isFetching}
                 />
               </Form.Group>
             </div>
@@ -190,7 +185,6 @@ const AnalyticsFilters = ({
                   value={endDate || currentDate || ''}
                   max={currentDate || ''}
                   onChange={(e) => handleEndDateChange(e.target.value)}
-                  disabled={isFetching}
                 />
               </Form.Group>
             </div>
@@ -209,7 +203,6 @@ const AnalyticsFilters = ({
                     as="select"
                     value={calculation}
                     onChange={(e) => setCalculation(e.target.value)}
-                    disabled={isFetching}
                   >
                     <option value={CALCULATION.TOTAL}>
                       {intl.formatMessage({
@@ -256,7 +249,6 @@ const AnalyticsFilters = ({
                     as="select"
                     value={granularity}
                     onChange={(e) => setGranularity(e.target.value)}
-                    disabled={isFetching}
                   >
                     <option value={GRANULARITY.DAILY}>
                       {intl.formatMessage({
@@ -418,7 +410,6 @@ const AnalyticsFilters = ({
                     controlClassName="font-weight-normal analytics-filter-form-controls rounded-0"
                     as="select"
                     onChange={(e) => setCourseType(e.target.value)}
-                    disabled={isFetching}
                     defaultValue={COURSE_TYPES.ALL_COURSE_TYPES}
                     value={courseType}
                   >
@@ -470,9 +461,7 @@ AnalyticsFilters.propTypes = {
   groupUUID: PropTypes.string,
   setGroupUUID: PropTypes.func.isRequired,
   currentDate: PropTypes.string.isRequired,
-  data: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   groups: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-  isFetching: PropTypes.bool.isRequired,
   isGroupsLoading: PropTypes.bool.isRequired,
   activeTab: PropTypes.string.isRequired,
   isEnterpriseCoursesFetching: PropTypes.bool,

--- a/src/components/AdvanceAnalyticsV2.0/AnalyticsFiltersContext.js
+++ b/src/components/AdvanceAnalyticsV2.0/AnalyticsFiltersContext.js
@@ -1,5 +1,0 @@
-import { createContext, useContext } from 'react';
-
-export const AnalyticsFiltersContext = createContext(null);
-
-export const useAnalyticsFilters = () => useContext(AnalyticsFiltersContext);

--- a/src/components/AdvanceAnalyticsV2.0/AnalyticsPage.jsx
+++ b/src/components/AdvanceAnalyticsV2.0/AnalyticsPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState } from 'react';
 import { Tabs, Tab, Stack } from '@openedx/paragon';
 import { Helmet } from 'react-helmet';
 import PropTypes from 'prop-types';
@@ -7,18 +7,11 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 import Hero from '../Hero';
 import Engagements from './tabs/Engagements';
 import Progress from './tabs/Progress';
-import { GRANULARITY, CALCULATION } from './data/constants';
-import { useAllFlexEnterpriseGroups } from '../learner-credit-management/data';
-import { AnalyticsFiltersContext } from './AnalyticsFiltersContext';
 import Outcomes from './tabs/Outcomes';
 
 const AnalyticsPage = ({ enterpriseId }) => {
   const [activeTab, setActiveTab] = useState('engagements');
-  const [granularity, setGranularity] = useState(GRANULARITY.WEEKLY);
-  const [calculation, setCalculation] = useState(CALCULATION.TOTAL);
-  const [groupUUID, setGroupUUID] = useState('');
   const intl = useIntl();
-  const { data: groups, isLoading: isGroupsLoading } = useAllFlexEnterpriseGroups(enterpriseId);
 
   const PAGE_TITLE = intl.formatMessage({
     id: 'analytics.page.title.heading',
@@ -26,77 +19,59 @@ const AnalyticsPage = ({ enterpriseId }) => {
     description: 'Title of the analytics page',
   });
 
-  const currentDate = new Date().toISOString().split('T')[0];
-
-  const filtersContextValue = useMemo(() => ({
-    currentDate,
-    granularity,
-    calculation,
-    groupUUID,
-    enterpriseId,
-    setGranularity,
-    setCalculation,
-    setGroupUUID,
-    groups,
-    isGroupsLoading,
-  }), [
-    currentDate, granularity, calculation,
-    groupUUID, enterpriseId, groups, isGroupsLoading,
-  ]);
-
   return (
     <>
       <Helmet title={PAGE_TITLE} />
       <Hero title={PAGE_TITLE} />
       <Stack className="container-fluid w-100" gap={4}>
-        <AnalyticsFiltersContext.Provider value={filtersContextValue}>
-          <div className="tabs-container pt-3">
-            <Tabs
-              variant="tabs"
-              activeKey={activeTab}
-              onSelect={(tab) => {
-                setActiveTab(tab);
-              }}
+        <div className="tabs-container pt-3">
+          <Tabs
+            variant="tabs"
+            activeKey={activeTab}
+            onSelect={(tab) => {
+              setActiveTab(tab);
+            }}
+            mountOnEnter
+            unmountOnExit
+          >
+            <Tab
+              eventKey="engagements"
+              title={intl.formatMessage({
+                id: 'analytics.engagement.tab.title.heading',
+                defaultMessage: 'Engagement',
+                description: 'Title for the engagements tab in advance analytics.',
+              })}
             >
-              <Tab
-                eventKey="engagements"
-                title={intl.formatMessage({
-                  id: 'analytics.engagement.tab.title.heading',
-                  defaultMessage: 'Engagement',
-                  description: 'Title for the engagements tab in advance analytics.',
-                })}
-              >
-                <Engagements
-                  enterpriseId={enterpriseId}
-                />
-              </Tab>
-              <Tab
-                eventKey="Progress"
-                title={intl.formatMessage({
-                  id: 'advance.analytics.progress.tab.title.heading',
-                  defaultMessage: 'Progress',
-                  description: 'Title for the progress tab in advance analytics.',
-                })}
-              >
-                <Progress
-                  enterpriseId={enterpriseId}
-                />
-              </Tab>
-              <Tab
-                eventKey="Outcomes"
-                title={intl.formatMessage({
-                  id: 'advance.analytics.outcomes.tab.title.heading',
-                  defaultMessage: 'Outcomes',
-                  description: 'Title for the outcomes tab in advance analytics.',
-                })}
-              >
-                <Outcomes
-                  enterpriseId={enterpriseId}
-                />
-              </Tab>
-            </Tabs>
-          </div>
-        </AnalyticsFiltersContext.Provider>
+              <Engagements
+                enterpriseId={enterpriseId}
+              />
+            </Tab>
+            <Tab
+              eventKey="Progress"
+              title={intl.formatMessage({
+                id: 'advance.analytics.progress.tab.title.heading',
+                defaultMessage: 'Progress',
+                description: 'Title for the progress tab in advance analytics.',
+              })}
+            >
+              <Progress
+                enterpriseId={enterpriseId}
+              />
+            </Tab>
+            <Tab
+              eventKey="Outcomes"
+              title={intl.formatMessage({
+                id: 'advance.analytics.outcomes.tab.title.heading',
+                defaultMessage: 'Outcomes',
+                description: 'Title for the outcomes tab in advance analytics.',
+              })}
+            >
+              <Outcomes
+                enterpriseId={enterpriseId}
+              />
+            </Tab>
+          </Tabs>
+        </div>
 
       </Stack>
     </>

--- a/src/components/AdvanceAnalyticsV2.0/data/constants.js
+++ b/src/components/AdvanceAnalyticsV2.0/data/constants.js
@@ -77,8 +77,8 @@ export const advanceAnalyticsQueryKeys = {
   leaderboardTable: (enterpriseUUID, requestOptions) => (
     generateKey(analyticsDataTableKeys.leaderboard, enterpriseUUID, requestOptions)
   ),
-  aggregates: (enterpriseUUID, requestOptions) => (
-    generateKey('aggregates', enterpriseUUID, requestOptions)
+  aggregates: (enterpriseUUID, requestOptions, tabKey) => (
+    generateKey(`aggregates-${tabKey}`, enterpriseUUID, requestOptions)
   ),
 };
 

--- a/src/components/AdvanceAnalyticsV2.0/data/hooks/index.js
+++ b/src/components/AdvanceAnalyticsV2.0/data/hooks/index.js
@@ -1,7 +1,9 @@
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
-import { advanceAnalyticsQueryKeys, COURSE_TYPES, ALL_COURSES } from '../constants';
+import {
+  advanceAnalyticsQueryKeys, COURSE_TYPES, ALL_COURSES,
+} from '../constants';
 
 import EnterpriseDataApiService from '../../../../data/services/EnterpriseDataApiService';
 
@@ -81,8 +83,10 @@ export const usePaginatedData = (data) => useMemo(() => {
 
 export const useEnterpriseAnalyticsAggregatesData = ({
   enterpriseCustomerUUID,
+  tabKey,
   startDate,
   endDate,
+  groupUUID = undefined,
   courseType = undefined,
   course = undefined,
   budgetUUID = undefined,
@@ -92,6 +96,10 @@ export const useEnterpriseAnalyticsAggregatesData = ({
     startDate,
     endDate,
   };
+
+  if (groupUUID) {
+    requestOptions.groupUUID = groupUUID;
+  }
 
   if (courseType && courseType !== COURSE_TYPES.ALL_COURSE_TYPES) {
     requestOptions.courseType = courseType;
@@ -106,7 +114,7 @@ export const useEnterpriseAnalyticsAggregatesData = ({
   }
 
   return useQuery({
-    queryKey: advanceAnalyticsQueryKeys.aggregates(enterpriseCustomerUUID, requestOptions),
+    queryKey: advanceAnalyticsQueryKeys.aggregates(enterpriseCustomerUUID, requestOptions, tabKey),
     queryFn: () => EnterpriseDataApiService.fetchAdminAggregatesData(
       enterpriseCustomerUUID,
       requestOptions,

--- a/src/components/AdvanceAnalyticsV2.0/tabs/Engagements.test.jsx
+++ b/src/components/AdvanceAnalyticsV2.0/tabs/Engagements.test.jsx
@@ -15,7 +15,6 @@ import Engagements from './Engagements';
 import { queryClient } from '../../test/testUtils';
 import EnterpriseDataApiService from '../../../data/services/EnterpriseDataApiService';
 import * as hooks from '../data/hooks';
-import { useAnalyticsFilters } from '../AnalyticsFiltersContext';
 
 const mockEngagementTableData = {
   next: null,
@@ -197,10 +196,6 @@ jest.mock('@edx/frontend-enterprise-utils', () => {
   });
 });
 
-jest.mock('../AnalyticsFiltersContext', () => ({
-  useAnalyticsFilters: jest.fn(),
-}));
-
 jest.mock('../data/hooks', () => ({
   useEnterpriseAnalyticsAggregatesData: jest.fn(),
   useEnterpriseEngagementData: jest.fn(),
@@ -237,20 +232,6 @@ describe('Rendering tests', () => {
 
     axiosMock.onGet(/\/enrollments\/stats(\?.*)/).reply(200, mockEnrollmentChartsData);
     axiosMock.onGet(/\/enrollments(\?.*)/).reply(200, mockEnrollmentTableData);
-
-    useAnalyticsFilters.mockReturnValue({
-      startDate: '2021-01-01',
-      setStartDate: jest.fn(),
-      endDate: '2021-12-31',
-      setEndDate: jest.fn(),
-      granularity: 'Daily',
-      calculation: 'Total',
-      groupUUID: 'group-123',
-      setGroupUUID: jest.fn(),
-      currentDate: '2021-12-31',
-      groups: [],
-      isGroupsLoading: false,
-    });
 
     hooks.useEnterpriseAnalyticsAggregatesData.mockReturnValue({
       isFetching: false,
@@ -369,20 +350,6 @@ describe('Rendering tests', () => {
 
     axiosMock.onGet(/\/enrollments\/stats(\?.*)/).reply(200, mockEnrollmentChartsData);
     axiosMock.onGet(/\/enrollments(\?.*)/).reply(200, mockEnrollmentTableData);
-
-    useAnalyticsFilters.mockReturnValue({
-      startDate: '2021-01-01',
-      setStartDate: jest.fn(),
-      endDate: '2021-12-31',
-      setEndDate: jest.fn(),
-      granularity: 'Daily',
-      calculation: 'Total',
-      groupUUID: 'group-123',
-      setGroupUUID: jest.fn(),
-      currentDate: '2021-12-31',
-      groups: [],
-      isGroupsLoading: false,
-    });
 
     hooks.useEnterpriseAnalyticsAggregatesData.mockReturnValue({
       isFetching: false,

--- a/src/components/AdvanceAnalyticsV2.0/tabs/Outcomes.jsx
+++ b/src/components/AdvanceAnalyticsV2.0/tabs/Outcomes.jsx
@@ -10,38 +10,33 @@ import {
   useEnterpriseCourses,
 } from '../data/hooks';
 import AnalyticsFilters from '../AnalyticsFilters';
-import { useAnalyticsFilters } from '../AnalyticsFiltersContext';
 import Stats from '../Stats';
 import TopSkillsChart from '../charts/TopSkillsChart';
 import CompletionsOverTimeChart from '../charts/CompletionsOverTimeChart';
 import TopSkillsByCompletionChart from '../charts/TopSkillsByCompletionChart';
 import EVENT_NAMES from '../../../eventTracking';
 import { get90DayPriorDate } from '../data/utils';
-import { ALL_COURSES } from '../data/constants';
+import { ALL_COURSES, GRANULARITY, CALCULATION } from '../data/constants';
+import { useAllFlexEnterpriseGroups } from '../../learner-credit-management/data';
 
 const Outcomes = ({ enterpriseId }) => {
-  // Filters
-  const {
-    granularity,
-    setGranularity,
-    calculation,
-    setCalculation,
-    groupUUID,
-    setGroupUUID,
-    currentDate,
-    groups,
-    isGroupsLoading,
-  } = useAnalyticsFilters();
+  const currentDate = new Date().toISOString().split('T')[0];
 
+  // Filters
   const [startDate, setStartDate] = useState(get90DayPriorDate());
   const [endDate, setEndDate] = useState(currentDate);
+  const [granularity, setGranularity] = useState(GRANULARITY.WEEKLY);
+  const [calculation, setCalculation] = useState(CALCULATION.TOTAL);
+  const [groupUUID, setGroupUUID] = useState('');
   const [course, setCourse] = useState(ALL_COURSES);
 
   // Stats Data
   const { isFetching: isStatsFetching, isError: isStatsError, data: statsData } = useEnterpriseAnalyticsAggregatesData({
     enterpriseCustomerUUID: enterpriseId,
+    tabKey: ANALYTICS_TABS.OUTCOMES,
     startDate,
     endDate,
+    groupUUID,
     course,
   });
 
@@ -53,6 +48,7 @@ const Outcomes = ({ enterpriseId }) => {
     key: ANALYTICS_TABS.SKILLS,
     startDate,
     endDate,
+    groupUUID,
     course,
   });
 
@@ -79,6 +75,11 @@ const Outcomes = ({ enterpriseId }) => {
     endDate,
     groupUUID,
   });
+
+  // Groups Data
+  const {
+    isLoading: isGroupsLoading, data: groups,
+  } = useAllFlexEnterpriseGroups(enterpriseId);
 
   const handleChartClick = (chartData) => {
     sendEnterpriseTrackEvent(
@@ -148,7 +149,7 @@ const Outcomes = ({ enterpriseId }) => {
         isFetching={isSkillsFetching}
         isError={isSkillsError}
         data={skillsData?.topSkills}
-        startDate={startDate || statsData?.minEnrollmentDate}
+        startDate={startDate}
         endDate={endDate || currentDate}
         onClick={handleChartClick}
       />
@@ -158,7 +159,7 @@ const Outcomes = ({ enterpriseId }) => {
         isFetching={isCompletionsFetching}
         isError={isCompletionsError}
         data={completionsData?.completionsOverTime}
-        startDate={startDate || statsData?.minEnrollmentDate}
+        startDate={startDate}
         endDate={endDate || currentDate}
         granularity={granularity}
         calculation={calculation}
@@ -170,7 +171,7 @@ const Outcomes = ({ enterpriseId }) => {
         isFetching={isSkillsFetching}
         isError={isSkillsError}
         data={skillsData?.topSkillsByCompletions}
-        startDate={startDate || statsData?.minEnrollmentDate}
+        startDate={startDate}
         endDate={endDate || currentDate}
         onClick={handleChartClick}
       />

--- a/src/components/AdvanceAnalyticsV2.0/tabs/Outcomes.test.jsx
+++ b/src/components/AdvanceAnalyticsV2.0/tabs/Outcomes.test.jsx
@@ -14,7 +14,6 @@ import Outcomess from './Outcomes';
 import { queryClient } from '../../test/testUtils';
 import EnterpriseDataApiService from '../../../data/services/EnterpriseDataApiService';
 import * as hooks from '../data/hooks';
-import { useAnalyticsFilters } from '../AnalyticsFiltersContext';
 
 const mockAnalyticsSkillsData = {
   topSkills: [
@@ -71,10 +70,6 @@ jest.mock('@edx/frontend-enterprise-utils', () => {
   });
 });
 
-jest.mock('../AnalyticsFiltersContext', () => ({
-  useAnalyticsFilters: jest.fn(),
-}));
-
 jest.mock('../data/hooks', () => ({
   useEnterpriseAnalyticsAggregatesData: jest.fn(),
   useEnterpriseAnalyticsData: jest.fn(),
@@ -103,20 +98,6 @@ const findReact = (dom, traverseUp = 0) => {
 
 describe('Rendering tests', () => {
   test('renders all sections', async () => {
-    useAnalyticsFilters.mockReturnValue({
-      startDate: '2021-01-01',
-      setStartDate: jest.fn(),
-      endDate: '2021-12-31',
-      setEndDate: jest.fn(),
-      granularity: 'Daily',
-      calculation: 'Total',
-      groupUUID: 'group-123',
-      setGroupUUID: jest.fn(),
-      currentDate: '2021-12-31',
-      groups: [],
-      isGroupsLoading: false,
-    });
-
     hooks.useEnterpriseAnalyticsAggregatesData.mockReturnValue({
       data: { minEnrollmentDate: '2021-01-01' },
     });
@@ -186,20 +167,6 @@ describe('Rendering tests', () => {
   });
 
   test('calls sendEnterpriseTrackEvent on chart click', async () => {
-    useAnalyticsFilters.mockReturnValue({
-      startDate: '2021-01-01',
-      setStartDate: jest.fn(),
-      endDate: '2021-12-31',
-      setEndDate: jest.fn(),
-      granularity: 'Daily',
-      calculation: 'Total',
-      groupUUID: 'group-123',
-      setGroupUUID: jest.fn(),
-      currentDate: '2021-12-31',
-      groups: [],
-      isGroupsLoading: false,
-    });
-
     hooks.useEnterpriseAnalyticsAggregatesData.mockReturnValue({
       data: { minEnrollmentDate: '2021-01-01' },
     });

--- a/src/components/AdvanceAnalyticsV2.0/tabs/Progress.jsx
+++ b/src/components/AdvanceAnalyticsV2.0/tabs/Progress.jsx
@@ -4,42 +4,26 @@ import PropTypes from 'prop-types';
 import { ANALYTICS_TABS } from '../constants';
 import {
   useEnterpriseCompletionsData,
-  useEnterpriseAnalyticsAggregatesData,
   useEnterpriseCourses,
 } from '../data/hooks';
 import AnalyticsFilters from '../AnalyticsFilters';
-import { useAnalyticsFilters } from '../AnalyticsFiltersContext';
 import TopCoursesByCompletionTable from '../tables/TopCoursesByCompletionTable';
 import TopSubjectsByCompletionTable from '../tables/TopSubjectsByCompletionTable';
 import IndividualCompletionsTable from '../tables/IndividualCompletionsTable';
 import { get90DayPriorDate } from '../data/utils';
-import { ALL_COURSES } from '../data/constants';
+import { ALL_COURSES, GRANULARITY, CALCULATION } from '../data/constants';
+import { START_DATE_DEFAULT_TO_TODAY_THRESHOLD_DAYS, useAllFlexEnterpriseGroups } from '../../learner-credit-management/data';
 
 const Progress = ({ enterpriseId }) => {
-  // Filters
-  const {
-    granularity,
-    setGranularity,
-    calculation,
-    setCalculation,
-    groupUUID,
-    setGroupUUID,
-    currentDate,
-    groups,
-    isGroupsLoading,
-  } = useAnalyticsFilters();
+  const currentDate = new Date().toISOString().split('T')[0];
 
+  // Filters
   const [startDate, setStartDate] = useState(get90DayPriorDate());
   const [endDate, setEndDate] = useState(currentDate);
+  const [granularity, setGranularity] = useState(GRANULARITY.WEEKLY);
+  const [calculation, setCalculation] = useState(CALCULATION.TOTAL);
+  const [groupUUID, setGroupUUID] = useState('');
   const [course, setCourse] = useState(ALL_COURSES);
-
-  // Stats Data
-  const { data: statsData } = useEnterpriseAnalyticsAggregatesData({
-    enterpriseCustomerUUID: enterpriseId,
-    startDate,
-    endDate,
-    course,
-  });
 
   // Completions data
   const {
@@ -64,6 +48,11 @@ const Progress = ({ enterpriseId }) => {
     endDate,
     groupUUID,
   });
+
+  // Groups Data
+  const {
+    isLoading: isGroupsLoading, data: groups,
+  } = useAllFlexEnterpriseGroups(enterpriseId);
 
   return (
     <div className="tab-Progress mt-4">
@@ -116,7 +105,7 @@ const Progress = ({ enterpriseId }) => {
             <TopCoursesByCompletionTable
               isFetching={isFetching}
               data={completionsData?.topCoursesByCompletions}
-              startDate={startDate || statsData?.minEnrollmentDate}
+              startDate={startDate}
               endDate={endDate || currentDate}
               granularity={granularity}
               calculation={calculation}
@@ -129,7 +118,7 @@ const Progress = ({ enterpriseId }) => {
             <TopSubjectsByCompletionTable
               isFetching={isFetching}
               data={completionsData?.topSubjectsByCompletions}
-              startDate={startDate || statsData?.minEnrollmentDate}
+              startDate={START_DATE_DEFAULT_TO_TODAY_THRESHOLD_DAYS}
               endDate={endDate || currentDate}
               granularity={granularity}
               calculation={calculation}
@@ -142,7 +131,7 @@ const Progress = ({ enterpriseId }) => {
       <div className="bg-primary-100 rounded-lg container-fluid mb-3">
         <div className="h-100 overflow-hidden">
           <IndividualCompletionsTable
-            startDate={startDate || statsData?.minEnrollmentDate}
+            startDate={startDate}
             endDate={endDate || currentDate}
             enterpriseId={enterpriseId}
             groupUUID={groupUUID}

--- a/src/components/AdvanceAnalyticsV2.0/tabs/Progress.test.jsx
+++ b/src/components/AdvanceAnalyticsV2.0/tabs/Progress.test.jsx
@@ -12,11 +12,6 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import Progress from './Progress';
 import { queryClient } from '../../test/testUtils';
 import * as hooks from '../data/hooks';
-import { useAnalyticsFilters } from '../AnalyticsFiltersContext';
-
-jest.mock('../AnalyticsFiltersContext', () => ({
-  useAnalyticsFilters: jest.fn(),
-}));
 
 jest.mock('../data/hooks', () => ({
   useEnterpriseAnalyticsAggregatesData: jest.fn(),
@@ -44,22 +39,6 @@ describe('Progress Component', () => {
   });
 
   test('renders all progress tab sections', async () => {
-    useAnalyticsFilters.mockReturnValue({
-      startDate: '2021-01-01',
-      setStartDate: jest.fn(),
-      endDate: '2021-12-31',
-      setEndDate: jest.fn(),
-      granularity: 'Daily',
-      setGranularity: jest.fn(),
-      calculation: 'Total',
-      setCalculation: jest.fn(),
-      groupUUID: 'group-123',
-      setGroupUUID: jest.fn(),
-      currentDate: '2021-12-31',
-      groups: [],
-      isGroupsLoading: false,
-    });
-
     hooks.useEnterpriseAnalyticsAggregatesData.mockReturnValue({
       data: { minEnrollmentDate: '2021-01-01' },
     });


### PR DESCRIPTION
**Ticket:**
https://2u-internal.atlassian.net/browse/ENT-10849

**Description:**
This PR introduces several improvements and optimizations across the analytics V2.0
- Enabled support for all filters in Stats/Metrics
- Applied structural optimizations to reduce unnecessary re-renders and improve performance
- Removed the Filters Context (no longer required)
- Added lazy loading for tabs using `mountOnEnter` and `unmountOnExit` (tabs are now mounted/unmounted only when active)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
