### PR TITLE
[ENT-10947] Integrate Outcomes Metrics Data

### DIFF
--- a/src/components/AdvanceAnalyticsV2.0/Stats.jsx
+++ b/src/components/AdvanceAnalyticsV2.0/Stats.jsx
@@ -94,24 +94,24 @@ const Stats = ({
                 <p className="mb-0 small font-weight-normal title-unique-skills">
                   <FormattedMessage id="advance.analytics.outcomes.stats.unique.skills.title" defaultMessage="Unique skills gained" />
                 </p>
-                <p className="font-weight-bolder analytics-stat-number value-unique-skills">{formatNumber(0)}</p>
+                <p className="font-weight-bolder analytics-stat-number value-unique-skills">{formatNumber(data?.uniqueSkillsGained || 0)}</p>
               </div>
 
               <div className="col d-flex flex-column justify-content-center align-items-center">
                 <p className="mb-0 small font-weight-normal title-upskilled-learners">
                   <FormattedMessage id="advance.analytics.outcomes.stats.upskilled.learners.title" defaultMessage="Upskilled learners" />
                 </p>
-                <p className="font-weight-bolder analytics-stat-number value-upskilled-learners">{formatNumber(0)}</p>
+                <p className="font-weight-bolder analytics-stat-number value-upskilled-learners">{formatNumber(data?.upskilledLearners || 0)}</p>
               </div>
 
               <div className="col d-flex flex-column justify-content-center align-items-center">
                 <p className="mb-0 small font-weight-normal title-new-skills">
                   <FormattedMessage
-                    id="advance.analytics.outcomes.stats.new.skills.this.year.title"
-                    defaultMessage={`New skills learned in ${new Date().getFullYear()}`}
+                    id="advance.analytics.outcomes.stats.new.skills.gained.title"
+                    defaultMessage="New skills gained"
                   />
                 </p>
-                <p className="font-weight-bolder analytics-stat-number value-new-skills">{formatNumber(0)}</p>
+                <p className="font-weight-bolder analytics-stat-number value-new-skills">{formatNumber(data?.newSkillsLearned || 0)}</p>
               </div>
             </>
           )}
@@ -129,6 +129,9 @@ Stats.propTypes = {
     sessions: PropTypes.number,
     hours: PropTypes.number,
     completions: PropTypes.number,
+    uniqueSkillsGained: PropTypes.number,
+    upskilledLearners: PropTypes.number,
+    newSkillsLearned: PropTypes.number,
   }).isRequired,
   isFetching: PropTypes.bool.isRequired,
   isError: PropTypes.bool.isRequired,

--- a/src/components/AdvanceAnalyticsV2.0/tests/Stats.test.jsx
+++ b/src/components/AdvanceAnalyticsV2.0/tests/Stats.test.jsx
@@ -9,6 +9,10 @@ const data = {
   sessions: 1892,
   hours: 25349876,
   completions: 265400,
+  uniqueSkillsGained: 300,
+  upskilledLearners: 200,
+  newSkillsLearned: 250,
+
 };
 describe('Stats', () => {
   it('renders the correct values for each engagement statistic', async () => {
@@ -43,10 +47,10 @@ describe('Stats', () => {
     expect(container.querySelector('.title-completions')?.textContent).toEqual('Completions');
     expect(container.querySelector('.value-completions')?.textContent).toEqual('265.4K');
     expect(container.querySelector('.title-unique-skills')?.textContent).toEqual('Unique skills gained');
-    expect(container.querySelector('.value-unique-skills')?.textContent).toEqual('0');
+    expect(container.querySelector('.value-unique-skills')?.textContent).toEqual('300');
     expect(container.querySelector('.title-upskilled-learners')?.textContent).toEqual('Upskilled learners');
-    expect(container.querySelector('.value-upskilled-learners')?.textContent).toEqual('0');
-    expect(container.querySelector('.title-new-skills')?.textContent).toContain('New skills learned in');
-    expect(container.querySelector('.value-new-skills')?.textContent).toEqual('0');
+    expect(container.querySelector('.value-upskilled-learners')?.textContent).toEqual('200');
+    expect(container.querySelector('.title-new-skills')?.textContent).toContain('New skills gained');
+    expect(container.querySelector('.value-new-skills')?.textContent).toEqual('250');
   });
 });


### PR DESCRIPTION
**Ticket:**
https://2u-internal.atlassian.net/browse/ENT-10947

**Description:**
This PR integrates the data for following metics:
- Unique Skills Gained
- Upskilled Learners
- New Skills Learned This Year

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
