### PR TITLE
fix: fixing bug in Track Learner Progress onboarding flow

### DIFF
--- a/src/components/ProductTours/AdminOnboardingTours/AdminOnboardingTours.tsx
+++ b/src/components/ProductTours/AdminOnboardingTours/AdminOnboardingTours.tsx
@@ -11,17 +11,10 @@ import CheckpointOverlay from '../CheckpointOverlay';
 import '../_ProductTours.scss';
 import { RESET_TARGETS } from './constants';
 
-interface Insights {
-  learner_engagement?: any;
-  learner_progress?: any;
-}
-
 interface AdminOnboardingToursProps {
   adminUuid: string,
   enterpriseId: string;
   enterpriseSlug: string;
-  insights: Insights;
-  insightsLoading: boolean;
   isOpen: boolean;
   onClose: () => void;
   setTarget: Function,
@@ -33,10 +26,6 @@ interface AdminOnboardingToursProps {
 }
 
 interface RootState {
-  dashboardInsights: {
-    insights: Insights;
-    loading: boolean;
-  };
   enterpriseCustomerAdmin: {
     uuid: string;
   };
@@ -53,18 +42,16 @@ interface RootState {
 const AdminOnboardingTours: FC<AdminOnboardingToursProps> = ({
   enterpriseFeatures,
   enablePortalLearnerCreditManagementScreen,
-  adminUuid, enterpriseId, enterpriseSlug, insights, insightsLoading, isOpen, onClose, setTarget, targetSelector,
+  adminUuid, enterpriseId, enterpriseSlug, isOpen, onClose, setTarget, targetSelector,
 }) => {
   const intl = useIntl();
   const location = useLocation();
-  const aiButtonVisible = (insights?.learner_engagement && insights?.learner_progress) && !insightsLoading;
   const [currentStep, setCurrentStep] = useState(0);
   const prevPathnameRef = useRef(location.pathname);
   const adminOnboardingSteps = AdminOnboardingTour({
     enterpriseFeatures,
     enablePortalLearnerCreditManagementScreen,
     adminUuid,
-    aiButtonVisible,
     currentStep,
     setCurrentStep,
     enterpriseId,
@@ -150,11 +137,6 @@ const AdminOnboardingTours: FC<AdminOnboardingToursProps> = ({
 AdminOnboardingTours.propTypes = {
   adminUuid: PropTypes.string.isRequired,
   enterpriseSlug: PropTypes.string.isRequired,
-  insights: PropTypes.shape({
-    learner_engagement: PropTypes.shape({}),
-    learner_progress: PropTypes.shape({}),
-  }).isRequired,
-  insightsLoading: PropTypes.bool.isRequired,
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   setTarget: PropTypes.func.isRequired,
@@ -164,8 +146,6 @@ const mapStateToProps = (state: RootState) => ({
   adminUuid: state.enterpriseCustomerAdmin.uuid,
   enterpriseId: state.portalConfiguration.enterpriseId,
   enterpriseSlug: state.portalConfiguration.enterpriseSlug,
-  insights: state.dashboardInsights.insights,
-  insightsLoading: state.dashboardInsights.loading,
   enablePortalLearnerCreditManagementScreen: state.portalConfiguration.enablePortalLearnerCreditManagementScreen,
   enterpriseFeatures: state.portalConfiguration.enterpriseFeatures,
 });

--- a/src/components/ProductTours/AdminOnboardingTours/flows/AdminOnboardingTour.tsx
+++ b/src/components/ProductTours/AdminOnboardingTours/flows/AdminOnboardingTour.tsx
@@ -24,7 +24,6 @@ import useFetchCompletedOnboardingFlows from '../data/useFetchCompletedOnboardin
 
 interface AdminOnboardingTourProps {
   adminUuid: string;
-  aiButtonVisible: boolean;
   currentStep: number;
   enablePortalLearnerCreditManagementScreen: boolean;
   enterpriseFeatures: {
@@ -40,7 +39,6 @@ interface AdminOnboardingTourProps {
 const AdminOnboardingTour = (
   {
     adminUuid,
-    aiButtonVisible,
     currentStep,
     enablePortalLearnerCreditManagementScreen,
     enterpriseFeatures,
@@ -81,7 +79,7 @@ const AdminOnboardingTour = (
   const analyticsFlow = AnalyticsFlow({ handleAdvanceTour, handleBackTour, handleEndTour });
   const customizeReportsFlow = CustomizeReportsFlow({ handleEndTour });
   const learnerProgressFlow = LearnerProgressFlow({
-    aiButtonVisible, handleAdvanceTour, handleBackTour, handleEndTour,
+    handleAdvanceTour, handleBackTour, handleEndTour,
   });
   const organizeLearnersFlow = OrganizeLearnersFlow({
     enterpriseId, handleAdvanceTour, handleBackTour, handleEndTour,

--- a/src/components/ProductTours/AdminOnboardingTours/flows/LearnerProgressFlow.tsx
+++ b/src/components/ProductTours/AdminOnboardingTours/flows/LearnerProgressFlow.tsx
@@ -5,14 +5,12 @@ import { TourStep } from '../../types';
 import { configuration } from '../../../../config';
 
 interface CreateTourFlowsProps {
-  aiButtonVisible?: boolean;
   handleAdvanceTour: (advanceEventName: string) => void;
   handleEndTour: (endEventName: string, flowUuid?: string) => void;
   handleBackTour: (backEventName: string) => void;
 }
 
 const LearnerProgressFlow = ({
-  aiButtonVisible,
   handleAdvanceTour,
   handleEndTour,
   handleBackTour,
@@ -36,15 +34,21 @@ const LearnerProgressFlow = ({
   }, {
     target: `#${TRACK_LEARNER_PROGRESS_TARGETS.PROGRESS_REPORT}`,
     placement: 'top',
-    body: intl.formatMessage(messages.trackLearnerProgressStepFourBody),
+    body: intl.formatMessage(messages.trackLearnerProgressStepThreeBody),
     onAdvance: onLearnerAdvance,
     onBack: onLearnerBack,
   }, {
     target: `#${TRACK_LEARNER_PROGRESS_TARGETS.FULL_PROGRESS_REPORT}`,
     placement: 'top',
-    body: intl.formatMessage(messages.trackLearnerProgressStepFiveBody),
+    body: intl.formatMessage(messages.trackLearnerProgressStepFourBody),
     onAdvance: onLearnerAdvance,
     onBack: onLearnerBack,
+  }, {
+    target: `#${TRACK_LEARNER_PROGRESS_TARGETS.MODULE_ACTIVITY}`,
+    placement: 'top',
+    body: intl.formatMessage(messages.trackLearnerProgressStepFiveBody),
+    onBack: onLearnerBack,
+    onAdvance: onLearnerAdvance,
   }, {
     target: `#${TRACK_LEARNER_PROGRESS_TARGETS.FILTER}`,
     placement: 'top',
@@ -55,28 +59,12 @@ const LearnerProgressFlow = ({
     target: `#${TRACK_LEARNER_PROGRESS_TARGETS.CSV_DOWNLOAD}`,
     placement: 'top',
     body: intl.formatMessage(messages.trackLearnerProgressStepSevenBody),
-    onAdvance: onLearnerAdvance,
-    onBack: onLearnerBack,
-  }, {
-    target: `#${TRACK_LEARNER_PROGRESS_TARGETS.MODULE_ACTIVITY}`,
-    placement: 'top',
-    body: intl.formatMessage(messages.trackLearnerProgressStepEightBody),
     onBack: onLearnerBack,
     onEnd: () => handleEndTour(
       ADMIN_TOUR_EVENT_NAMES.LEARNER_PROGRESS_COMPLETED_EVENT_NAME,
       configuration.ADMIN_ONBOARDING_UUIDS.FLOW_TRACK_LEARNER_PROGRESS_UUID,
     ),
   }];
-
-  if (aiButtonVisible) {
-    learnerProgressFlow.splice(2, 0, {
-      target: `#${TRACK_LEARNER_PROGRESS_TARGETS.AI_SUMMARY}`,
-      placement: 'right',
-      body: intl.formatMessage(messages.trackLearnerProgressStepThreeBody),
-      onAdvance: onLearnerAdvance,
-      onBack: onLearnerBack,
-    });
-  }
 
   return learnerProgressFlow;
 };

--- a/src/components/ProductTours/AdminOnboardingTours/messages.js
+++ b/src/components/ProductTours/AdminOnboardingTours/messages.js
@@ -73,19 +73,19 @@ const messages = defineMessages({
     description: 'Description for the learner progress tracking step two',
   },
   trackLearnerProgressStepThreeBody: {
-    id: 'adminPortal.productTours.adminOnboarding.trackLearnerProgress.body.3',
-    defaultMessage: 'Get a quick AI-generated overview of your learner analytics with just one click.',
-    description: 'Description for the learner progress tracking step three',
-  },
-  trackLearnerProgressStepFourBody: {
     id: 'adminPortal.productTours.adminOnboarding.trackLearnerProgress.body.4',
     defaultMessage: 'Scroll down for a detailed, twice-daily updated progress report.',
     description: 'Description for the learner progress tracking step four',
   },
-  trackLearnerProgressStepFiveBody: {
+  trackLearnerProgressStepFourBody: {
     id: 'adminPortal.productTours.adminOnboarding.trackLearnerProgress.body.5',
     defaultMessage: 'Access the full Learner Progress Report here.',
     description: 'Description for the learner progress tracking step five',
+  },
+  trackLearnerProgressStepFiveBody: {
+    id: 'adminPortal.productTours.adminOnboarding.trackLearnerProgress.body.8',
+    defaultMessage: 'View module-level details for Executive Education courses.',
+    description: 'Description for the learner progress tracking step eight',
   },
   trackLearnerProgressStepSixBody: {
     id: 'adminPortal.productTours.adminOnboarding.trackLearnerProgress.body.6',
@@ -96,11 +96,6 @@ const messages = defineMessages({
     id: 'adminPortal.productTours.adminOnboarding.trackLearnerProgress.body.7',
     defaultMessage: 'Export the report as a CSV to gain insights and organize data efficiently.',
     description: 'Description for the learner progress tracking step seven',
-  },
-  trackLearnerProgressStepEightBody: {
-    id: 'adminPortal.productTours.adminOnboarding.trackLearnerProgress.body.8',
-    defaultMessage: 'View module-level details for Executive Education courses.',
-    description: 'Description for the learner progress tracking step eight',
   },
   organizeLearnersStepOneTitle: {
     id: 'adminPortal.productTours.adminOnboarding.organizeLearners.title.1',

--- a/src/components/ProductTours/AdminOnboardingTours/tests/LearnerProgressFlow.test.jsx
+++ b/src/components/ProductTours/AdminOnboardingTours/tests/LearnerProgressFlow.test.jsx
@@ -28,10 +28,9 @@ describe('tourFlows', () => {
     jest.clearAllMocks();
   });
 
-  it('creates learner progress flow with correct structure when AI button is not visible', () => {
+  it('creates learner progress flow with correct structure', () => {
     const { result } = renderHook(
       () => useCreateLearnerProgressFlow({
-        aiButtonVisible: false,
         handleAdvanceTour: mockHandleAdvanceTour,
         handleEndTour: mockHandleEndTour,
       }),
@@ -58,65 +57,37 @@ describe('tourFlows', () => {
     expect(flow[2]).toMatchObject({
       target: `#${TRACK_LEARNER_PROGRESS_TARGETS.PROGRESS_REPORT}`,
       placement: 'top',
-      body: messages.trackLearnerProgressStepFourBody.defaultMessage,
+      body: messages.trackLearnerProgressStepThreeBody.defaultMessage,
     });
 
     expect(flow[3]).toMatchObject({
       target: `#${TRACK_LEARNER_PROGRESS_TARGETS.FULL_PROGRESS_REPORT}`,
       placement: 'top',
-      body: messages.trackLearnerProgressStepFiveBody.defaultMessage,
+      body: messages.trackLearnerProgressStepFourBody.defaultMessage,
     });
 
     expect(flow[4]).toMatchObject({
+      target: `#${TRACK_LEARNER_PROGRESS_TARGETS.MODULE_ACTIVITY}`,
+      placement: 'top',
+      body: messages.trackLearnerProgressStepFiveBody.defaultMessage,
+    });
+
+    expect(flow[5]).toMatchObject({
       target: `#${TRACK_LEARNER_PROGRESS_TARGETS.FILTER}`,
       placement: 'top',
       body: messages.trackLearnerProgressStepSixBody.defaultMessage,
     });
 
-    expect(flow[5]).toMatchObject({
+    expect(flow[6]).toMatchObject({
       target: `#${TRACK_LEARNER_PROGRESS_TARGETS.CSV_DOWNLOAD}`,
       placement: 'top',
       body: messages.trackLearnerProgressStepSevenBody.defaultMessage,
     });
-
-    expect(flow[6]).toMatchObject({
-      target: `#${TRACK_LEARNER_PROGRESS_TARGETS.MODULE_ACTIVITY}`,
-      placement: 'top',
-      body: messages.trackLearnerProgressStepEightBody.defaultMessage,
-    });
-  });
-
-  it('creates learner progress flow with AI button step when AI button is visible', () => {
-    const { result } = renderHook(
-      () => useCreateLearnerProgressFlow({
-        aiButtonVisible: true,
-        handleAdvanceTour: mockHandleAdvanceTour,
-        handleEndTour: mockHandleEndTour,
-      }),
-      { wrapper },
-    );
-
-    const flow = result.current;
-
-    expect(flow).toHaveLength(8);
-
-    expect(flow[0].target).toBe(`#${TRACK_LEARNER_PROGRESS_TARGETS.LEARNER_PROGRESS_SIDEBAR}`);
-    expect(flow[1].target).toBe(`#${TRACK_LEARNER_PROGRESS_TARGETS.LPR_OVERVIEW}`);
-
-    expect(flow[2]).toMatchObject({
-      target: `#${TRACK_LEARNER_PROGRESS_TARGETS.AI_SUMMARY}`,
-      placement: 'right',
-      body: messages.trackLearnerProgressStepThreeBody.defaultMessage,
-    });
-
-    expect(flow[3].target).toBe(`#${TRACK_LEARNER_PROGRESS_TARGETS.PROGRESS_REPORT}`);
-    expect(flow[7].target).toBe(`#${TRACK_LEARNER_PROGRESS_TARGETS.MODULE_ACTIVITY}`);
   });
 
   it('calls formatMessage for all step messages', () => {
     renderHook(
       () => useCreateLearnerProgressFlow({
-        aiButtonVisible: false,
         handleAdvanceTour: mockHandleAdvanceTour,
         handleEndTour: mockHandleEndTour,
       }),
@@ -126,23 +97,10 @@ describe('tourFlows', () => {
     expect(mockFormatMessage).toHaveBeenCalledWith(messages.trackLearnerProgressStepOneTitle);
     expect(mockFormatMessage).toHaveBeenCalledWith(messages.trackLearnerProgressStepOneBody);
     expect(mockFormatMessage).toHaveBeenCalledWith(messages.trackLearnerProgressStepTwoBody);
+    expect(mockFormatMessage).toHaveBeenCalledWith(messages.trackLearnerProgressStepThreeBody);
     expect(mockFormatMessage).toHaveBeenCalledWith(messages.trackLearnerProgressStepFourBody);
     expect(mockFormatMessage).toHaveBeenCalledWith(messages.trackLearnerProgressStepFiveBody);
     expect(mockFormatMessage).toHaveBeenCalledWith(messages.trackLearnerProgressStepSixBody);
     expect(mockFormatMessage).toHaveBeenCalledWith(messages.trackLearnerProgressStepSevenBody);
-    expect(mockFormatMessage).toHaveBeenCalledWith(messages.trackLearnerProgressStepEightBody);
-  });
-
-  it('calls formatMessage for AI step when AI button is visible', () => {
-    renderHook(
-      () => useCreateLearnerProgressFlow({
-        aiButtonVisible: true,
-        handleAdvanceTour: mockHandleAdvanceTour,
-        handleEndTour: mockHandleEndTour,
-      }),
-      { wrapper },
-    );
-
-    expect(mockFormatMessage).toHaveBeenCalledWith(messages.trackLearnerProgressStepThreeBody);
   });
 });


### PR DESCRIPTION
Removed the step explaining the AI insights because it was dynamically rendering after the tour and causing errors. Also, since the "Module activity (Executive Education)" tab highlight was at the end, if the customer didn't have it the complete_tour_flow logic never triggered, so customer's without it couldn't complete the flow. Moved it to the middle, so if it doesn't render it doesn't effect the overall experience. 

[Jira ticket
](https://2u-internal.atlassian.net/browse/ENT-10968)

To test locally, replace your EntepriseDataApiService with this file with mocked data. 
[MockEnterpriseDataApiService.txt](https://github.com/user-attachments/files/22542751/MockEnterpriseDataApiService.txt)

# For all changes

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
