### PR TITLE
fix: fixing bug in useBudgetDetailActivityOverview hook

### DIFF
--- a/src/components/learner-credit-management/data/hooks/useBudgetDetailActivityOverview.js
+++ b/src/components/learner-credit-management/data/hooks/useBudgetDetailActivityOverview.js
@@ -19,7 +19,7 @@ const useBudgetDetailActivityOverview = ({
     queryKey: learnerCreditManagementQueryKeys.budgetActivityOverview(localBudgetId),
     queryFn: (args) => retrieveBudgetDetailActivityOverview({
       ...args,
-      localBudgetId,
+      budgetId: localBudgetId,
       subsidyAccessPolicy,
       enterpriseUUID,
       isTopDownAssignmentEnabled,


### PR DESCRIPTION
After I merged [this PR](https://github.com/openedx/frontend-app-admin-portal/pull/1679) and was testing on prod, I noticed that a customer that I know had spent and assigned transactions was showing up as zero state. To test this PR, go to https://localhost.stage.edx.org:1991/pawnee-parks/admin/learner-credit/ and validate that it is not showing up as zero state. 

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
