### PR TITLE
fix: handle null values in sort heuristic

### DIFF
--- a/src/components/learner-credit-management/data/tests/utils.test.js
+++ b/src/components/learner-credit-management/data/tests/utils.test.js
@@ -7,16 +7,13 @@ import {
   getTranslatedBudgetStatus,
   getTranslatedBudgetTerm,
   orderBudgets,
-  startAndEnrollBySortLogic,
-  transformSubsidySummary,
   retrieveBudgetDetailActivityOverview,
-  transformRequestOverview,
+  startAndEnrollBySortLogic,
   transformLearnerRequestStateCounts,
+  transformRequestOverview,
+  transformSubsidySummary,
 } from '../utils';
-import {
-  COURSE_PACING_MAP,
-  EXEC_ED_OFFER_TYPE,
-} from '../constants';
+import { COURSE_PACING_MAP, EXEC_ED_OFFER_TYPE } from '../constants';
 import EnterpriseDataApiService from '../../../../data/services/EnterpriseDataApiService';
 import SubsidyApiService from '../../../../data/services/EnterpriseSubsidyApiService';
 import EnterpriseAccessApiService from '../../../../data/services/EnterpriseAccessApiService';
@@ -245,6 +242,19 @@ describe('orderBudgets', () => {
 
     // Since both offers have the same status ("active") and end date, they should be sorted alphabetically by name.
     expect(sortedBudgets.map((budget) => budget.name)).toEqual(['Budget A', 'Budget B']);
+  });
+
+  it('should handle offers with missing metadata', () => {
+    const budgetWithMissingMetadata = [
+      { name: 'Budget A', start: '2023-01-01T00:00:00Z', end: '2023-01-15T00:00:00Z' },
+      { name: 'Budget B', start: '2024-01-01T00:00:00Z', end: null },
+      { name: 'Budget C', start: null, end: '2024-01-15T00:00:00Z' },
+      { name: 'Budget D', start: null, end: null },
+      { name: 'Budget E', start: '2025-09-24-T00:00:00Z', end: '2050-09-24T00:00:00Z' },
+    ];
+    const sortedBudgets = orderBudgets(intl, budgetWithMissingMetadata);
+    console.log(sortedBudgets);
+    expect(sortedBudgets.map((budget) => budget.name)).toEqual(['Budget A', 'Budget C', 'Budget E', 'Budget B', 'Budget D']);
   });
 });
 

--- a/src/components/learner-credit-management/data/tests/utils.test.js
+++ b/src/components/learner-credit-management/data/tests/utils.test.js
@@ -253,7 +253,6 @@ describe('orderBudgets', () => {
       { name: 'Budget E', start: '2025-09-24-T00:00:00Z', end: '2050-09-24T00:00:00Z' },
     ];
     const sortedBudgets = orderBudgets(intl, budgetWithMissingMetadata);
-    console.log(sortedBudgets);
     expect(sortedBudgets.map((budget) => budget.name)).toEqual(['Budget A', 'Budget C', 'Budget E', 'Budget B', 'Budget D']);
   });
 });

--- a/src/components/learner-credit-management/data/utils.js
+++ b/src/components/learner-credit-management/data/utils.js
@@ -10,15 +10,15 @@ import SubsidyApiService from '../../../data/services/EnterpriseSubsidyApiServic
 import { isPlanApproachingExpiry } from '../../BudgetExpiryAlertAndModal/data/utils';
 import { BUDGET_STATUSES } from '../../EnterpriseApp/data/constants';
 import {
+  APPROVED_REQUEST_TYPE,
   ASSIGNMENT_ENROLLMENT_DEADLINE,
   COURSE_PACING_MAP,
   DAYS_UNTIL_ASSIGNMENT_ALLOCATION_EXPIRATION,
   LATE_ENROLLMENTS_BUFFER_DAYS,
+  LEARNER_CREDIT_REQUEST_STATE_LABELS,
   LOW_REMAINING_BALANCE_PERCENT_THRESHOLD,
   NO_BALANCE_REMAINING_DOLLAR_THRESHOLD,
   START_DATE_DEFAULT_TO_TODAY_THRESHOLD_DAYS,
-  APPROVED_REQUEST_TYPE,
-  LEARNER_CREDIT_REQUEST_STATE_LABELS,
 } from './constants';
 import { capitalizeFirstLetter } from '../../../utils';
 
@@ -271,6 +271,17 @@ export const orderBudgets = (intl, budgets) => {
     }
 
     if (budgetA.end !== budgetB.end) {
+      // Handle null values: push null end dates to the end
+      if (budgetA.end === null && budgetB.end !== null) {
+        return 1; // budgetA (null) comes after budgetB (non-null)
+      }
+      if (budgetA.end !== null && budgetB.end === null) {
+        return -1; // budgetA (non-null) comes before budgetB (null)
+      }
+      if (budgetA.end === null && budgetB.end === null) {
+        return 0; // both null, equal
+      }
+      // Both are non-null, use existing comparison logic
       return budgetA.end.localeCompare(budgetB.end);
     }
 


### PR DESCRIPTION
# For all changes
This pull request improves the robustness of the `orderBudgets` utility function and its associated tests in the learner credit management module. The main focus is on handling budgets with missing metadata, specifically when `start` or `end` dates are `null`, ensuring that sorting behaves predictably even with incomplete data. Additionally, import statements have been cleaned up for better readability.

**Enhancements to budget sorting:**

* Updated `orderBudgets` in `utils.js` to handle `null` end dates, ensuring that budgets with missing end dates are always sorted to the end of the list.

* Added a new test case in `utils.test.js` to verify that `orderBudgets` correctly sorts budgets when some have missing `start` or `end` metadata.

**Code organization and readability:**

* Cleaned up and reordered import statements in both `utils.js` and `utils.test.js` for consistency and clarity. [[1]](diffhunk://#diff-892d8f2bf336fdfb32957f1f31f87639ccdf28dbfe8303bbbba5d76efeca2dfcL10-R16) [[2]](diffhunk://#diff-9506465fc57bfe20a997860fa416667429c562024b407ea223a4f156cf08cffeR13-L21)

- [ ] Ensure adequate tests are in place (or reviewed existing tests cover changes)

# Only if submitting a visual change

- [ ] Ensure to attach screenshots
- [ ] Ensure to have UX team confirm screenshots
