### PR TITLE
feat: expand highlight window for tour elements

### DIFF
--- a/src/components/ProductTours/CheckpointOverlay.tsx
+++ b/src/components/ProductTours/CheckpointOverlay.tsx
@@ -58,10 +58,10 @@ const CheckpointOverlay: FC<CheckpointOverlayProps> = ({ target }) => {
           if (targetElement) {
             const boundingRect = targetElement.getBoundingClientRect();
             setRect({
-              top: boundingRect.top,
-              left: boundingRect.left,
-              width: boundingRect.width,
-              height: boundingRect.height,
+              top: boundingRect.top - 10,
+              left: boundingRect.left - 10,
+              width: boundingRect.width + 20,
+              height: boundingRect.height + 20,
             });
           }
         };

--- a/src/components/ProductTours/tests/CheckpointOverlay.test.jsx
+++ b/src/components/ProductTours/tests/CheckpointOverlay.test.jsx
@@ -143,34 +143,34 @@ describe('CheckpointOverlay', () => {
       top: '0px',
       left: '0px',
       right: '0px',
-      height: `${mockRect.top}px`,
+      height: `${mockRect.top - 10}px`,
       backgroundColor: 'rgba(0, 0, 0, 0.5)',
     });
 
     // Check left section
     expect(sections[1]).toHaveStyle({
       position: 'absolute',
-      top: `${mockRect.top}px`,
+      top: `${mockRect.top - 10}px`,
       left: '0px',
-      width: `${mockRect.left}px`,
-      height: `${mockRect.height}px`,
+      width: `${mockRect.left - 10}px`,
+      height: `${mockRect.height + 20}px`,
       backgroundColor: 'rgba(0, 0, 0, 0.5)',
     });
 
     // Check right section
     expect(sections[2]).toHaveStyle({
       position: 'absolute',
-      top: `${mockRect.top}px`,
-      left: `${mockRect.left + mockRect.width}px`,
+      top: `${mockRect.top - 10}px`,
+      left: `${mockRect.left + mockRect.width + 10}px`,
       right: '0px',
-      height: `${mockRect.height}px`,
+      height: `${mockRect.height + 20}px`,
       backgroundColor: 'rgba(0, 0, 0, 0.5)',
     });
 
     // Check bottom section
     expect(sections[3]).toHaveStyle({
       position: 'absolute',
-      top: `${mockRect.top + mockRect.height}px`,
+      top: `${mockRect.top + mockRect.height + 10}px`,
       left: '0px',
       right: '0px',
       bottom: '0px',


### PR DESCRIPTION
[Jira Ticket](https://2u-internal.atlassian.net/browse/ENT-10794)

## Fixes
- Expanded the 'window' over the element that is the focus of the tour step, bringing appearance more in line with [Figma designs](https://www.figma.com/design/QvzeKm2skgshekt88CXsoY/Admin-Portal-Onboarding?node-id=2012-15629&t=HrAKYwO831qhDmll-0)

## Testing Instructions
- Pull down this branch and run `npm run start:stage`
- Navigate to https://localhost.stage.edx.org:1991/exec-ed-2u-integration-qa/admin/subscriptions/manage-learners
- Open Quick Start Guide and select 'Administer Subscriptions'
- Go through subscription tour and verify the highlight window over tour elements has some additional aesthetic spacing around the element

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
